### PR TITLE
feat: DIP134 lint rule — warn on max_retries vs max_restarts confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **DIP134 lint rule**: warns when `max_retries` is set in defaults with `restart: true` edges but no `max_restarts` — catches the common confusion between per-node LLM retries and loop restart budget.
+
 ## [v0.19.1] — 2026-04-16
 
 ### Added

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -367,7 +367,7 @@ func nodeValidationExplanations() map[string]Explanation {
 			Summary: "max_retries set with restart edges but no max_restarts",
 			Trigger: "The workflow defaults set max_retries (per-node LLM retry count) and the workflow has restart: true edges, but max_restarts (global loop restart budget) is not set. These are commonly confused.",
 			Fix:     "If you want to control loop iterations, set max_restarts instead of (or in addition to) max_retries.",
-			Example: "defaults\n  max_restarts: 10  // loop restart budget\n  max_retries: 3    // per-node LLM retries",
+			Example: "defaults\n  max_retries: 5  // but no max_restarts!\n\nedges\n  Review -> Implement  restart: true",
 		},
 	}
 }

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -250,6 +250,14 @@ func configExplanations() map[string]Explanation {
 }
 
 func advancedExplanations() map[string]Explanation {
+	m := conditionExplanations()
+	for k, v := range nodeValidationExplanations() {
+		m[k] = v
+	}
+	return m
+}
+
+func conditionExplanations() map[string]Explanation {
 	return map[string]Explanation{
 		DIP120: {
 			Code:    DIP120,
@@ -300,6 +308,11 @@ func advancedExplanations() map[string]Explanation {
 			Fix:     "Fix the ref path or create the missing workflow file.",
 			Example: "subgraph Review\n  ref: review_pipeline.dip  // file not found",
 		},
+	}
+}
+
+func nodeValidationExplanations() map[string]Explanation {
+	return map[string]Explanation{
 		DIP127: {
 			Code:    DIP127,
 			Summary: "invalid human node mode",
@@ -348,6 +361,13 @@ func advancedExplanations() map[string]Explanation {
 			Trigger: "A key in the params block matches a typed first-class field like model, provider, or response_format. The typed field takes precedence and the params entry is ignored.",
 			Fix:     "Move the value from params to the dedicated typed field.",
 			Example: "agent Call\n  params:\n    model: gpt-4  // use top-level model: instead",
+		},
+		DIP134: {
+			Code:    DIP134,
+			Summary: "max_retries set with restart edges but no max_restarts",
+			Trigger: "The workflow defaults set max_retries (per-node LLM retry count) and the workflow has restart: true edges, but max_restarts (global loop restart budget) is not set. These are commonly confused.",
+			Fix:     "If you want to control loop iterations, set max_restarts instead of (or in addition to) max_retries.",
+			Example: "defaults\n  max_restarts: 10  // loop restart budget\n  max_retries: 3    // per-node LLM retries",
 		},
 	}
 }

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -5,7 +5,7 @@ import (
 	"github.com/2389-research/dippin-lang/simulate"
 )
 
-// Lint runs all semantic quality checks (DIP101–DIP133) on the workflow
+// Lint runs all semantic quality checks (DIP101–DIP134) on the workflow
 // and returns all diagnostics found. These are warnings, not errors —
 // the workflow can still execute, but the findings indicate likely bugs
 // or quality issues.

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -34,6 +34,7 @@ func Lint(w *ir.Workflow) Result {
 	diags = append(diags, lintToolTimeout(w)...)
 	diags = append(diags, lintReadsWithoutUpstreamWrites(w)...)
 	diags = append(diags, lintRetryPolicy(w)...)
+	diags = append(diags, lintRetryRestartConfusion(w)...)
 	diags = append(diags, lintFidelity(w)...)
 	diags = append(diags, lintGoalGateFallback(w)...)
 	diags = append(diags, lintCompactionThreshold(w)...)

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP133).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP134).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge
@@ -35,6 +35,7 @@ const (
 	DIP131 = "DIP131" // response_schema/response_format mismatch
 	DIP132 = "DIP132" // response_schema is not valid JSON
 	DIP133 = "DIP133" // agent params key shadows a first-class field
+	DIP134 = "DIP134" // max_retries set with restart edges but no max_restarts
 )
 
 func init() {
@@ -72,4 +73,5 @@ func init() {
 	CodeDescription[DIP131] = "response_schema and response_format mismatch"
 	CodeDescription[DIP132] = "response_schema is not valid JSON"
 	CodeDescription[DIP133] = "agent params key shadows a first-class field"
+	CodeDescription[DIP134] = "max_retries set in defaults with restart edges but no max_restarts — did you mean max_restarts?"
 }

--- a/validator/lint_retry.go
+++ b/validator/lint_retry.go
@@ -92,8 +92,8 @@ func lintRetryRestartConfusion(w *ir.Workflow) []Diagnostic {
 	return []Diagnostic{{
 		Code:     DIP134,
 		Severity: SeverityWarning,
-		Message:  fmt.Sprintf("defaults has max_retries: %d but no max_restarts, and the workflow has restart: true edges — did you mean max_restarts?", w.Defaults.MaxRetries),
-		Help:     "max_retries controls per-node LLM retries; max_restarts controls the loop restart budget for restart: true edges",
+		Message:  fmt.Sprintf("defaults specify max_retries: %d but no max_restarts, and the workflow has restart: true edges", w.Defaults.MaxRetries),
+		Help:     "max_retries controls per-node LLM retries; max_restarts controls the loop restart budget for restart: true edges — did you mean max_restarts?",
 	}}
 }
 

--- a/validator/lint_retry.go
+++ b/validator/lint_retry.go
@@ -78,6 +78,35 @@ func checkNodeRetryPolicies(w *ir.Workflow) []Diagnostic {
 	return diags
 }
 
+// lintRetryRestartConfusion checks DIP134: if the workflow has restart: true
+// edges and max_retries is set in defaults but max_restarts is not, the user
+// likely confused the two. max_retries controls per-node LLM retries;
+// max_restarts controls the global loop restart budget.
+func lintRetryRestartConfusion(w *ir.Workflow) []Diagnostic {
+	if !hasRestartEdges(w) {
+		return nil
+	}
+	if w.Defaults.MaxRetries == 0 || w.Defaults.MaxRestarts != 0 {
+		return nil
+	}
+	return []Diagnostic{{
+		Code:     DIP134,
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("defaults has max_retries: %d but no max_restarts, and the workflow has restart: true edges — did you mean max_restarts?", w.Defaults.MaxRetries),
+		Help:     "max_retries controls per-node LLM retries; max_restarts controls the loop restart budget for restart: true edges",
+	}}
+}
+
+// hasRestartEdges returns true if any edge has Restart: true.
+func hasRestartEdges(w *ir.Workflow) bool {
+	for _, e := range w.Edges {
+		if e.Restart {
+			return true
+		}
+	}
+	return false
+}
+
 // lintGoalGateFallback checks DIP115: nodes with goal_gate: true should have
 // a retry_target or fallback_target so the pipeline has a recovery path when
 // the gate fails.

--- a/validator/lint_test.go
+++ b/validator/lint_test.go
@@ -2036,3 +2036,53 @@ func TestLintAllStructuredFieldsValidNoWarnings(t *testing.T) {
 	assertNoCode(t, res, DIP132)
 	assertNoCode(t, res, DIP133)
 }
+
+func resultHasCode(r Result, code string) bool {
+	for _, d := range r.Diagnostics {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLintRetryRestartConfusion(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxRetries  int
+		maxRestarts int
+		hasRestart  bool
+		wantDIP134  bool
+	}{
+		{"max_retries with restart edges and no max_restarts", 5, 0, true, true},
+		{"max_retries with restart edges and max_restarts set", 5, 10, true, false},
+		{"no max_retries", 0, 0, true, false},
+		{"max_retries but no restart edges", 5, 0, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			edges := []*ir.Edge{{From: "A", To: "B"}}
+			if tt.hasRestart {
+				edges = append(edges, &ir.Edge{From: "B", To: "A", Restart: true})
+			}
+			w := &ir.Workflow{
+				Start: "A",
+				Exit:  "B",
+				Defaults: ir.WorkflowDefaults{
+					MaxRetries:  tt.maxRetries,
+					MaxRestarts: tt.maxRestarts,
+				},
+				Nodes: []*ir.Node{
+					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
+					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
+				},
+				Edges: edges,
+			}
+			result := Lint(w)
+			got := resultHasCode(result, DIP134)
+			if got != tt.wantDIP134 {
+				t.Errorf("DIP134: got %v, want %v", got, tt.wantDIP134)
+			}
+		})
+	}
+}

--- a/validator/lint_test.go
+++ b/validator/lint_test.go
@@ -2037,52 +2037,37 @@ func TestLintAllStructuredFieldsValidNoWarnings(t *testing.T) {
 	assertNoCode(t, res, DIP133)
 }
 
-func resultHasCode(r Result, code string) bool {
-	for _, d := range r.Diagnostics {
-		if d.Code == code {
-			return true
+func TestLintRetryRestartConfusion(t *testing.T) {
+	buildWorkflow := func(maxRetries, maxRestarts int, hasRestart bool) *ir.Workflow {
+		edges := []*ir.Edge{{From: "A", To: "B"}}
+		if hasRestart {
+			edges = append(edges, &ir.Edge{From: "B", To: "A", Restart: true})
+		}
+		return &ir.Workflow{
+			Start: "A",
+			Exit:  "B",
+			Defaults: ir.WorkflowDefaults{
+				MaxRetries:  maxRetries,
+				MaxRestarts: maxRestarts,
+			},
+			Nodes: []*ir.Node{
+				{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
+				{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
+			},
+			Edges: edges,
 		}
 	}
-	return false
-}
 
-func TestLintRetryRestartConfusion(t *testing.T) {
-	tests := []struct {
-		name        string
-		maxRetries  int
-		maxRestarts int
-		hasRestart  bool
-		wantDIP134  bool
-	}{
-		{"max_retries with restart edges and no max_restarts", 5, 0, true, true},
-		{"max_retries with restart edges and max_restarts set", 5, 10, true, false},
-		{"no max_retries", 0, 0, true, false},
-		{"max_retries but no restart edges", 5, 0, false, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			edges := []*ir.Edge{{From: "A", To: "B"}}
-			if tt.hasRestart {
-				edges = append(edges, &ir.Edge{From: "B", To: "A", Restart: true})
-			}
-			w := &ir.Workflow{
-				Start: "A",
-				Exit:  "B",
-				Defaults: ir.WorkflowDefaults{
-					MaxRetries:  tt.maxRetries,
-					MaxRestarts: tt.maxRestarts,
-				},
-				Nodes: []*ir.Node{
-					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
-					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
-				},
-				Edges: edges,
-			}
-			result := Lint(w)
-			got := resultHasCode(result, DIP134)
-			if got != tt.wantDIP134 {
-				t.Errorf("DIP134: got %v, want %v", got, tt.wantDIP134)
-			}
-		})
-	}
+	t.Run("fires when max_retries set with restart edges and no max_restarts", func(t *testing.T) {
+		assertHasCode(t, Lint(buildWorkflow(5, 0, true)), DIP134)
+	})
+	t.Run("silent when max_restarts also set", func(t *testing.T) {
+		assertNoCode(t, Lint(buildWorkflow(5, 10, true)), DIP134)
+	})
+	t.Run("silent when no max_retries", func(t *testing.T) {
+		assertNoCode(t, Lint(buildWorkflow(0, 0, true)), DIP134)
+	})
+	t.Run("silent when no restart edges", func(t *testing.T) {
+		assertNoCode(t, Lint(buildWorkflow(5, 0, false)), DIP134)
+	})
 }


### PR DESCRIPTION
## Summary

New **DIP134** lint warning: when `max_retries` is set in defaults and the workflow has `restart: true` edges but no `max_restarts`, warns the user they likely confused the two.

- `max_retries` = per-node LLM retry count
- `max_restarts` = global loop restart budget for `restart: true` edges

This catches the exact scenario from the issue: user sets `max_retries: 5` expecting 5 loop iterations, but the actual restart budget stays at the default.

## Test plan
- [x] `just check` passes
- [x] Table-driven test covers all 4 cases: fires when expected, silent when `max_restarts` is set, silent when no `max_retries`, silent when no restart edges
- [x] Explanation added to `dippin explain DIP134`

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DIP134 lint rule: warns when workflow defaults set max_retries while restart edges exist but max_restarts is not configured.

* **Documentation**
  * Updated changelog with the new Unreleased entry describing the DIP134 rule.

* **Tests**
  * Added tests covering DIP134 behavior across combinations of retry/restart settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->