### PR TITLE
feat: add HumanConfig timeout + WorkflowDefaults budget fields

### DIFF
--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -223,7 +223,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `goal_gate` | bool | Pipeline fails if gate fails. Add `retry_target` or `fallback_target` (DIP115) |
 | `response_format` | string | `json_object` or `json_schema` (DIP130) |
 | `response_schema` | multiline JSON | Must be valid JSON (DIP132). Requires `response_format: json_schema` (DIP131) |
-| `reasoning_effort` | string | `low`, `medium`, `high` (DIP119) |
+| `reasoning_effort` | string | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` (DIP119) |
 | `fidelity` | string | `full`, `summary:high`, `summary:medium`, `summary:low`, `compact`, `truncate` (DIP114) |
 | `cache_tools` | bool | Cache tool results |
 | `compaction` | string | Context compaction strategy |
@@ -489,7 +489,7 @@ The primary loop for authoring .dip files:
 | DIP116 | Invalid compaction threshold | Use float 0.0-1.0 |
 | DIP117 | Stylesheet class references undefined class | Fix class name in stylesheet block |
 | DIP118 | Stylesheet ID references unknown node | Fix node ID in stylesheet block |
-| DIP119 | Invalid reasoning_effort | Use: `low`, `medium`, `high` |
+| DIP119 | Invalid reasoning_effort | Use: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
 | DIP120 | Condition var missing namespace | Prefix with `ctx.`, `params.`, or `graph.` |
 | DIP123 | Shell syntax error in command | Fix the shell command (checked via `bash -n`) |
 | DIP124 | `${ctx.*}` in tool command | Remove — runtime variables expand to empty at parse time |

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -45,7 +45,7 @@ workflow <Name>
 | Kind | Required Fields | Optional Fields |
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
-| `human` | `mode` (freeform\|choice) | `default`, `timeout` (Duration, e.g. 5m), `timeout_action` (String: fail\|default) |
+| `human` | `mode` (freeform\|choice\|interview) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
 | `tool` | `command` | `timeout` (e.g. 30s, 5m) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
@@ -249,8 +249,8 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `prompt` | multiline | Prompt text |
 | `questions_key` | string | Context key for interview questions |
 | `answers_key` | string | Context key for interview answers |
-| `timeout` | Duration | e.g. `5m`, `1h`. How long to wait for human response. |
-| `timeout_action` | String | `fail` or `default`. Action on timeout (default: `fail`). |
+| `timeout` | duration | e.g. `5m`, `1h`. How long to wait for human response. |
+| `timeout_action` | string | `fail` or `default`. Action on timeout (default: `fail`). |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -394,9 +394,9 @@ All defaults are inherited by nodes unless overridden at the node level.
 
 | Default Field | Type | Notes |
 |---------------|------|-------|
-| `max_total_tokens` | Integer | Budget cap on total tokens consumed. |
-| `max_cost_cents` | Integer | Budget cap in cents (e.g. 1000 = $10.00). |
-| `max_wall_time` | Duration | Maximum wall-clock time for the workflow (e.g. `30m`, `2h`). |
+| `max_total_tokens` | int | Budget cap on total tokens consumed. |
+| `max_cost_cents` | int | Budget cap in cents (e.g. 1000 = $10.00). |
+| `max_wall_time` | duration | Maximum wall-clock time for the workflow (e.g. `30m`, `2h`). |
 
 ## CLI Reference
 

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -17,6 +17,9 @@ workflow <Name>
   [defaults
     model: <string>
     provider: <string>
+    max_total_tokens: <int>
+    max_cost_cents: <int>
+    max_wall_time: <duration>
     ...]
 
   [vars
@@ -42,7 +45,7 @@ workflow <Name>
 | Kind | Required Fields | Optional Fields |
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
-| `human` | `mode` (freeform\|choice) | `default` |
+| `human` | `mode` (freeform\|choice) | `default`, `timeout` (Duration, e.g. 5m), `timeout_action` (String: fail\|default) |
 | `tool` | `command` | `timeout` (e.g. 30s, 5m) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
@@ -246,6 +249,8 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `prompt` | multiline | Prompt text |
 | `questions_key` | string | Context key for interview questions |
 | `answers_key` | string | Context key for interview answers |
+| `timeout` | Duration | e.g. `5m`, `1h`. How long to wait for human response. |
+| `timeout_action` | String | `fail` or `default`. Action on timeout (default: `fail`). |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -380,9 +385,18 @@ Fields `prompt:`, `system_prompt:`, `command:`, `response_schema:` support inden
     max_restarts: 3
     cache_tools: true
     compaction: auto
+    max_total_tokens: 500000
+    max_cost_cents: 1000
+    max_wall_time: 30m
 ```
 
 All defaults are inherited by nodes unless overridden at the node level.
