### PR TITLE
feat: add WorkingDir field to AgentConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ### Added
 - **`backend` field** on agent nodes for per-node backend selection (e.g., `native`, `claude-code`, `acp`). Previously this value was silently dropped by the parser.
+- **`working_dir` field** on agent nodes for per-node working directory override.
 
 ### Fixed
 - **Unrecognized node fields** now emit a parse diagnostic suggesting the user put the field under `params:`, instead of being silently discarded.

--- a/docs/GRAMMAR.ebnf
+++ b/docs/GRAMMAR.ebnf
@@ -68,6 +68,7 @@ agent_field     = "prompt"            ":" field_value
                 | "model"             ":" field_value
                 | "provider"          ":" field_value
                 | "backend"           ":" field_value
+                | "working_dir"       ":" field_value
                 | "max_turns"         ":" INTEGER
                 | "cmd_timeout"       ":" DURATION
                 | "goal_gate"         ":" BOOLEAN

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -35,7 +35,7 @@ workflow <Name>
 
 | Kind | Required Fields | Optional Fields |
 |------|----------------|-----------------|
-| `agent` | `prompt` | `model`, `provider`, `backend`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
+| `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
 | `human` | `mode` (freeform\|choice) | `default` |
 | `tool` | `command` | `timeout` (e.g. 30s, 5m) |
 | `parallel` | `-> Target1, Target2` (inline) | — |

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -104,6 +104,7 @@ Agent nodes invoke an LLM. They are the most configurable node kind.
 | `model` | String | workflow default | LLM model identifier (e.g., `"claude-opus-4-6"`, `"gpt-5.4"`). Overrides the workflow-level default. |
 | `provider` | String | workflow default | LLM provider (e.g., `"anthropic"`, `"openai"`, `"gemini"`). Overrides the workflow-level default. |
 | `backend` | String | runtime default | Per-node backend override (e.g., `native`, `claude-code`, `acp`). |
+| `working_dir` | String | — | Per-node working directory override for isolated execution. |
 | `max_turns` | Integer | 1 | Maximum conversation turns in an agentic loop. A turn is one request-response cycle. Set higher for multi-step tool-using agents. |
 | `cmd_timeout` | Duration | — | Command execution timeout for the agent's agentic loop (e.g., `30s`, `5m`). Applies to tool/command calls made within the agent, not to the LLM API call itself. |
 | `cache_tools` | Boolean | workflow default | Whether to cache tool call results for this agent. Useful for expensive, deterministic tools. |

--- a/export/dot.go
+++ b/export/dot.go
@@ -210,8 +210,16 @@ func applyAgentAttrs(attrs map[string]string, cfg ir.AgentConfig) {
 	if cfg.Provider != "" {
 		attrs["provider"] = cfg.Provider
 	}
+	applyAgentRuntimeAttrs(attrs, cfg)
+}
+
+// applyAgentRuntimeAttrs adds backend and working_dir attributes.
+func applyAgentRuntimeAttrs(attrs map[string]string, cfg ir.AgentConfig) {
 	if cfg.Backend != "" {
 		attrs["backend"] = cfg.Backend
+	}
+	if cfg.WorkingDir != "" {
+		attrs["working_dir"] = cfg.WorkingDir
 	}
 }
 

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -315,6 +315,9 @@ func writeAgentRuntimeFields(wr *writer, cfg ir.AgentConfig) {
 	if cfg.Backend != "" {
 		wr.line("backend: %s", quoteValue(cfg.Backend))
 	}
+	if cfg.WorkingDir != "" {
+		wr.line("working_dir: %s", quoteValue(cfg.WorkingDir))
+	}
 }
 
 // writeAgentResponseFields writes response format fields for agent nodes.

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -97,6 +97,7 @@ type AgentConfig struct {
 	ResponseFormat      string            // "json_object" or "json_schema"
 	ResponseSchema      string            // JSON schema (when ResponseFormat is "json_schema")
 	Backend             string            // Per-node backend override: "native", "claude-code", "acp"
+	WorkingDir          string            // Per-node working directory override
 	Params              map[string]string // Generic key-value pairs passed through to runtime
 }
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -257,6 +257,9 @@ func applyModelAttrs(cfg *ir.AgentConfig, attrs map[string]string) {
 	if v, ok := attrs["backend"]; ok {
 		cfg.Backend = v
 	}
+	if v, ok := attrs["working_dir"]; ok {
+		cfg.WorkingDir = v
+	}
 }
 
 // applyModelField sets the model field from model or llm_model attrs.

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -282,6 +282,8 @@ func applyAgentRuntimeField(cfg *ir.AgentConfig, key, val string) bool {
 	switch key {
 	case "backend":
 		cfg.Backend = val
+	case "working_dir":
+		cfg.WorkingDir = val
 	default:
 		return false
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1420,3 +1420,33 @@ func TestParseUnrecognizedSubgraphFieldSuggestsParams(t *testing.T) {
 		t.Errorf("subgraph nodes support params — hint should mention params, got: %s", err.Error())
 	}
 }
+
+func TestParseAgentWorkingDirField(t *testing.T) {
+	input := `workflow Test
+  start: A
+  exit: B
+  agent A
+    working_dir: .ai/worktrees/claude
+    prompt: do it
+  agent B
+    prompt: done
+  edges
+    A -> B
+`
+	p := NewParser(input, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	node := w.Node("A")
+	if node == nil {
+		t.Fatal("node A not found")
+	}
+	cfg, ok := node.Config.(ir.AgentConfig)
+	if !ok {
+		t.Fatalf("expected AgentConfig, got %T", node.Config)
+	}
+	if cfg.WorkingDir != ".ai/worktrees/claude" {
+		t.Errorf("expected working_dir '.ai/worktrees/claude', got %q", cfg.WorkingDir)
+	}
+}

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -8,6 +8,7 @@ layout: "changelog"
 
 ### Added
 - **`backend` field** on agent nodes for per-node backend selection (e.g., `native`, `claude-code`, `acp`). Previously this value was silently dropped by the parser.
+- **`working_dir` field** on agent nodes for per-node working directory override.
 
 ### Fixed
 - **Unrecognized node fields** now emit a parse diagnostic suggesting the user put the field under `params:`, instead of being silently discarded.

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -104,6 +104,7 @@ Agent nodes invoke an LLM. They are the most configurable node kind. Key fields 
 | `model` | String | LLM model to use (overrides defaults) |
 | `provider` | String | LLM provider (e.g., "anthropic", "openai") |
 | `backend` | String | Per-node backend override (e.g., `native`, `claude-code`, `acp`) |
+| `working_dir` | String | Per-node working directory override for isolated execution. |
 | `prompt` | Block | Multiline prompt text sent to the model |
 | `system_prompt` | Block | System-level instructions prepended before the prompt |
 | `max_turns` | Integer | Maximum conversation turns before the node exits |

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -63,6 +63,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `model` | string | Must be valid model ID (DIP108) |
 | `provider` | string | anthropic, openai, google, deepseek, xai, mistral, cohere |
 | `backend` | string | Per-node backend override (e.g., `native`, `claude-code`, `acp`) |
+| `working_dir` | string | Per-node working directory override for isolated execution. |
 | `max_turns` | int | Max conversation turns |
 | `cmd_timeout` | duration | e.g. `30s`, `5m` |
 | `auto_status` | bool | Parses `STATUS: success/fail` → `ctx.outcome` |


### PR DESCRIPTION
## Summary

- **`working_dir` field** on agent nodes for per-node working directory override (e.g., `.ai/worktrees/claude`). Same pattern as the `backend` fix in #10.
- Wired through IR, parser, formatter, DOT export, and DOT migrate
- All documentation updated (nodes.md, GRAMMAR.ebnf, llm-reference.md, language.md, changelogs)

## Test plan
- [x] `just check` passes
- [x] New parser test verifies `working_dir: .ai/worktrees/claude` is parsed into `AgentConfig.WorkingDir`

Closes #12