### PR TITLE
feat: workflow-level vars block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 ## [Unreleased]
 
 ### Added
+- **`vars` block** at the workflow level for declaring user-defined variables. Vars export as DOT graph-level attributes and round-trip through parse → format → export → migrate.
 - **DIP134 lint rule**: warns when `max_retries` is set in defaults with `restart: true` edges but no `max_restarts` — catches the common confusion between per-node LLM retries and loop restart budget.
 
 ## [v0.19.1] — 2026-04-16

--- a/docs/GRAMMAR.ebnf
+++ b/docs/GRAMMAR.ebnf
@@ -25,7 +25,7 @@ workflow_file   = workflow_decl ;
 workflow_decl   = "workflow" IDENTIFIER NEWLINE
                   INDENT workflow_body OUTDENT ;
 
-workflow_body   = { workflow_field | defaults_section
+workflow_body   = { workflow_field | defaults_section | vars_section
                   | node_decl | edges_section
                   | stylesheet_section | NEWLINE } ;
 
@@ -49,6 +49,14 @@ defaults_field   = "model"          ":" field_value
                  | "cache_tools"    ":" BOOLEAN
                  | "compaction"     ":" field_value
                  | "on_resume"      ":" field_value ;
+
+(* ═══════════════════════════════════════════════════════════ *)
+(* Vars Section                                               *)
+(* ═══════════════════════════════════════════════════════════ *)
+
+vars_section     = "vars" NEWLINE INDENT { vars_field } OUTDENT ;
+
+vars_field       = IDENTIFIER ":" field_value ;
 
 (* ═══════════════════════════════════════════════════════════ *)
 (* Node Declarations                                          *)
@@ -310,5 +318,5 @@ digit           = "0" | "1" | ... | "9" ;
 (* These identifiers have special meaning in context but can  *)
 (* be used as node IDs without conflict:                      *)
 (* workflow, agent, human, tool, subgraph, parallel, fan_in,  *)
-(* edges, defaults, when, and, or, not, contains, startswith, *)
+(* edges, defaults, vars, when, and, or, not, contains, startswith, *)
 (* endswith, in, true, false, restart, label, weight          *)

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -17,6 +17,10 @@ workflow <Name>
     provider: <string>
     ...]
 
+  [vars
+    <key>: <value>
+    ...]
+
   <kind> <NodeID>
     <field>: <value>
     <multiline_field>:

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -420,6 +420,35 @@ The subgraph handles the full interview lifecycle: generating questions with sug
 
 ---
 