+
+| Default Field | Type | Notes |
+|---------------|------|-------|
+| `max_total_tokens` | Integer | Budget cap on total tokens consumed. |
+| `max_cost_cents` | Integer | Budget cap in cents (e.g. 1000 = $10.00). |
+| `max_wall_time` | Duration | Maximum wall-clock time for the workflow (e.g. `30m`, `2h`). |
 
 ## CLI Reference
 

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -43,7 +43,7 @@ workflow <Name>
 | Kind | Required Fields | Optional Fields |
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
-| `human` | `mode` (freeform\|choice) | `default`, `timeout` (Duration, e.g. 5m), `timeout_action` (String: fail\|default) |
+| `human` | `mode` (freeform\|choice\|interview) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
 | `tool` | `command` | `timeout` (e.g. 30s, 5m) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -15,6 +15,9 @@ workflow <Name>
   [defaults
     model: <string>
     provider: <string>
+    max_total_tokens: <int>
+    max_cost_cents: <int>
+    max_wall_time: <duration>
     ...]
 
   [vars
@@ -40,7 +43,7 @@ workflow <Name>
 | Kind | Required Fields | Optional Fields |
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
-| `human` | `mode` (freeform\|choice) | `default` |
+| `human` | `mode` (freeform\|choice) | `default`, `timeout` (Duration, e.g. 5m), `timeout_action` (String: fail\|default) |
 | `tool` | `command` | `timeout` (e.g. 30s, 5m) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |

--- a/export/dot.go
+++ b/export/dot.go
@@ -61,6 +61,7 @@ var reservedGraphAttrs = map[string]bool{
 	"goal": true, "rankdir": true, "model": true, "provider": true,
 	"fidelity": true, "default_fidelity": true,
 	"max_retries": true, "default_max_retry": true, "max_restarts": true,
+	"max_total_tokens": true, "max_cost_cents": true, "max_wall_time": true,
 }
 
 // writeDOTHeader writes the digraph opening and global attributes.

--- a/export/dot.go
+++ b/export/dot.go
@@ -267,6 +267,12 @@ func applyHumanAttrs(attrs map[string]string, cfg ir.HumanConfig) {
 	if cfg.Default != "" {
 		attrs["default"] = cfg.Default
 	}
+	if cfg.Timeout != 0 {
+		attrs["timeout"] = formatDuration(cfg.Timeout)
+	}
+	if cfg.TimeoutAction != "" {
+		attrs["timeout_action"] = cfg.TimeoutAction
+	}
 }
 
 // applySubgraphAttrs adds subgraph-specific attributes.

--- a/export/dot.go
+++ b/export/dot.go
@@ -137,8 +137,10 @@ func writeNodeDOT(b *strings.Builder, n *ir.Node, w *ir.Workflow, opts ExportOpt
 		applyGoalGateHighlight(attrs, n)
 	}
 
+	applySemanticConfigAttrs(attrs, n.Config)
+
 	if opts.IncludePrompts {
-		applyConfigAttrs(attrs, n.Config)
+		applyPromptConfigAttrs(attrs, n.Config)
 	}
 
 	fmt.Fprintf(b, "  %s %s;\n", dotID(n.ID), formatDOTAttrs(attrs))
@@ -190,30 +192,29 @@ func applyGoalGateHighlight(attrs map[string]string, n *ir.Node) {
 	}
 }
 