+## Vars Block
+
+The optional `vars` block at the workflow level declares user-defined variables. These are substituted by the runtime wherever `$key` placeholders appear in prompts and commands.
+
+```dippin
+  vars
+    source_ref: "references/claude-agent-sdk-python/src"
+    target_name: claude-agents-rs
+    target_module: "claude-agents-rs/src/"
+```
+
+### Vars Fields
+
+Each entry is a key-value pair. Values follow the same syntax as other field values — quoted strings or bare identifiers:
+
+```dippin
+  vars
+    my_path: "some/quoted/path"
+    my_name: bare-identifier
+```
+
+Keys must be unique within the block. Duplicate keys cause a parse error.
+
+### DOT Export
+
+Vars are exported as graph-level DOT attributes (e.g., `source_ref="references/..."`) so they round-trip through `dippin export-dot` and `dippin migrate`.
+
+---
+
 ## Node Declaration Order
 
 Nodes can be declared in any order within the workflow. The `start` and `exit` fields (not declaration order) determine entry and exit points. However, the canonical formatter groups nodes by kind for readability.

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -441,7 +441,7 @@ Each entry is a key-value pair. Values follow the same syntax as other field val
     my_name: bare-identifier
 ```
 
-Keys must be unique within the block. Duplicate keys cause a parse error.
+Keys should be unique within the block. Duplicate keys emit a parse diagnostic (last value wins).
 
 ### DOT Export
 

--- a/docs/superpowers/plans/2026-04-16-vars-block.md
+++ b/docs/superpowers/plans/2026-04-16-vars-block.md
@@ -1,0 +1,812 @@
+# Vars Block Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `vars` block to Dippin workflows for declaring user-defined key-value variables that export as DOT graph attributes.
+
+**Architecture:** `Workflow.Vars map[string]string` is a new top-level IR field. The parser handles `vars` as a workflow-level block (peer to `defaults`, `edges`). The formatter emits it between defaults and nodes. DOT export emits vars as graph-level attributes. DOT migrate captures unknown graph attributes into Vars.
+
+**Tech Stack:** Go, dippin-lang IR/parser/formatter/export/migrate packages
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `ir/ir.go` | Modify | Add `Vars map[string]string` to `Workflow` |
+| `parser/parser.go` | Modify | Add `"vars"` case to `dispatchWorkflowField` |
+| `parser/parse_vars.go` | Create | Parse `vars` block (key-value pairs) |
+| `parser/parser_test.go` | Modify | Add parse tests for vars |
+| `formatter/format.go` | Modify | Emit `vars` block between defaults and nodes |
+| `formatter/format_test.go` | Modify | Add formatter tests for vars |
+| `export/dot.go` | Modify | Emit vars as graph-level attributes |
+| `export/dot_test.go` | Modify | Add DOT export test for vars |
+| `migrate/migrate.go` | Modify | Catch-all for unknown graph attrs → `Workflow.Vars` |
+| `migrate/migrate_test.go` | Modify | Add migrate test for vars round-trip |
+| `examples/semport_thematic.dip` | Modify | Add `vars` block with existing `$` placeholders |
+| `docs/GRAMMAR.ebnf` | Modify | Add `vars_section` production rule |
+| `docs/nodes.md` | Modify | Document vars block |
+| `site/content/language.md` | Modify | Document vars block |
+| `docs/llm-reference.md` | Modify | Mention vars in workflow structure |
+| `CHANGELOG.md` | Modify | Add entry |
+| `site/content/changelog.md` | Modify | Add entry |
+
+---
+
+## Task 1: IR — Add `Vars` to `Workflow`
+
+**Files:**
+- Modify: `ir/ir.go:11-22`
+
+- [ ] **Step 1: Add `Vars` field to `Workflow` struct**
+
+In `ir/ir.go`, add `Vars` after `Defaults`:
+
+```go
+type Workflow struct {
+	Name       string
+	Version    string           // Dippin format version
+	Goal       string           // Human-readable objective
+	Start      string           // Explicit entry node ID (required)
+	Exit       string           // Explicit exit node ID (required)
+	Defaults   WorkflowDefaults // Graph-level config
+	Vars       map[string]string // User-defined workflow variables
+	Nodes      []*Node          // Ordered for deterministic processing
+	Edges      []*Edge
+	Stylesheet []StylesheetRule // Theme/styling rules
+	SourceMap  *SourceMap       // File/line mapping for diagnostics
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `just build`
+Expected: PASS (no code references `Vars` yet, zero-value `nil` is fine)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ir/ir.go
+git commit -m "feat(ir): add Vars map to Workflow struct"
+```
+
+---
+
+## Task 2: Parser — Parse `vars` Block
+
+**Files:**
+- Create: `parser/parse_vars.go`
+- Modify: `parser/parser.go:87-100`
+- Test: `parser/parser_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `parser/parser_test.go`, add:
+
+```go
+func TestParseVarsBlock(t *testing.T) {
+	input := `workflow Test
+  start: A
+  exit: B
+
+  vars
+    source_ref: "references/sdk-python/src"
+    target_name: my-crate
+
+  agent A
+    prompt: go
+  agent B
+    prompt: done
+  edges
+    A -> B
+`
+	p := NewParser(input, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if w.Vars == nil {
+		t.Fatal("expected Vars to be populated")
+	}
+	if got := w.Vars["source_ref"]; got != "references/sdk-python/src" {
+		t.Errorf("source_ref = %q, want %q", got, "references/sdk-python/src")
+	}
+	if got := w.Vars["target_name"]; got != "my-crate" {
+		t.Errorf("target_name = %q, want %q", got, "my-crate")
+	}
+	if len(w.Vars) != 2 {
+		t.Errorf("expected 2 vars, got %d", len(w.Vars))
+	}
+}
+
+func TestParseVarsDuplicateKey(t *testing.T) {
+	input := `workflow Test
+  start: A
+  exit: B
+
+  vars
+    key: first
+    key: second
+
+  agent A
+    prompt: go
+  agent B
+    prompt: done
+  edges
+    A -> B
+`
+	p := NewParser(input, "test.dip")
+	_, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected parse error for duplicate vars key")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error should mention 'duplicate', got: %s", err.Error())
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-pkg parser`
+Expected: FAIL — `vars` keyword is unrecognized at workflow level.
+
+- [ ] **Step 3: Create `parser/parse_vars.go`**
+
+```go
+package parser
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+func (p *Parser) parseVars() {
+	p.lexer.NextToken() // vars
+	p.expect(TokenNewline)
+	p.expect(TokenIndent)
+	p.parseVarsBody()
+	p.expect(TokenOutdent)
+}
+
+// parseVarsBody parses the indented body of a vars block.
+func (p *Parser) parseVarsBody() {
+	if p.workflow.Vars == nil {
+		p.workflow.Vars = make(map[string]string)
+	}
+	for p.lexer.PeekToken().Type != TokenOutdent && p.lexer.PeekToken().Type != TokenEOF {
+		t := p.lexer.PeekToken()
+		if t.Type == TokenNewline {
+			p.lexer.NextToken()
+			continue
+		}
+		if t.Type == TokenIdentifier {
+			p.parseVarField(t)
+		} else {
+			p.lexer.NextToken()
+		}
+	}
+}
+
+// parseVarField reads a single var field (key: value).
+func (p *Parser) parseVarField(t Token) {
+	key := t.Value
+	p.lexer.NextToken()
+	p.expect(TokenColon)
+	val := p.readFieldValue(t.Location.Line)
+	p.applyVarField(key, val, t.Location)
+}
+
+// applyVarField adds a var to the workflow, checking for duplicates.
+func (p *Parser) applyVarField(key, val string, loc ir.SourceLocation) {
+	if _, exists := p.workflow.Vars[key]; exists {
+		p.diagnostics = append(p.diagnostics,
+			fmt.Sprintf("duplicate vars key %q at %d:%d", key, loc.Line, loc.Column))
+	}
+	p.workflow.Vars[key] = val
+}
+```
+
+- [ ] **Step 4: Wire `vars` into the parser dispatch**
+
+In `parser/parser.go`, add `"vars"` case to `dispatchWorkflowField`:
+
+```go
+func (p *Parser) dispatchWorkflowField(t Token) {
+	switch t.Value {
+	case "goal", "start", "exit":
+		p.parseWorkflowStringField(t)
+	case "defaults":
+		p.parseDefaults()
+	case "vars":
+		p.parseVars()
+	case "edges":
+		p.parseEdges()
+	case "stylesheet":
+		p.parseStylesheet()
+	default:
+		p.dispatchWorkflowBlock(t)
+	}
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `just test-pkg parser`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add parser/parse_vars.go parser/parser.go parser/parser_test.go
+git commit -m "feat(parser): parse vars block with duplicate key detection"
+```
+
+---
+
+## Task 3: Formatter — Emit `vars` Block
+
+**Files:**
+- Modify: `formatter/format.go:19-45`
+- Test: `formatter/format_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `formatter/format_test.go`, add:
+
+```go
+func TestFormatVarsBlock(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "test",
+		Start: "A",
+		Exit:  "B",
+		Vars: map[string]string{
+			"source_ref":  "references/sdk-python/src",
+			"target_name": "my-crate",
+		},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
+			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "A", To: "B"}},
+	}
+	got := Format(w)
+	if !strings.Contains(got, "vars") {
+		t.Errorf("expected 'vars' block in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "source_ref:") {
+		t.Errorf("expected 'source_ref:' in vars block, got:\n%s", got)
+	}
+	if !strings.Contains(got, "target_name:") {
+		t.Errorf("expected 'target_name:' in vars block, got:\n%s", got)
+	}
+	// source_ref should come before target_name (sorted)
+	srcIdx := strings.Index(got, "source_ref:")
+	tgtIdx := strings.Index(got, "target_name:")
+	if srcIdx > tgtIdx {
+		t.Error("vars should be sorted alphabetically")
+	}
+}
+
+func TestFormatVarsEmptyOmitted(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "test",
+		Start: "A",
+		Exit:  "B",
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
+			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "A", To: "B"}},
+	}
+	got := Format(w)
+	if strings.Contains(got, "vars") {
+		t.Errorf("empty vars should not appear in output, got:\n%s", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-pkg formatter`
+Expected: FAIL — formatter doesn't emit `vars` block.
+
+- [ ] **Step 3: Add `writeVars` to the formatter**
+
+In `formatter/format.go`, add the `writeVars` function:
+
+```go
+func writeVars(wr *writer, vars map[string]string) {
+	wr.line("vars")
+	wr.push()
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		wr.line("%s: %s", k, quoteValue(vars[k]))
+	}
+	wr.pop()
+}
+```
+
+In `Format()`, add vars emission between defaults and nodes:
+
+```go
+func Format(w *ir.Workflow) string {
+	wr := &writer{}
+
+	writeWorkflowHeader(wr, w)
+
+	if !isDefaultsZero(w.Defaults) {
+		wr.blank()
+		writeDefaults(wr, w.Defaults)
+	}
+
+	if len(w.Vars) > 0 {
+		wr.blank()
+		writeVars(wr, w.Vars)
+	}
+
+	for _, n := range w.Nodes {
+		wr.blank()
+		writeNode(wr, n)
+	}
+
+	// ... rest unchanged
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test-pkg formatter`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add formatter/format.go formatter/format_test.go
+git commit -m "feat(formatter): emit vars block with sorted keys"
+```
+
+---
+
+## Task 4: DOT Export — Emit Vars as Graph Attributes
+
+**Files:**
+- Modify: `export/dot.go:58-72`
+- Test: `export/dot_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `export/dot_test.go`, add:
+
+```go
+func TestExportVarsAsGraphAttrs(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "test",
+		Start: "A",
+		Exit:  "B",
+		Vars: map[string]string{
+			"source_ref":  "refs/sdk/src",
+			"target_name": "my-crate",
+		},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
+			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "A", To: "B"}},
+	}
+	dot := ExportDOT(w, ExportOptions{})
+	if !strings.Contains(dot, `source_ref=`) {
+		t.Errorf("expected source_ref graph attribute, got:\n%s", dot)
+	}
+	if !strings.Contains(dot, `target_name=`) {
+		t.Errorf("expected target_name graph attribute, got:\n%s", dot)
+	}
+}
+
+func TestExportVarsSkipsDefaultsCollision(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "test",
+		Start: "A",
+		Exit:  "B",
+		Vars: map[string]string{
+			"model":    "should-be-skipped",
+			"safe_var": "kept",
+		},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
+			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "A", To: "B"}},
+	}
+	dot := ExportDOT(w, ExportOptions{})
+	if strings.Contains(dot, "should-be-skipped") {
+		t.Errorf("vars that collide with known graph attrs should be skipped, got:\n%s", dot)
+	}
+	if !strings.Contains(dot, `safe_var=`) {
+		t.Errorf("non-colliding vars should be emitted, got:\n%s", dot)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test-pkg export`
+Expected: FAIL
+
+- [ ] **Step 3: Implement vars emission in DOT header**
+
+In `export/dot.go`, add a function to write vars and a set of reserved names:
+
+```go
+// reservedGraphAttrs are DOT graph attribute names used by defaults/header.
+// Vars with these names are skipped during export to avoid collisions.
+var reservedGraphAttrs = map[string]bool{
+	"goal": true, "rankdir": true, "model": true, "provider": true,
+	"fidelity": true, "default_fidelity": true,
+	"max_retries": true, "default_max_retry": true, "max_restarts": true,
+}
+
+// writeVarsAttrs emits workflow vars as graph-level attributes.
+func writeVarsAttrs(b *strings.Builder, vars map[string]string) {
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		if !reservedGraphAttrs[k] {
+			keys = append(keys, k)
+		}
+	}
+	sortStrings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(b, "  %s=%s;\n", k, dotQuote(vars[k]))
+	}
+}
+```
+
+In `writeDOTHeader`, add a call after the existing header lines:
+
+```go
+func writeDOTHeader(b *strings.Builder, w *ir.Workflow, opts ExportOptions) {
+	// ... existing code ...
+	b.WriteString("  edge [fontname=\"Helvetica\"];\n")
+	if len(w.Vars) > 0 {
+		writeVarsAttrs(b, w.Vars)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test-pkg export`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add export/dot.go export/dot_test.go
+git commit -m "feat(export): emit workflow vars as DOT graph attributes"
+```
+
+---
+
+## Task 5: DOT Migrate — Capture Unknown Graph Attrs as Vars
+
+**Files:**
+- Modify: `migrate/migrate.go:121-144`
+- Test: `migrate/migrate_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `migrate/migrate_test.go`, add:
+
+```go
+func TestMigrateGraphAttrsToVars(t *testing.T) {
+	dot := `digraph test {
+  source_ref="references/sdk/src";
+  target_name="my-crate";
+  model="claude-opus-4-6";
+  Start [shape=Mdiamond];
+  End [shape=Msquare];
+  Start -> End;
+}`
+	w, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// model should go to Defaults, not Vars
+	if w.Defaults.Model != "claude-opus-4-6" {
+		t.Errorf("model should be in defaults, got %q", w.Defaults.Model)
+	}
+	// source_ref and target_name should be in Vars
+	if w.Vars == nil {
+		t.Fatal("expected Vars to be populated")
+	}
+	if got := w.Vars["source_ref"]; got != "references/sdk/src" {
+		t.Errorf("source_ref = %q, want %q", got, "references/sdk/src")
+	}
+	if got := w.Vars["target_name"]; got != "my-crate" {
+		t.Errorf("target_name = %q, want %q", got, "my-crate")
+	}
+	// model should NOT be in Vars
+	if _, ok := w.Vars["model"]; ok {
+		t.Error("model should not be in Vars (it's a known default)")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-pkg migrate`
+Expected: FAIL — unknown graph attrs are silently dropped.
+
+- [ ] **Step 3: Modify `extractGraphDefaults` to capture unknown attrs**
+
+In `migrate/migrate.go`, modify `applyIntDefault` to capture non-integer unknown attrs into `Workflow.Vars`:
+
+Replace `applyIntDefault` with a function that tries integer parsing first, then falls back to vars:
+
+```go
+// applyUnknownGraphAttr handles graph attributes not in the handler map.
+// Integer values go to known int defaults; everything else goes to Vars.
+func applyUnknownGraphAttr(k, v string, w *ir.Workflow) {
+	if applyIntDefault(k, v, w) {
+		return
+	}
+	if w.Vars == nil {
+		w.Vars = make(map[string]string)
+	}
+	w.Vars[k] = v
+}
+
+// applyIntDefault handles integer-valued graph defaults. Returns true if handled.
+func applyIntDefault(k, v string, w *ir.Workflow) bool {
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return false
+	}
+	switch k {
+	case "default_max_retry", "max_retries":
+		w.Defaults.MaxRetries = n
+	case "max_restarts":
+		w.Defaults.MaxRestarts = n
+	default:
+		return false
+	}
+	return true
+}
+```
+
+In `extractGraphDefaults`, change the fallback call:
+
+```go
+func extractGraphDefaults(attrs map[string]string, w *ir.Workflow) {
+	for k, v := range attrs {
+		if handler, ok := graphDefaultsHandlers[k]; ok {
+			handler(v, w)
+			continue
+		}
+		applyUnknownGraphAttr(k, v, w)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test-pkg migrate`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrate/migrate.go migrate/migrate_test.go
+git commit -m "feat(migrate): capture unknown DOT graph attributes as workflow vars"
+```
+
+---
+
+## Task 6: Update Example — `semport_thematic.dip`
+
+**Files:**
+- Modify: `examples/semport_thematic.dip`
+
+- [ ] **Step 1: Add `vars` block to `semport_thematic.dip`**
+
+After the `defaults` block (line 8), add:
+
+```dip
+  vars
+    source_ref: "references/claude-agent-sdk-python/src"
+    target_name: "claude-agents-rs"
+    target_module: "claude-agents-rs/src/"
+```
+
+- [ ] **Step 2: Verify the example validates**
+
+Run: `just validate-examples`
+Expected: PASS
+
+- [ ] **Step 3: Verify the example lints cleanly**
+
+Run: `just lint-examples`
+Expected: No new warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/semport_thematic.dip
+git commit -m "docs: add vars block to semport_thematic example"
+```
+
+---
+
+## Task 7: Documentation and Full Validation
+
+**Files:**
+- Modify: `docs/GRAMMAR.ebnf`
+- Modify: `docs/nodes.md`
+- Modify: `docs/llm-reference.md`
+- Modify: `site/content/language.md`
+- Modify: `CHANGELOG.md`
+- Modify: `site/content/changelog.md`
+
+- [ ] **Step 1: Update GRAMMAR.ebnf**
+
+Add `vars_section` production rule and add it to `workflow_body`:
+
+```ebnf
+workflow_body   = { workflow_field | defaults_section | vars_section
+                  | node_decl | edges_section
+                  | stylesheet_section | NEWLINE } ;
+```
+
+Add after `defaults_section`:
+
+```ebnf
+(* Vars Section                                               *)
+(* ═══════════════════════════════════════════════════════════ *)
+
+vars_section     = "vars" NEWLINE INDENT { vars_field } OUTDENT ;
+
+vars_field       = IDENTIFIER ":" field_value ;
+```
+
+- [ ] **Step 2: Update `docs/nodes.md`**
+
+Add a "Vars Block" section after the "Defaults" section, documenting:
+- Purpose: declare workflow-level variables for runtime expansion
+- Syntax: `vars` block with key-value pairs
+- DOT export: emitted as graph-level attributes
+- Example showing the `vars` block
+
+- [ ] **Step 3: Update `docs/llm-reference.md`**
+
+Add `vars` to the workflow structure description.
+
+- [ ] **Step 4: Update `site/content/language.md`**
+
+Add vars block documentation to the website language reference.
+
+- [ ] **Step 5: Update changelogs**
+
+Add `[Unreleased]` section to `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Added
+- **`vars` block** at the workflow level for declaring user-defined variables. Vars export as DOT graph-level attributes and round-trip through parse → format → export → migrate.
+```
+
+Mirror in `site/content/changelog.md`.
+
+- [ ] **Step 6: Run full check**
+
+Run: `just check`
+Expected: All checks pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/GRAMMAR.ebnf docs/nodes.md docs/llm-reference.md site/content/language.md CHANGELOG.md site/content/changelog.md
+git commit -m "docs: vars block in GRAMMAR, nodes.md, language.md, changelogs"
+```
+
+---
+
+## Task 8: Round-Trip Test and Final PR
+
+- [ ] **Step 1: Add a parse → format → re-parse round-trip test**
+
+In `parser/parser_test.go`, add:
+
+```go
+func TestParseVarsRoundTrip(t *testing.T) {
+	input := `workflow Test
+  start: A
+  exit: B
+
+  vars
+    source_ref: "references/sdk-python/src"
+    target_name: my-crate
+
+  agent A
+    prompt: go
+
+  agent B
+    prompt: done
+
+  edges
+    A -> B
+`
+	p := NewParser(input, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	formatted := formatter.Format(w)
+	p2 := NewParser(formatted, "roundtrip.dip")
+	w2, err := p2.Parse()
+	if err != nil {
+		t.Fatalf("re-parse error: %v\nformatted:\n%s", err, formatted)
+	}
+	if len(w2.Vars) != 2 {
+		t.Errorf("expected 2 vars after round-trip, got %d", len(w2.Vars))
+	}
+	if w2.Vars["source_ref"] != "references/sdk-python/src" {
+		t.Errorf("source_ref lost in round-trip: %q", w2.Vars["source_ref"])
+	}
+	if w2.Vars["target_name"] != "my-crate" {
+		t.Errorf("target_name lost in round-trip: %q", w2.Vars["target_name"])
+	}
+}
+```
+
+- [ ] **Step 2: Run full check**
+
+Run: `just check`
+Expected: All checks pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add parser/parser_test.go
+git commit -m "test: vars round-trip through parse → format → re-parse"
+```
+
+- [ ] **Step 4: Create PR**
+
+```bash
+gh pr create --title "feat: workflow-level vars block" --body "$(cat <<'EOF'
+## Summary
+
+Adds a `vars` block at the workflow level for declaring user-defined key-value variables:
+
+```dip
+vars
+  source_ref: "references/sdk-python/src"
+  target_name: my-crate
+```
+
+- Stored as `Workflow.Vars map[string]string` in the IR
+- Exports as DOT graph-level attributes (what Tracker reads via `graph.Attrs`)
+- DOT migration captures unknown graph attributes into Vars
+- Parser detects duplicate var keys
+- Formatter emits sorted keys between defaults and nodes
+- Vars that collide with known defaults names (model, provider, etc.) are skipped during DOT export
+
+## Test plan
+- [ ] `just check` passes
+- [ ] Parse test: vars block populates `Workflow.Vars`
+- [ ] Parse test: duplicate var key emits diagnostic
+- [ ] Formatter test: vars block emitted with sorted keys, omitted when empty
+- [ ] DOT export test: vars as graph attributes, defaults collisions skipped
+- [ ] Migrate test: unknown graph attrs → `Workflow.Vars`, known attrs → `Defaults`
+- [ ] Round-trip test: parse → format → re-parse preserves vars
+
+Closes #5
+EOF
+)"
+```

--- a/examples/semport_thematic.dip
+++ b/examples/semport_thematic.dip
@@ -6,6 +6,11 @@ workflow SemportThematic
   defaults
     max_retries: 5
 
+  vars
+    source_ref: "references/claude-agent-sdk-python/src"
+    target_name: claude-agents-rs
+    target_module: "claude-agents-rs/src/"
+
   agent Start
     label: Start
 

--- a/export/dot.go
+++ b/export/dot.go
@@ -93,7 +93,7 @@ func writeVarsAttrs(b *strings.Builder, vars map[string]string) {
 	}
 	sortStrings(keys)
 	for _, k := range keys {
-		fmt.Fprintf(b, "  %s=%s;\n", k, dotQuote(vars[k]))
+		fmt.Fprintf(b, "  %s=%s;\n", dotID(k), dotQuote(vars[k]))
 	}
 }
 

--- a/export/dot.go
+++ b/export/dot.go
@@ -55,6 +55,14 @@ func ExportDOT(w *ir.Workflow, opts ExportOptions) string {
 	return b.String()
 }
 
+// reservedGraphAttrs are DOT graph attributes used by the defaults/header — skip
+// them when re-emitting workflow vars so they don't collide.
+var reservedGraphAttrs = map[string]bool{
+	"goal": true, "rankdir": true, "model": true, "provider": true,
+	"fidelity": true, "default_fidelity": true,
+	"max_retries": true, "default_max_retry": true, "max_restarts": true,
+}
+
 // writeDOTHeader writes the digraph opening and global attributes.
 func writeDOTHeader(b *strings.Builder, w *ir.Workflow, opts ExportOptions) {
 	rankDir := opts.RankDir
@@ -69,6 +77,24 @@ func writeDOTHeader(b *strings.Builder, w *ir.Workflow, opts ExportOptions) {
 	fmt.Fprintf(b, "  rankdir=%s;\n", rankDir)
 	b.WriteString("  node [fontname=\"Helvetica\"];\n")
 	b.WriteString("  edge [fontname=\"Helvetica\"];\n")
+	if len(w.Vars) > 0 {
+		writeVarsAttrs(b, w.Vars)
+	}
+}
+
+// writeVarsAttrs emits workflow vars as DOT graph-level attributes,
+// skipping any key that collides with a reserved graph attribute.
+func writeVarsAttrs(b *strings.Builder, vars map[string]string) {
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		if !reservedGraphAttrs[k] {
+			keys = append(keys, k)
+		}
+	}
+	sortStrings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(b, "  %s=%s;\n", k, dotQuote(vars[k]))
+	}
 }
 
 // buildExecOrder builds a map from node ID to execution order indices.

--- a/export/dot_test.go
+++ b/export/dot_test.go
@@ -1191,3 +1191,66 @@ func TestExportConditionalNodeDiamond(t *testing.T) {
 		t.Errorf("expected diamond shape for conditional node, got:\n%s", dot)
 	}
 }
+
+func TestExportVarsAsGraphAttrs(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "Test",
+		Start: "A",
+		Exit:  "B",
+		Vars: map[string]string{
+			"env":     "production",
+			"api_url": "https://example.com/api",
+		},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "do it"}},
+			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "A", To: "B"}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+
+	if !strings.Contains(out, `api_url="https://example.com/api"`) {
+		t.Errorf("expected api_url graph attr, got:\n%s", out)
+	}
+	if !strings.Contains(out, `env="production"`) {
+		t.Errorf("expected env graph attr, got:\n%s", out)
+	}
+	// Sorted: api_url must appear before env
+	apiIdx := strings.Index(out, "api_url=")
+	envIdx := strings.Index(out, "env=")
+	if apiIdx < 0 || envIdx < 0 {
+		t.Fatalf("keys missing from output:\n%s", out)
+	}
+	if apiIdx > envIdx {
+		t.Errorf("vars not sorted: api_url@%d should precede env@%d\n%s", apiIdx, envIdx, out)
+	}
+}
+
+func TestExportVarsSkipsDefaultsCollision(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "Test",
+		Start: "A",
+		Exit:  "B",
+		Vars: map[string]string{
+			"model":   "should-be-skipped",
+			"env":     "staging",
+			"rankdir": "also-skipped",
+		},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "do it"}},
+			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "A", To: "B"}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+
+	// "model" and "rankdir" are reserved — they must not appear as extra graph attrs
+	// (rankdir appears as the layout directive, model must not appear separately)
+	if strings.Contains(out, `model="should-be-skipped"`) {
+		t.Errorf("reserved key 'model' should be skipped, got:\n%s", out)
+	}
+	// Non-reserved key must appear
+	if !strings.Contains(out, `env="staging"`) {
+		t.Errorf("expected env graph attr, got:\n%s", out)
+	}
+}

--- a/export/dot_test.go
+++ b/export/dot_test.go
@@ -1245,9 +1245,11 @@ func TestExportVarsSkipsDefaultsCollision(t *testing.T) {
 	out := ExportDOT(w, ExportOptions{})
 
 	// "model" and "rankdir" are reserved — they must not appear as extra graph attrs
-	// (rankdir appears as the layout directive, model must not appear separately)
 	if strings.Contains(out, `model="should-be-skipped"`) {
 		t.Errorf("reserved key 'model' should be skipped, got:\n%s", out)
+	}
+	if strings.Contains(out, `rankdir="also-skipped"`) {
+		t.Errorf("reserved key 'rankdir' should be skipped, got:\n%s", out)
 	}
 	// Non-reserved key must appear
 	if !strings.Contains(out, `env="staging"`) {

--- a/flatten/flatten.go
+++ b/flatten/flatten.go
@@ -107,6 +107,7 @@ func newOutputWorkflow(w *ir.Workflow) *ir.Workflow {
 		Start:      w.Start,
 		Exit:       w.Exit,
 		Defaults:   w.Defaults,
+		Vars:       w.Vars,
 		Stylesheet: w.Stylesheet,
 		SourceMap:  w.SourceMap,
 	}

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -26,6 +26,11 @@ func Format(w *ir.Workflow) string {
 		writeDefaults(wr, w.Defaults)
 	}
 
+	if len(w.Vars) > 0 {
+		wr.blank()
+		writeVars(wr, w.Vars)
+	}
+
 	for _, n := range w.Nodes {
 		wr.blank()
 		writeNode(wr, n)
@@ -172,6 +177,20 @@ func writeDefaultsCompactionFields(wr *writer, d ir.WorkflowDefaults) {
 	if d.OnResume != "" {
 		wr.line("on_resume: %s", quoteValue(d.OnResume))
 	}
+}
+
+func writeVars(wr *writer, vars map[string]string) {
+	wr.line("vars")
+	wr.push()
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		wr.line("%s: %s", k, quoteValue(vars[k]))
+	}
+	wr.pop()
 }
 
 func writeNode(wr *writer, n *ir.Node) {

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -18,35 +18,38 @@ import (
 // The output always ends with exactly one trailing newline.
 func Format(w *ir.Workflow) string {
 	wr := &writer{}
-
 	writeWorkflowHeader(wr, w)
+	writeWorkflowSections(wr, w)
+	return wr.String()
+}
 
+// writeWorkflowSections emits all optional top-level sections in canonical order.
+func writeWorkflowSections(wr *writer, w *ir.Workflow) {
 	if !isDefaultsZero(w.Defaults) {
 		wr.blank()
 		writeDefaults(wr, w.Defaults)
 	}
-
 	if len(w.Vars) > 0 {
 		wr.blank()
 		writeVars(wr, w.Vars)
 	}
-
 	for _, n := range w.Nodes {
 		wr.blank()
 		writeNode(wr, n)
 	}
+	writeWorkflowTailSections(wr, w)
+}
 
+// writeWorkflowTailSections emits stylesheet and edges after nodes.
+func writeWorkflowTailSections(wr *writer, w *ir.Workflow) {
 	if len(w.Stylesheet) > 0 {
 		wr.blank()
 		writeStylesheet(wr, w.Stylesheet)
 	}
-
 	if len(w.Edges) > 0 {
 		wr.blank()
 		writeEdges(wr, w.Edges)
 	}
-
-	return wr.String()
 }
 
 // writer wraps a strings.Builder with indentation tracking.

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -1671,3 +1671,69 @@ func TestFormatConditionalNode(t *testing.T) {
 		t.Errorf("expected 'label: Evaluate' in output, got:\n%s", output)
 	}
 }
+
+func TestFormatVarsBlock(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "Test",
+		Start: "A",
+		Exit:  "B",
+		Vars: map[string]string{
+			"env":     "production",
+			"api_url": "https://example.com/api",
+			"retries": "3",
+		},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "do it"}},
+			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "A", To: "B"}},
+	}
+	out := Format(w)
+
+	// vars block must appear
+	if !strings.Contains(out, "vars\n") {
+		t.Errorf("expected vars block header, got:\n%s", out)
+	}
+	// keys must be sorted
+	apiIdx := strings.Index(out, "api_url:")
+	envIdx := strings.Index(out, "env:")
+	retriesIdx := strings.Index(out, "retries:")
+	if apiIdx < 0 || envIdx < 0 || retriesIdx < 0 {
+		t.Fatalf("missing key in output:\n%s", out)
+	}
+	if !(apiIdx < envIdx && envIdx < retriesIdx) {
+		t.Errorf("vars keys not sorted: api_url@%d env@%d retries@%d\n%s", apiIdx, envIdx, retriesIdx, out)
+	}
+	// values present
+	if !strings.Contains(out, "api_url: https://example.com/api") {
+		t.Errorf("api_url value missing:\n%s", out)
+	}
+	if !strings.Contains(out, "env: production") {
+		t.Errorf("env value missing:\n%s", out)
+	}
+}
+
+func TestFormatVarsEmptyOmitted(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "Test",
+		Start: "A",
+		Exit:  "B",
+		Vars:  nil,
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "do it"}},
+			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "A", To: "B"}},
+	}
+	out := Format(w)
+	if strings.Contains(out, "vars") {
+		t.Errorf("expected no vars block for nil vars, got:\n%s", out)
+	}
+
+	// Also test empty map
+	w.Vars = map[string]string{}
+	out = Format(w)
+	if strings.Contains(out, "vars") {
+		t.Errorf("expected no vars block for empty vars map, got:\n%s", out)
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -14,8 +14,9 @@ type Workflow struct {
 	Goal       string           // Human-readable objective
 	Start      string           // Explicit entry node ID (required)
 	Exit       string           // Explicit exit node ID (required)
-	Defaults   WorkflowDefaults // Graph-level config
-	Nodes      []*Node          // Ordered for deterministic processing
+	Defaults   WorkflowDefaults   // Graph-level config
+	Vars       map[string]string // User-defined workflow variables
+	Nodes      []*Node           // Ordered for deterministic processing
 	Edges      []*Edge
 	Stylesheet []StylesheetRule // Theme/styling rules
 	SourceMap  *SourceMap       // File/line mapping for diagnostics

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -10,11 +10,11 @@ import "time"
 // Workflow is the top-level IR structure representing a complete pipeline.
 type Workflow struct {
 	Name       string
-	Version    string           // Dippin format version
-	Goal       string           // Human-readable objective
-	Start      string           // Explicit entry node ID (required)
-	Exit       string           // Explicit exit node ID (required)
-	Defaults   WorkflowDefaults   // Graph-level config
+	Version    string            // Dippin format version
+	Goal       string            // Human-readable objective
+	Start      string            // Explicit entry node ID (required)
+	Exit       string            // Explicit exit node ID (required)
+	Defaults   WorkflowDefaults  // Graph-level config
 	Vars       map[string]string // User-defined workflow variables
 	Nodes      []*Node           // Ordered for deterministic processing
 	Edges      []*Edge

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -125,22 +125,38 @@ func extractGraphDefaults(attrs map[string]string, w *ir.Workflow) {
 			handler(v, w)
 			continue
 		}
-		applyIntDefault(k, v, w)
+		applyUnknownGraphAttr(k, v, w)
 	}
 }
 
+// applyUnknownGraphAttr routes unknown graph attributes: integer-valued
+// attrs go to Defaults; everything else is captured in Workflow.Vars.
+func applyUnknownGraphAttr(k, v string, w *ir.Workflow) {
+	if applyIntDefault(k, v, w) {
+		return
+	}
+	if w.Vars == nil {
+		w.Vars = make(map[string]string)
+	}
+	w.Vars[k] = v
+}
+
 // applyIntDefault handles integer-valued graph defaults.
-func applyIntDefault(k, v string, w *ir.Workflow) {
+// Returns true if the key was recognised and applied.
+func applyIntDefault(k, v string, w *ir.Workflow) bool {
 	n, err := strconv.Atoi(v)
 	if err != nil {
-		return
+		return false
 	}
 	switch k {
 	case "default_max_retry", "max_retries":
 		w.Defaults.MaxRetries = n
 	case "max_restarts":
 		w.Defaults.MaxRestarts = n
+	default:
+		return false
 	}
+	return true
 }
 
 // convertNode converts a DOT node to an IR node.

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -129,16 +130,30 @@ func extractGraphDefaults(attrs map[string]string, w *ir.Workflow) {
 	}
 }
 
-// applyUnknownGraphAttr routes unknown graph attributes: integer-valued
-// attrs go to Defaults; everything else is captured in Workflow.Vars.
+// applyUnknownGraphAttr routes unknown graph attributes: only recognized
+// integer-backed default keys (max_retries, max_restarts) go to Defaults;
+// all other attrs, including unrecognized integer-valued ones, are captured
+// in Workflow.Vars. Keys that aren't valid Dippin identifiers are skipped.
 func applyUnknownGraphAttr(k, v string, w *ir.Workflow) {
 	if applyIntDefault(k, v, w) {
+		return
+	}
+	if !isDippinIdentifier(k) {
 		return
 	}
 	if w.Vars == nil {
 		w.Vars = make(map[string]string)
 	}
 	w.Vars[k] = v
+}
+
+// dippinIdentPattern matches valid Dippin identifiers:
+// alphanumeric start, followed by alphanumeric, underscore, or dash.
+var dippinIdentPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+// isDippinIdentifier returns true if s is a valid Dippin identifier.
+func isDippinIdentifier(s string) bool {
+	return dippinIdentPattern.MatchString(s)
 }
 
 // applyIntDefault handles integer-valued graph defaults.

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -142,7 +142,7 @@ func applyUnknownGraphAttr(k, v string, w *ir.Workflow) {
 }
 
 // applyIntDefault handles integer-valued graph defaults.
-// Returns true if the key was recognised and applied.
+// Returns true if the key was recognized and applied.
 func applyIntDefault(k, v string, w *ir.Workflow) bool {
 	n, err := strconv.Atoi(v)
 	if err != nil {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -148,8 +148,8 @@ func applyUnknownGraphAttr(k, v string, w *ir.Workflow) {
 }
 
 // dippinIdentPattern matches valid Dippin identifiers:
-// alphanumeric start, followed by alphanumeric, underscore, or dash.
-var dippinIdentPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+// alphanumeric start, followed by alphanumeric, underscore, dash, dot, or slash.
+var dippinIdentPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_\-./]*$`)
 
 // isDippinIdentifier returns true if s is a valid Dippin identifier.
 func isDippinIdentifier(s string) bool {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2246,3 +2246,40 @@ func TestMigrateToSourceError(t *testing.T) {
 		t.Error("expected error for invalid DOT input")
 	}
 }
+
+func TestMigrateGraphAttrsToVars(t *testing.T) {
+	input := `digraph pipeline {
+  graph [goal="Run the pipeline", model="claude-opus-4-6", max_retries=3, max_restarts=2, api_url="example.com/api", env=production];
+  A [shape=box, label="Agent A"];
+  B [shape=Msquare, label="Done"];
+  A -> B;
+}`
+	w, err := Migrate(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Known attrs go to Defaults
+	if w.Defaults.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want 3", w.Defaults.MaxRetries)
+	}
+	if w.Defaults.MaxRestarts != 2 {
+		t.Errorf("MaxRestarts = %d, want 2", w.Defaults.MaxRestarts)
+	}
+	if w.Defaults.Model != "claude-opus-4-6" {
+		t.Errorf("Defaults.Model = %q, want %q", w.Defaults.Model, "claude-opus-4-6")
+	}
+
+	// Unknown attrs go to Vars
+	if w.Vars["api_url"] != "example.com/api" {
+		t.Errorf("Vars[api_url] = %q, want %q", w.Vars["api_url"], "example.com/api")
+	}
+	if w.Vars["env"] != "production" {
+		t.Errorf("Vars[env] = %q, want %q", w.Vars["env"], "production")
+	}
+
+	// goal is a known handler — should NOT appear in Vars
+	if _, ok := w.Vars["goal"]; ok {
+		t.Errorf("goal should not be in Vars, but it is: %q", w.Vars["goal"])
+	}
+}

--- a/parser/parse_vars.go
+++ b/parser/parse_vars.go
@@ -15,9 +15,7 @@ func (p *Parser) parseVars() {
 }
 
 func (p *Parser) parseVarsBody() {
-	if p.workflow.Vars == nil {
-		p.workflow.Vars = make(map[string]string)
-	}
+	p.ensureVarsMap()
 	for p.lexer.PeekToken().Type != TokenOutdent && p.lexer.PeekToken().Type != TokenEOF {
 		t := p.lexer.PeekToken()
 		if t.Type == TokenNewline {
@@ -29,6 +27,12 @@ func (p *Parser) parseVarsBody() {
 		} else {
 			p.lexer.NextToken()
 		}
+	}
+}
+
+func (p *Parser) ensureVarsMap() {
+	if p.workflow.Vars == nil {
+		p.workflow.Vars = make(map[string]string)
 	}
 }
 

--- a/parser/parse_vars.go
+++ b/parser/parse_vars.go
@@ -25,6 +25,8 @@ func (p *Parser) parseVarsBody() {
 		if t.Type == TokenIdentifier {
 			p.parseVarField(t)
 		} else {
+			p.diagnostics = append(p.diagnostics,
+				fmt.Sprintf("unexpected token in vars block at %d:%d", t.Location.Line, t.Location.Column))
 			p.lexer.NextToken()
 		}
 	}

--- a/parser/parse_vars.go
+++ b/parser/parse_vars.go
@@ -1,0 +1,49 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+func (p *Parser) parseVars() {
+	p.lexer.NextToken() // vars
+	p.expect(TokenNewline)
+	p.expect(TokenIndent)
+	p.parseVarsBody()
+	p.expect(TokenOutdent)
+}
+
+func (p *Parser) parseVarsBody() {
+	if p.workflow.Vars == nil {
+		p.workflow.Vars = make(map[string]string)
+	}
+	for p.lexer.PeekToken().Type != TokenOutdent && p.lexer.PeekToken().Type != TokenEOF {
+		t := p.lexer.PeekToken()
+		if t.Type == TokenNewline {
+			p.lexer.NextToken()
+			continue
+		}
+		if t.Type == TokenIdentifier {
+			p.parseVarField(t)
+		} else {
+			p.lexer.NextToken()
+		}
+	}
+}
+
+func (p *Parser) parseVarField(t Token) {
+	key := t.Value
+	p.lexer.NextToken()
+	p.expect(TokenColon)
+	val := p.readFieldValue(t.Location.Line)
+	p.applyVarField(key, val, t.Location)
+}
+
+func (p *Parser) applyVarField(key, val string, loc ir.SourceLocation) {
+	if _, exists := p.workflow.Vars[key]; exists {
+		p.diagnostics = append(p.diagnostics,
+			fmt.Sprintf("duplicate vars key %q at %d:%d", key, loc.Line, loc.Column))
+	}
+	p.workflow.Vars[key] = val
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -90,6 +90,8 @@ func (p *Parser) dispatchWorkflowField(t Token) {
 		p.parseWorkflowStringField(t)
 	case "defaults":
 		p.parseDefaults()
+	case "vars":
+		p.parseVars()
 	case "edges":
 		p.parseEdges()
 	case "stylesheet":

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -85,6 +85,14 @@ var workflowNodeKinds = map[string]bool{
 
 // dispatchWorkflowField routes a workflow-level identifier to the right handler.
 func (p *Parser) dispatchWorkflowField(t Token) {
+	if dispatchWorkflowSimpleField(p, t) {
+		return
+	}
+	p.dispatchWorkflowBlock(t)
+}
+
+// dispatchWorkflowSimpleField handles scalar keywords. Returns true if handled.
+func dispatchWorkflowSimpleField(p *Parser, t Token) bool {
 	switch t.Value {
 	case "goal", "start", "exit":
 		p.parseWorkflowStringField(t)
@@ -92,13 +100,23 @@ func (p *Parser) dispatchWorkflowField(t Token) {
 		p.parseDefaults()
 	case "vars":
 		p.parseVars()
+	default:
+		return dispatchWorkflowTailField(p, t)
+	}
+	return true
+}
+
+// dispatchWorkflowTailField handles edges, stylesheet. Returns true if handled.
+func dispatchWorkflowTailField(p *Parser, t Token) bool {
+	switch t.Value {
 	case "edges":
 		p.parseEdges()
 	case "stylesheet":
 		p.parseStylesheet()
 	default:
-		p.dispatchWorkflowBlock(t)
+		return false
 	}
+	return true
 }
 
 // dispatchWorkflowBlock handles parallel, fan_in, node kinds, and unknown identifiers.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -91,7 +91,7 @@ func (p *Parser) dispatchWorkflowField(t Token) {
 	p.dispatchWorkflowBlock(t)
 }
 
-// dispatchWorkflowSimpleField handles scalar keywords. Returns true if handled.
+// dispatchWorkflowSimpleField handles header fields and config blocks (defaults, vars). Returns true if handled.
 func dispatchWorkflowSimpleField(p *Parser, t Token) bool {
 	switch t.Value {
 	case "goal", "start", "exit":

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1450,3 +1450,65 @@ func TestParseAgentWorkingDirField(t *testing.T) {
 		t.Errorf("expected working_dir '.ai/worktrees/claude', got %q", cfg.WorkingDir)
 	}
 }
+
+func TestParseVarsBlock(t *testing.T) {
+	input := `workflow Test
+  start: A
+  exit: B
+
+  vars
+    api_url: https://example.com/api
+    env: production
+    retries: 3
+
+  agent A
+    prompt: do it
+  agent B
+    prompt: done
+  edges
+    A -> B
+`
+	p := NewParser(input, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if len(w.Vars) != 3 {
+		t.Fatalf("expected 3 vars, got %d", len(w.Vars))
+	}
+	if w.Vars["api_url"] != "https://example.com/api" {
+		t.Errorf("api_url = %q, want %q", w.Vars["api_url"], "https://example.com/api")
+	}
+	if w.Vars["env"] != "production" {
+		t.Errorf("env = %q, want %q", w.Vars["env"], "production")
+	}
+	if w.Vars["retries"] != "3" {
+		t.Errorf("retries = %q, want %q", w.Vars["retries"], "3")
+	}
+}
+
+func TestParseVarsDuplicateKey(t *testing.T) {
+	input := `workflow Test
+  start: A
+  exit: B
+
+  vars
+    key: first
+    key: second
+
+  agent A
+    prompt: do it
+  agent B
+    prompt: done
+  edges
+    A -> B
+`
+	p := NewParser(input, "test.dip")
+	_, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected error for duplicate vars key, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate vars key") {
+		t.Errorf("error %q does not mention duplicate vars key", err.Error())
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1512,3 +1512,43 @@ func TestParseVarsDuplicateKey(t *testing.T) {
 		t.Errorf("error %q does not mention duplicate vars key", err.Error())
 	}
 }
+
+func TestParseVarsRoundTrip(t *testing.T) {
+	input := `workflow Test
+  start: A
+  exit: B
+
+  vars
+    source_ref: "references/sdk-python/src"
+    target_name: my-crate
+
+  agent A
+    prompt: go
+
+  agent B
+    prompt: done
+
+  edges
+    A -> B
+`
+	p := NewParser(input, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	formatted := formatter.Format(w)
+	p2 := NewParser(formatted, "roundtrip.dip")
+	w2, err := p2.Parse()
+	if err != nil {
+		t.Fatalf("re-parse error: %v\nformatted:\n%s", err, formatted)
+	}
+	if len(w2.Vars) != 2 {
+		t.Errorf("expected 2 vars after round-trip, got %d", len(w2.Vars))
+	}
+	if w2.Vars["source_ref"] != "references/sdk-python/src" {
+		t.Errorf("source_ref lost in round-trip: %q", w2.Vars["source_ref"])
+	}
+	if w2.Vars["target_name"] != "my-crate" {
+		t.Errorf("target_name lost in round-trip: %q", w2.Vars["target_name"])
+	}
+}

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [Unreleased]
+
+### Added
+- **`vars` block** at the workflow level for declaring user-defined variables. Vars export as DOT graph-level attributes and round-trip through parse → format → export → migrate.
+
 ## [v0.19.1] — 2026-04-16
 
 ### Added

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -68,6 +68,21 @@ The optional `defaults` block sets graph-level configuration that applies to all
 | `cache_tools` | Boolean | Whether to cache tool call results |
 | `compaction` | String | Context compaction mode for long pipelines |
 
+## Vars Block
+
+The optional `vars` block declares user-defined variables that are substituted wherever `$key` placeholders appear in prompts and commands.
+
+```
+  vars
+    source_ref: "references/claude-agent-sdk-python/src"
+    target_name: claude-agents-rs
+    target_module: "claude-agents-rs/src/"
+```
+
+Values can be quoted strings or bare identifiers. Keys must be unique — duplicate keys cause a parse error.
+
+Vars are exported as graph-level DOT attributes so they round-trip through `dippin export-dot` and `dippin migrate`.
+
 ## Node Kinds
 
 There are 6 node kinds, each with its own syntax and configuration:

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -7,7 +7,7 @@ subtitle: "Complete syntax for .dip workflow files."
 
 ## File Structure
 
-Every `.dip` file contains exactly one workflow. The top-level structure has five sections that must appear in order:
+Every `.dip` file contains exactly one workflow. The top-level structure has up to five sections, in this order:
 
 <div class="flow-diagram">
   <div class="flow-step">workflow &lt;name&gt;</div>

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -7,7 +7,7 @@ subtitle: "Complete syntax for .dip workflow files."
 
 ## File Structure
 
-Every `.dip` file contains exactly one workflow. The top-level structure has four sections that must appear in order:
+Every `.dip` file contains exactly one workflow. The top-level structure has five sections that must appear in order:
 
 <div class="flow-diagram">
   <div class="flow-step">workflow &lt;name&gt;</div>
@@ -15,6 +15,8 @@ Every `.dip` file contains exactly one workflow. The top-level structure has fou
   <div class="flow-step">Header<br>goal, start, exit</div>
   <div class="flow-arrow">&rarr;</div>
   <div class="flow-step">Defaults (optional)<br>model, provider, ...</div>
+  <div class="flow-arrow">&rarr;</div>
+  <div class="flow-step">Vars (optional)<br>key: value, ...</div>
   <div class="flow-arrow">&rarr;</div>
   <div class="flow-step">Node Definitions<br>agent, human, tool, ...</div>
   <div class="flow-arrow">&rarr;</div>


### PR DESCRIPTION
## Summary

Adds a `vars` block at the workflow level for declaring user-defined key-value variables:

```dip
vars
  source_ref: "references/sdk-python/src"
  target_name: my-crate
```

- Stored as `Workflow.Vars map[string]string` in the IR
- Exports as DOT graph-level attributes (what Tracker reads via `graph.Attrs`)
- DOT migration captures unknown graph attributes into Vars (previously silently dropped)
- Parser detects duplicate var keys
- Formatter emits sorted keys between defaults and nodes
- Vars that collide with known defaults names (model, provider, etc.) are skipped during DOT export

## Test plan
- [x] `just check` passes
- [x] Parse test: vars block populates `Workflow.Vars`
- [x] Parse test: duplicate var key emits diagnostic
- [x] Formatter test: vars block emitted with sorted keys, omitted when empty
- [x] DOT export test: vars as graph attributes, defaults collisions skipped
- [x] Migrate test: unknown graph attrs → `Workflow.Vars`, known attrs → `Defaults`
- [x] Round-trip test: parse → format → re-parse preserves vars
- [x] `semport_thematic.dip` updated with real vars block

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow-level `vars` block for user-defined variables; supports interpolation and exports as DOT graph-level attributes for round-tripping.

* **Documentation**
  * Updated grammar, language reference, examples, and changelog to describe `vars` syntax, placement, and behavior.

* **Tests**
  * Added parser, formatter, export, migrate, and formatter tests to validate parsing, formatting, DOT emission, collision handling, migration, and round-trip consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->