-// applyConfigAttrs adds config-specific attributes to the node.
-func applyConfigAttrs(attrs map[string]string, cfg interface{}) {
-	if !applyPrimaryConfigAttrs(attrs, cfg) {
-		applyStructuralConfigAttrs(attrs, cfg)
+// applySemanticConfigAttrs adds non-prompt runtime attributes unconditionally.
+// These carry runtime semantics (timeout, mode, etc.) and must always be exported.
+func applySemanticConfigAttrs(attrs map[string]string, cfg interface{}) {
+	if !applySemanticNodeAttrs(attrs, cfg) {
+		applySemanticStructuralAttrs(attrs, cfg)
 	}
 }
 
-// applyPrimaryConfigAttrs handles agent, tool, and human configs. Returns true if matched.
-func applyPrimaryConfigAttrs(attrs map[string]string, cfg interface{}) bool {
+// applySemanticNodeAttrs handles human and tool semantic attrs. Returns true if matched.
+func applySemanticNodeAttrs(attrs map[string]string, cfg interface{}) bool {
 	switch c := cfg.(type) {
-	case ir.AgentConfig:
-		applyAgentAttrs(attrs, c)
-	case ir.ToolConfig:
-		applyToolAttrs(attrs, c)
 	case ir.HumanConfig:
-		applyHumanAttrs(attrs, c)
+		applyHumanSemanticAttrs(attrs, c)
+	case ir.ToolConfig:
+		applyToolSemanticAttrs(attrs, c)
 	default:
 		return false
 	}
 	return true
 }
 
-// applyStructuralConfigAttrs handles subgraph, parallel, and fan-in configs.
-func applyStructuralConfigAttrs(attrs map[string]string, cfg interface{}) {
+// applySemanticStructuralAttrs handles subgraph, parallel, and fan-in semantic attrs.
+func applySemanticStructuralAttrs(attrs map[string]string, cfg interface{}) {
 	switch c := cfg.(type) {
 	case ir.SubgraphConfig:
 		applySubgraphAttrs(attrs, c)
@@ -221,12 +222,22 @@ func applyStructuralConfigAttrs(attrs map[string]string, cfg interface{}) {
 		applyParallelAttrs(attrs, c)
 	case ir.FanInConfig:
 		applyFanInAttrs(attrs, c)
-	case ir.ConditionalConfig:
-		// No additional attributes for conditional nodes.
 	}
 }
 
-// applyAgentAttrs adds agent-specific attributes.
+// applyPromptConfigAttrs adds prompt/text attributes gated behind IncludePrompts.
+func applyPromptConfigAttrs(attrs map[string]string, cfg interface{}) {
+	switch c := cfg.(type) {
+	case ir.AgentConfig:
+		applyAgentAttrs(attrs, c)
+	case ir.ToolConfig:
+		applyToolPromptAttrs(attrs, c)
+	case ir.HumanConfig:
+		applyHumanPromptAttrs(attrs, c)
+	}
+}
+
+// applyAgentAttrs adds agent-specific attributes (prompt + runtime).
 func applyAgentAttrs(attrs map[string]string, cfg ir.AgentConfig) {
 	if cfg.Prompt != "" {
 		attrs["prompt"] = escapeNewlines(cfg.Prompt)
@@ -250,18 +261,23 @@ func applyAgentRuntimeAttrs(attrs map[string]string, cfg ir.AgentConfig) {
 	}
 }
 
-// applyToolAttrs adds tool-specific attributes.
-func applyToolAttrs(attrs map[string]string, cfg ir.ToolConfig) {
-	if cfg.Command != "" {
-		attrs["tool_command"] = escapeNewlines(cfg.Command)
-	}
+// applyToolSemanticAttrs adds tool timeout (runtime, always exported).
+func applyToolSemanticAttrs(attrs map[string]string, cfg ir.ToolConfig) {
 	if cfg.Timeout != 0 {
 		attrs["timeout"] = formatDuration(cfg.Timeout)
 	}
 }
 
-// applyHumanAttrs adds human-specific attributes.
-func applyHumanAttrs(attrs map[string]string, cfg ir.HumanConfig) {
+// applyToolPromptAttrs adds tool command text (gated behind IncludePrompts).
+func applyToolPromptAttrs(attrs map[string]string, cfg ir.ToolConfig) {
+	if cfg.Command != "" {
+		attrs["tool_command"] = escapeNewlines(cfg.Command)
+	}
+}
+
+// applyHumanSemanticAttrs adds human mode, default, timeout, and timeout_action.
+// These are all runtime-behavioral — not prompt text.
+func applyHumanSemanticAttrs(attrs map[string]string, cfg ir.HumanConfig) {
 	if cfg.Mode != "" {
 		attrs["mode"] = cfg.Mode
 	}
@@ -273,6 +289,13 @@ func applyHumanAttrs(attrs map[string]string, cfg ir.HumanConfig) {
 	}
 	if cfg.TimeoutAction != "" {
 		attrs["timeout_action"] = cfg.TimeoutAction
+	}
+}
+
+// applyHumanPromptAttrs adds human prompt text (gated behind IncludePrompts).
+func applyHumanPromptAttrs(attrs map[string]string, cfg ir.HumanConfig) {
+	if cfg.Prompt != "" {
+		attrs["prompt"] = escapeNewlines(cfg.Prompt)
 	}
 }
 

--- a/export/dot_test.go
+++ b/export/dot_test.go
@@ -154,7 +154,7 @@ func TestExportDOTMinimal(t *testing.T) {
 
 	assertContains(t, out, "digraph minimal {")
 	assertContains(t, out, "rankdir=TB;")
-	assertContains(t, out, `Begin [label="Begin", shape="Mdiamond"];`)
+	assertContains(t, out, `Begin [label="Begin", mode="freeform", shape="Mdiamond"];`)
 	assertContains(t, out, `End [label="End", shape="Msquare"];`)
 	assertContains(t, out, "Begin -> End;")
 	assertContains(t, out, "}\n")
@@ -166,8 +166,8 @@ func TestExportDOTFullWorkflow(t *testing.T) {
 	// Verify digraph structure.
 	assertContains(t, out, "digraph ask_and_execute {")
 
-	// Start node gets Mdiamond shape.
-	assertContains(t, out, `AskUser [label="AskUser", shape="Mdiamond"];`)
+	// Start node (human) gets Mdiamond shape and emits mode.
+	assertContains(t, out, `AskUser [label="AskUser", mode="freeform", shape="Mdiamond"];`)
 
 	// Exit node gets Msquare shape.
 	assertContains(t, out, `Done [label="Done", shape="Msquare"];`)
@@ -175,14 +175,14 @@ func TestExportDOTFullWorkflow(t *testing.T) {
 	// Regular agent node gets box shape.
 	assertContains(t, out, `Interpret [label="Interpret", shape="box"];`)
 
-	// Human node (non-start) gets hexagon shape.
-	assertContains(t, out, `Approve [label="Approve", shape="hexagon"];`)
+	// Human node (non-start) emits mode and default as semantic attrs.
+	assertContains(t, out, `Approve [default="Yes", label="Approve", mode="choice", shape="hexagon"];`)
 
-	// Parallel node gets component shape.
-	assertContains(t, out, `ImplementFanOut [label="ImplementFanOut", shape="component"];`)
+	// Parallel node gets component shape and emits targets.
+	assertContains(t, out, `ImplementFanOut [label="ImplementFanOut", shape="component", targets="ImplementClaude,ImplementCodex"];`)
 
-	// Fan-in node gets tripleoctagon shape.
-	assertContains(t, out, `ImplementJoin [label="ImplementJoin", shape="tripleoctagon"];`)
+	// Fan-in node gets tripleoctagon shape and emits sources.
+	assertContains(t, out, `ImplementJoin [label="ImplementJoin", shape="tripleoctagon", sources="ImplementClaude,ImplementCodex"];`)
 
 	// Simple edge.
 	assertContains(t, out, "AskUser -> Interpret;")

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -442,6 +442,17 @@ func writeHumanModeFields(wr *writer, cfg ir.HumanConfig) {
 	if cfg.AnswersKey != "" {
 		wr.line("answers_key: %s", quoteValue(cfg.AnswersKey))
 	}
+	writeHumanTimeoutFields(wr, cfg)
+}
+
+// writeHumanTimeoutFields writes timeout and timeout_action fields for human nodes.
+func writeHumanTimeoutFields(wr *writer, cfg ir.HumanConfig) {
+	if cfg.Timeout != 0 {
+		wr.line("timeout: %s", formatDuration(cfg.Timeout))
+	}
+	if cfg.TimeoutAction != "" {
+		wr.line("timeout_action: %s", quoteValue(cfg.TimeoutAction))
+	}
 }
 
 func writeToolFields(wr *writer, n *ir.Node, cfg ir.ToolConfig) {

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -180,6 +180,20 @@ func writeDefaultsCompactionFields(wr *writer, d ir.WorkflowDefaults) {
 	if d.OnResume != "" {
 		wr.line("on_resume: %s", quoteValue(d.OnResume))
 	}
+	writeDefaultsBudgetFields(wr, d)
+}
+
+// writeDefaultsBudgetFields writes max_total_tokens, max_cost_cents, and max_wall_time.
+func writeDefaultsBudgetFields(wr *writer, d ir.WorkflowDefaults) {
+	if d.MaxTotalTokens != 0 {
+		wr.line("max_total_tokens: %d", d.MaxTotalTokens)
+	}
+	if d.MaxCostCents != 0 {
+		wr.line("max_cost_cents: %d", d.MaxCostCents)
+	}
+	if d.MaxWallTime != 0 {
+		wr.line("max_wall_time: %s", formatDuration(d.MaxWallTime))
+	}
 }
 
 func writeVars(wr *writer, vars map[string]string) {

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -37,16 +37,19 @@ type StyleSelector struct {
 // WorkflowDefaults holds graph-level configuration that applies to all nodes
 // unless overridden at the node level.
 type WorkflowDefaults struct {
-	Model         string // Default LLM model
-	Provider      string // Default LLM provider
-	RetryPolicy   string // Default retry policy name
-	MaxRetries    int    // Default max retries
-	Fidelity      string // Default fidelity level
-	MaxRestarts   int    // Max loop restarts (default 5)
-	RestartTarget string // Where to restart on loop
-	CacheTools    bool   // Cache tool results
-	Compaction    string // Context compaction mode
-	OnResume      string // Fidelity behavior on resume: "preserve" or "degrade"
+	Model          string        // Default LLM model
+	Provider       string        // Default LLM provider
+	RetryPolicy    string        // Default retry policy name
+	MaxRetries     int           // Default max retries
+	Fidelity       string        // Default fidelity level
+	MaxRestarts    int           // Max loop restarts (default 5)
+	RestartTarget  string        // Where to restart on loop
+	CacheTools     bool          // Cache tool results
+	Compaction     string        // Context compaction mode
+	OnResume       string        // Fidelity behavior on resume: "preserve" or "degrade"
+	MaxTotalTokens int           // Hard ceiling on total tokens
+	MaxCostCents   int           // Hard ceiling on cost in cents (USD)
+	MaxWallTime    time.Duration // Hard ceiling on wall time
 }
 
 // Node represents a single step in the workflow.

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -106,11 +106,13 @@ func (AgentConfig) nodeConfig() {}
 
 // HumanConfig holds configuration for human gate nodes.
 type HumanConfig struct {
-	Mode         string // "choice" | "freeform" | "interview"
-	Default      string // Default choice
-	Prompt       string // Instructions shown to the human
-	QuestionsKey string // Context key to read questions from (interview mode)
-	AnswersKey   string // Context key to write answers to (interview mode)
+	Mode          string        // "choice" | "freeform" | "interview"
+	Default       string        // Default choice
+	Prompt        string        // Instructions shown to the human
+	QuestionsKey  string        // Context key to read questions from (interview mode)
+	AnswersKey    string        // Context key to write answers to (interview mode)
+	Timeout       time.Duration // Per-gate timeout; 0 = no timeout
+	TimeoutAction string        // "fail" | "default" | "" (pick default-if-set else fail)
 }
 
 func (HumanConfig) nodeConfig() {}

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -159,6 +159,9 @@ func isDippinIdentifier(s string) bool {
 // applyIntDefault handles integer-valued graph defaults.
 // Returns true if the key was recognized and applied.
 func applyIntDefault(k, v string, w *ir.Workflow) bool {
+	if applyIntBudgetDefault(k, v, w) {
+		return true
+	}
 	n, err := strconv.Atoi(v)
 	if err != nil {
 		return false
@@ -171,6 +174,40 @@ func applyIntDefault(k, v string, w *ir.Workflow) bool {
 	default:
 		return false
 	}
+	return true
+}
+
+// applyIntBudgetDefault handles budget-related integer and duration defaults.
+func applyIntBudgetDefault(k, v string, w *ir.Workflow) bool {
+	switch k {
+	case "max_total_tokens":
+		return tryApplyIntDefault(v, &w.Defaults.MaxTotalTokens)
+	case "max_cost_cents":
+		return tryApplyIntDefault(v, &w.Defaults.MaxCostCents)
+	case "max_wall_time":
+		return tryApplyDurationDefault(v, &w.Defaults.MaxWallTime)
+	default:
+		return false
+	}
+}
+
+// tryApplyIntDefault parses an integer and sets it on target. Returns true on success.
+func tryApplyIntDefault(v string, target *int) bool {
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return false
+	}
+	*target = n
+	return true
+}
+
+// tryApplyDurationDefault parses a duration and sets it on target. Returns true on success.
+func tryApplyDurationDefault(v string, target *time.Duration) bool {
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return false
+	}
+	*target = d
 	return true
 }
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -156,7 +156,7 @@ func isDippinIdentifier(s string) bool {
 	return dippinIdentPattern.MatchString(s)
 }
 
-// applyIntDefault handles integer-valued graph defaults.
+// applyIntDefault handles integer-valued and duration-valued graph defaults.
 // Returns true if the key was recognized and applied.
 func applyIntDefault(k, v string, w *ir.Workflow) bool {
 	if applyIntBudgetDefault(k, v, w) {
@@ -230,22 +230,27 @@ func convertNode(dn dotNode, edges []dotEdge) (*ir.Node, error) {
 
 // applyNodeConfig sets kind-specific config on the node.
 func applyNodeConfig(node *ir.Node, kind ir.NodeKind, attrs map[string]string) (*ir.Node, error) {
+	cfg, err := buildNodeConfig(node, kind, attrs)
+	if err != nil {
+		return nil, err
+	}
+	node.Config = cfg
+	return node, nil
+}
+
+// buildNodeConfig returns the config for a node given its kind and DOT attributes.
+func buildNodeConfig(node *ir.Node, kind ir.NodeKind, attrs map[string]string) (ir.NodeConfig, error) {
 	switch kind {
 	case ir.NodeAgent:
-		node.Config = buildAgentConfig(attrs)
 		node.Retry = buildRetryConfig(attrs)
+		return buildAgentConfig(attrs), nil
 	case ir.NodeHuman:
-		node.Config = buildHumanConfig(attrs)
+		return buildHumanConfig(attrs)
 	case ir.NodeTool:
-		cfg, err := buildToolConfig(attrs)
-		if err != nil {
-			return nil, err
-		}
-		node.Config = cfg
+		return buildToolConfig(attrs)
 	default:
-		node.Config = buildOtherConfig(kind, attrs)
+		return buildOtherConfig(kind, attrs), nil
 	}
-	return node, nil
 }
 
 // buildOtherConfig builds config for parallel, fan_in, subgraph, conditional, or fallback.
@@ -390,7 +395,7 @@ func applyCmdTimeout(cfg *ir.AgentConfig, attrs map[string]string) {
 	}
 }
 
-func buildHumanConfig(attrs map[string]string) ir.HumanConfig {
+func buildHumanConfig(attrs map[string]string) (ir.HumanConfig, error) {
 	cfg := ir.HumanConfig{}
 	if v, ok := attrs["mode"]; ok {
 		cfg.Mode = v
@@ -398,19 +403,47 @@ func buildHumanConfig(attrs map[string]string) ir.HumanConfig {
 	if v, ok := attrs["default"]; ok {
 		cfg.Default = v
 	}
-	applyHumanTimeout(&cfg, attrs)
-	return cfg
+	if err := applyHumanTimeout(&cfg, attrs); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
 }
 
 // applyHumanTimeout parses and sets timeout fields on HumanConfig.
-func applyHumanTimeout(cfg *ir.HumanConfig, attrs map[string]string) {
-	if v, ok := attrs["timeout"]; ok {
-		if d, err := time.ParseDuration(v); err == nil {
-			cfg.Timeout = d
-		}
+// Returns an error if timeout is unparseable or timeout_action is invalid.
+func applyHumanTimeout(cfg *ir.HumanConfig, attrs map[string]string) error {
+	if err := applyHumanTimeoutDuration(cfg, attrs); err != nil {
+		return err
 	}
-	if v, ok := attrs["timeout_action"]; ok {
+	return applyHumanTimeoutAction(cfg, attrs)
+}
+
+// applyHumanTimeoutDuration parses and sets the timeout duration field.
+func applyHumanTimeoutDuration(cfg *ir.HumanConfig, attrs map[string]string) error {
+	v, ok := attrs["timeout"]
+	if !ok {
+		return nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fmt.Errorf("invalid timeout %q: %w", v, err)
+	}
+	cfg.Timeout = d
+	return nil
+}
+
+// applyHumanTimeoutAction validates and sets the timeout_action field.
+func applyHumanTimeoutAction(cfg *ir.HumanConfig, attrs map[string]string) error {
+	v, ok := attrs["timeout_action"]
+	if !ok {
+		return nil
+	}
+	switch v {
+	case "", "fail", "default":
 		cfg.TimeoutAction = v
+		return nil
+	default:
+		return fmt.Errorf("invalid timeout_action %q (use fail, default, or empty)", v)
 	}
 }
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -361,7 +361,20 @@ func buildHumanConfig(attrs map[string]string) ir.HumanConfig {
 	if v, ok := attrs["default"]; ok {
 		cfg.Default = v
 	}
+	applyHumanTimeout(&cfg, attrs)
 	return cfg
+}
+
+// applyHumanTimeout parses and sets timeout fields on HumanConfig.
+func applyHumanTimeout(cfg *ir.HumanConfig, attrs map[string]string) {
+	if v, ok := attrs["timeout"]; ok {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.Timeout = d
+		}
+	}
+	if v, ok := attrs["timeout_action"]; ok {
+		cfg.TimeoutAction = v
+	}
 }
 
 func buildToolConfig(attrs map[string]string) (ir.ToolConfig, error) {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -738,6 +738,84 @@ func TestMigrateLegacyAttributeNames(t *testing.T) {
 	}
 }
 
+func TestMigrateHumanTimeoutDOT(t *testing.T) {
+	dot := `digraph G {
+		Start [shape=Mdiamond];
+		H [shape=hexagon, mode=choice, timeout="5s", timeout_action="fail"];
+		Exit [shape=Msquare];
+		Start -> H;
+		H -> Exit;
+	}`
+	w, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	n := w.Node("H")
+	if n == nil {
+		t.Fatal("node H not found")
+	}
+	cfg, ok := n.Config.(ir.HumanConfig)
+	if !ok {
+		t.Fatalf("expected HumanConfig, got %T", n.Config)
+	}
+	if cfg.Timeout != 5*time.Second {
+		t.Errorf("timeout = %v, want 5s", cfg.Timeout)
+	}
+	if cfg.TimeoutAction != "fail" {
+		t.Errorf("timeout_action = %q, want %q", cfg.TimeoutAction, "fail")
+	}
+}
+
+func TestMigrateHumanTimeoutInvalidDuration(t *testing.T) {
+	dot := `digraph G {
+		Start [shape=Mdiamond];
+		H [shape=hexagon, mode=choice, timeout="notaduration"];
+		Exit [shape=Msquare];
+		Start -> H;
+		H -> Exit;
+	}`
+	_, err := Migrate(dot)
+	if err == nil {
+		t.Error("expected error for invalid timeout duration, got nil")
+	}
+}
+
+func TestMigrateHumanTimeoutActionInvalid(t *testing.T) {
+	dot := `digraph G {
+		Start [shape=Mdiamond];
+		H [shape=hexagon, mode=choice, timeout_action="explode"];
+		Exit [shape=Msquare];
+		Start -> H;
+		H -> Exit;
+	}`
+	_, err := Migrate(dot)
+	if err == nil {
+		t.Error("expected error for invalid timeout_action, got nil")
+	}
+}
+
+func TestMigrateBudgetDefaults(t *testing.T) {
+	dot := `digraph G {
+		graph [max_total_tokens="2000000", max_cost_cents="500", max_wall_time="30m"];
+		Start [shape=Mdiamond];
+		Exit [shape=Msquare];
+		Start -> Exit;
+	}`
+	w, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Defaults.MaxTotalTokens != 2000000 {
+		t.Errorf("max_total_tokens = %d, want 2000000", w.Defaults.MaxTotalTokens)
+	}
+	if w.Defaults.MaxCostCents != 500 {
+		t.Errorf("max_cost_cents = %d, want 500", w.Defaults.MaxCostCents)
+	}
+	if w.Defaults.MaxWallTime != 30*time.Minute {
+		t.Errorf("max_wall_time = %v, want 30m", w.Defaults.MaxWallTime)
+	}
+}
+
 // ============================================================
 // Parity Checker Tests (8 cases)
 // ============================================================

--- a/parser/parse_defaults.go
+++ b/parser/parse_defaults.go
@@ -97,6 +97,20 @@ func (p *Parser) applyDefaultComplexField(key, val string, loc ir.SourceLocation
 	case "cache_tools":
 		p.workflow.Defaults.CacheTools = (val == "true")
 	default:
+		p.applyDefaultBudgetField(key, val, loc)
+	}
+}
+
+// applyDefaultBudgetField handles budget-related default fields.
+func (p *Parser) applyDefaultBudgetField(key, val string, loc ir.SourceLocation) {
+	switch key {
+	case "max_total_tokens":
+		p.workflow.Defaults.MaxTotalTokens = p.parseInt(val, key, loc)
+	case "max_cost_cents":
+		p.workflow.Defaults.MaxCostCents = p.parseInt(val, key, loc)
+	case "max_wall_time":
+		p.workflow.Defaults.MaxWallTime = p.parseDuration(val, key, loc)
+	default:
 		p.diagnostics = append(p.diagnostics,
 			fmt.Sprintf("unknown defaults field %q at %d:%d", key, loc.Line, loc.Column))
 	}

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -358,7 +358,14 @@ func (p *Parser) applyHumanComplexField(cfg *ir.HumanConfig, key, val string, lo
 	case "timeout":
 		cfg.Timeout = p.parseDuration(val, key, loc)
 	case "timeout_action":
-		cfg.TimeoutAction = val
+		switch val {
+		case "", "fail", "default":
+			cfg.TimeoutAction = val
+		default:
+			p.diagnostics = append(p.diagnostics, fmt.Sprintf(
+				"invalid timeout_action %q at %d:%d (use fail, default, or empty)",
+				val, loc.Line, loc.Column))
+		}
 	default:
 		return false
 	}

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -346,7 +346,23 @@ func (p *Parser) applyHumanField(cfg *ir.HumanConfig, key, val string, loc ir.So
 	if applyHumanInterviewField(cfg, key, val) {
 		return
 	}
+	if p.applyHumanComplexField(cfg, key, val, loc) {
+		return
+	}
 	p.emitUnknownFieldHint("human", key, loc)
+}
+
+// applyHumanComplexField handles fields needing parsing for human config.
+func (p *Parser) applyHumanComplexField(cfg *ir.HumanConfig, key, val string, loc ir.SourceLocation) bool {
+	switch key {
+	case "timeout":
+		cfg.Timeout = p.parseDuration(val, key, loc)
+	case "timeout_action":
+		cfg.TimeoutAction = val
+	default:
+		return false
+	}
+	return true
 }
 
 func applyHumanStringField(cfg *ir.HumanConfig, key, val string) bool {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/2389-research/dippin-lang/formatter"
 	"github.com/2389-research/dippin-lang/ir"
@@ -1550,5 +1551,20 @@ func TestParseVarsRoundTrip(t *testing.T) {
 	}
 	if w2.Vars["target_name"] != "my-crate" {
 		t.Errorf("target_name lost in round-trip: %q", w2.Vars["target_name"])
+	}
+}
+
+func TestParseHumanTimeout(t *testing.T) {
+	w := parseFixture(t, "human_timeout.dip")
+	gate := findNode(t, w, "Gate")
+	cfg, ok := gate.Config.(ir.HumanConfig)
+	if !ok {
+		t.Fatal("Gate is not HumanConfig")
+	}
+	if cfg.Timeout != 5*time.Minute {
+		t.Errorf("Timeout = %v, want 5m0s", cfg.Timeout)
+	}
+	if cfg.TimeoutAction != "default" {
+		t.Errorf("TimeoutAction = %q, want default", cfg.TimeoutAction)
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1582,3 +1582,61 @@ func TestParseHumanTimeout(t *testing.T) {
 		t.Errorf("TimeoutAction = %q, want default", cfg.TimeoutAction)
 	}
 }
+
+func TestParseHumanTimeoutRoundTrip(t *testing.T) {
+	w1 := parseFixture(t, "human_timeout.dip")
+	formatted := formatter.Format(w1)
+	w2, err := NewParser(formatted, "roundtrip").Parse()
+	if err != nil {
+		t.Fatalf("re-parse error: %v\nformatted:\n%s", err, formatted)
+	}
+	gate := findNode(t, w2, "Gate")
+	cfg, ok := gate.Config.(ir.HumanConfig)
+	if !ok {
+		t.Fatal("round-trip: Gate is not HumanConfig")
+	}
+	if cfg.Timeout != 5*time.Minute {
+		t.Errorf("round-trip: Timeout = %v, want 5m0s", cfg.Timeout)
+	}
+	if cfg.TimeoutAction != "default" {
+		t.Errorf("round-trip: TimeoutAction = %q, want default", cfg.TimeoutAction)
+	}
+}
+
+func TestParseHumanTimeoutActionInvalid(t *testing.T) {
+	src := `workflow Test
+  start: Gate
+  exit: Gate
+
+  human Gate
+    mode: choice
+    timeout_action: explode
+`
+	p := NewParser(src, "test.dip")
+	_, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected parse error for invalid timeout_action, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid timeout_action") {
+		t.Errorf("expected error to mention invalid timeout_action, got: %v", err)
+	}
+}
+
+func TestParseDefaultsBudgetRoundTrip(t *testing.T) {
+	w1 := parseFixture(t, "defaults_budget.dip")
+	formatted := formatter.Format(w1)
+	w2, err := NewParser(formatted, "roundtrip").Parse()
+	if err != nil {
+		t.Fatalf("re-parse error: %v\nformatted:\n%s", err, formatted)
+	}
+	d := w2.Defaults
+	if d.MaxTotalTokens != 500000 {
+		t.Errorf("round-trip: max_total_tokens = %d, want 500000", d.MaxTotalTokens)
+	}
+	if d.MaxCostCents != 1000 {
+		t.Errorf("round-trip: max_cost_cents = %d, want 1000", d.MaxCostCents)
+	}
+	if d.MaxWallTime != 30*time.Minute {
+		t.Errorf("round-trip: max_wall_time = %v, want 30m0s", d.MaxWallTime)
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1554,6 +1554,20 @@ func TestParseVarsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseDefaultsBudget(t *testing.T) {
+	w := parseFixture(t, "defaults_budget.dip")
+	d := w.Defaults
+	if d.MaxTotalTokens != 500000 {
+		t.Errorf("max_total_tokens = %d, want 500000", d.MaxTotalTokens)
+	}
+	if d.MaxCostCents != 1000 {
+		t.Errorf("max_cost_cents = %d, want 1000", d.MaxCostCents)
+	}
+	if d.MaxWallTime != 30*time.Minute {
+		t.Errorf("max_wall_time = %v, want 30m0s", d.MaxWallTime)
+	}
+}
+
 func TestParseHumanTimeout(t *testing.T) {
 	w := parseFixture(t, "human_timeout.dip")
 	gate := findNode(t, w, "Gate")

--- a/parser/testdata/defaults_budget.dip
+++ b/parser/testdata/defaults_budget.dip
@@ -1,0 +1,16 @@
+workflow DefaultsBudget
+  goal: "Test budget defaults parsing"
+  start: A
+  exit: A
+
+  defaults
+    model: claude-sonnet-4-6
+    max_total_tokens: 500000
+    max_cost_cents: 1000
+    max_wall_time: 30m
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A

--- a/parser/testdata/human_timeout.dip
+++ b/parser/testdata/human_timeout.dip
@@ -1,0 +1,21 @@
+workflow HumanTimeout
+  goal: "Test human timeout parsing"
+  start: Agent
+  exit: Done
+
+  agent Agent
+    prompt: Do work.
+
+  human Gate
+    mode: choice
+    default: approve
+    timeout: 5m
+    timeout_action: default
+    prompt: Approve or reject.
+
+  agent Done
+    prompt: Finish.
+
+  edges
+    Agent -> Gate
+    Gate -> Done

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -93,6 +93,8 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `prompt` | multiline | Prompt text |
 | `questions_key` | string | Context key for interview questions |
 | `answers_key` | string | Context key for interview answers |
+| `timeout` | Duration | e.g. `5m`, `1h`. How long to wait for human response. |
+| `timeout_action` | String | `fail` or `default`. Action on timeout (default: `fail`). |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -227,9 +229,18 @@ Fields `prompt:`, `system_prompt:`, `command:`, `response_schema:` support inden
     max_restarts: 3
     cache_tools: true
     compaction: auto
+    max_total_tokens: 500000
+    max_cost_cents: 1000
+    max_wall_time: 30m
 ```
 
 All defaults are inherited by nodes unless overridden at the node level.
+
+| Default Field | Type | Notes |
+|---------------|------|-------|
+| `max_total_tokens` | Integer | Budget cap on total tokens consumed. |
+| `max_cost_cents` | Integer | Budget cap in cents (e.g. 1000 = $10.00). |
+| `max_wall_time` | Duration | Maximum wall-clock time for the workflow (e.g. `30m`, `2h`). |
 
 ## CLI Reference
 

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -93,8 +93,8 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `prompt` | multiline | Prompt text |
 | `questions_key` | string | Context key for interview questions |
 | `answers_key` | string | Context key for interview answers |
-| `timeout` | Duration | e.g. `5m`, `1h`. How long to wait for human response. |
-| `timeout_action` | String | `fail` or `default`. Action on timeout (default: `fail`). |
+| `timeout` | duration | e.g. `5m`, `1h`. How long to wait for human response. |
+| `timeout_action` | string | `fail` or `default`. Action on timeout (default: `fail`). |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -238,9 +238,9 @@ All defaults are inherited by nodes unless overridden at the node level.
 
 | Default Field | Type | Notes |
 |---------------|------|-------|
-| `max_total_tokens` | Integer | Budget cap on total tokens consumed. |
-| `max_cost_cents` | Integer | Budget cap in cents (e.g. 1000 = $10.00). |
-| `max_wall_time` | Duration | Maximum wall-clock time for the workflow (e.g. `30m`, `2h`). |
+| `max_total_tokens` | int | Budget cap on total tokens consumed. |
+| `max_cost_cents` | int | Budget cap in cents (e.g. 1000 = $10.00). |
+| `max_wall_time` | duration | Maximum wall-clock time for the workflow (e.g. `30m`, `2h`). |
 
 ## CLI Reference
 


### PR DESCRIPTION
## Summary

Two IR field additions requested by the tracker team:

**Issue #18 — HumanConfig Timeout:**
- `Timeout time.Duration` and `TimeoutAction string` on human nodes
- Enables per-gate timeouts (e.g., `timeout: 5s`, `timeout_action: fail`)
- Wired through parser, formatter, DOT export, and migrate

**Issue #21 — WorkflowDefaults Budget:**
- `max_total_tokens` (int), `max_cost_cents` (int), `max_wall_time` (duration) in defaults block
- Enables pipeline-level budget ceilings in the workflow definition
- Wired through parser, formatter, and DOT migrate

## Test plan
- [x] `just check` passes
- [x] Parser test for human timeout fields with round-trip
- [x] Parser test for budget defaults with round-trip
- [x] Both follow existing patterns (ToolConfig.Timeout, max_retries)

Closes #18, closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow-level budget limits: max_total_tokens, max_cost_cents, and max_wall_time.
  * Human node timeout and timeout_action to control per-gate timing behavior.
  * Expanded agent reasoning_effort with finer-grained options.

* **Documentation**
  * Updated reference and examples to document new defaults and human node options and reasoning_effort values.

* **Tests**
  * Added parser, formatter, migration, export, and round‑trip tests and fixtures for the new defaults and timeout behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->