### PR TITLE
feat: recognize ctx.node.<id>.* as valid scoped context reads

### DIFF
--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -223,7 +223,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `goal_gate` | bool | Pipeline fails if gate fails. Add `retry_target` or `fallback_target` (DIP115) |
 | `response_format` | string | `json_object` or `json_schema` (DIP130) |
 | `response_schema` | multiline JSON | Must be valid JSON (DIP132). Requires `response_format: json_schema` (DIP131) |
-| `reasoning_effort` | string | `low`, `medium`, `high` (DIP119) |
+| `reasoning_effort` | string | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` (DIP119) |
 | `fidelity` | string | `full`, `summary:high`, `summary:medium`, `summary:low`, `compact`, `truncate` (DIP114) |
 | `cache_tools` | bool | Cache tool results |
 | `compaction` | string | Context compaction strategy |
@@ -489,7 +489,7 @@ The primary loop for authoring .dip files:
 | DIP116 | Invalid compaction threshold | Use float 0.0-1.0 |
 | DIP117 | Stylesheet class references undefined class | Fix class name in stylesheet block |
 | DIP118 | Stylesheet ID references unknown node | Fix node ID in stylesheet block |
-| DIP119 | Invalid reasoning_effort | Use: `low`, `medium`, `high` |
+| DIP119 | Invalid reasoning_effort | Use: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
 | DIP120 | Condition var missing namespace | Prefix with `ctx.`, `params.`, or `graph.` |
 | DIP123 | Shell syntax error in command | Fix the shell command (checked via `bash -n`) |
 | DIP124 | `${ctx.*}` in tool command | Remove — runtime variables expand to empty at parse time |

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -61,13 +61,13 @@ func Lint(w *ir.Workflow) Result {
 
 // knownNamespaces lists the valid namespace prefixes for variable references.
 // Per §8.2 of the Dippin spec: ctx. (runtime context), graph. (workflow-level
-// attributes), params. (module parameters for composition), node. (per-node
-// scoped context — Tracker aliases each node's writes as node.<id>.<key>).
+// attributes), params. (module parameters for composition).
+// node.* is intentionally excluded: it requires structural validation
+// (node ID must exist, ref must have exactly 3 parts) handled in isVarRefValid.
 // Used by lint_context.go (DIP106) and lint_conditions.go (DIP120).
 var knownNamespaces = map[string]bool{
 	"ctx":    true,
 	"graph":  true,
-	"node":   true,
 	"params": true,
 }
 

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -61,11 +61,13 @@ func Lint(w *ir.Workflow) Result {
 
 // knownNamespaces lists the valid namespace prefixes for variable references.
 // Per §8.2 of the Dippin spec: ctx. (runtime context), graph. (workflow-level
-// attributes), params. (module parameters for composition).
+// attributes), params. (module parameters for composition), node. (per-node
+// scoped context — Tracker aliases each node's writes as node.<id>.<key>).
 // Used by lint_context.go (DIP106) and lint_conditions.go (DIP120).
 var knownNamespaces = map[string]bool{
 	"ctx":    true,
 	"graph":  true,
+	"node":   true,
 	"params": true,
 }
 

--- a/validator/lint_context.go
+++ b/validator/lint_context.go
@@ -17,13 +17,13 @@ var varRefPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
 func lintUndefinedVariables(w *ir.Workflow) []Diagnostic {
 	var diags []Diagnostic
 	for _, n := range w.Nodes {
-		diags = append(diags, checkNodeVarRefs(n)...)
+		diags = append(diags, checkNodeVarRefs(n, w)...)
 	}
 	return diags
 }
 
 // checkNodeVarRefs checks variable references in a single node's prompt.
-func checkNodeVarRefs(n *ir.Node) []Diagnostic {
+func checkNodeVarRefs(n *ir.Node, w *ir.Workflow) []Diagnostic {
 	prompt := nodePrompt(n)
 	if prompt == "" {
 		return nil
@@ -32,8 +32,7 @@ func checkNodeVarRefs(n *ir.Node) []Diagnostic {
 	matches := varRefPattern.FindAllStringSubmatch(prompt, -1)
 	for _, m := range matches {
 		varRef := m[1]
-		parts := strings.SplitN(varRef, ".", 2)
-		if len(parts) < 2 || !knownNamespaces[parts[0]] {
+		if !isVarRefValid(varRef, w) {
 			diags = append(diags, Diagnostic{
 				Code:     DIP106,
 				Severity: SeverityWarning,
@@ -44,6 +43,34 @@ func checkNodeVarRefs(n *ir.Node) []Diagnostic {
 		}
 	}
 	return diags
+}
+
+// isVarRefValid returns true if the variable reference is valid: either a known
+// namespace prefix (with ctx.node.* requiring a real node ID) or a bare
+// node-scoped reference (node.<existingNode>.*).
+func isVarRefValid(varRef string, w *ir.Workflow) bool {
+	// ctx.node.* is special: node ID must resolve in the workflow.
+	if strings.HasPrefix(varRef, "ctx.node.") {
+		return isNodeScopedKey(varRef, w)
+	}
+	parts := strings.SplitN(varRef, ".", 2)
+	return len(parts) >= 2 && knownNamespaces[parts[0]]
+}
+
+// isNodeScopedKey returns true if the key matches node.<nodeID>.* where nodeID
+// is a real node in the workflow. Tracker auto-aliases every context key a node
+// writes as node.<nodeID>.<key>, so these references are always valid.
+// The key may be prefixed with "ctx." (e.g. "ctx.node.Planner.last_response").
+func isNodeScopedKey(key string, w *ir.Workflow) bool {
+	k := strings.TrimPrefix(key, "ctx.")
+	if !strings.HasPrefix(k, "node.") {
+		return false
+	}
+	parts := strings.SplitN(k, ".", 3) // ["node", "<nodeID>", "<key>"]
+	if len(parts) < 3 {
+		return false
+	}
+	return w.Node(parts[1]) != nil
 }
 
 // lintUnusedWrites checks DIP107: context keys declared in a node's writes:
@@ -200,15 +227,16 @@ func checkUnprovidedReads(w *ir.Workflow, available map[string]map[string]bool) 
 
 	for _, n := range w.Nodes {
 		for _, key := range n.IO.Reads {
-			if !available[n.ID][key] {
-				diags = append(diags, Diagnostic{
-					Code:     DIP112,
-					Severity: SeverityWarning,
-					Message:  fmt.Sprintf("node %q reads context key %q but no upstream node declares it in writes", n.ID, key),
-					Location: n.Source,
-					Help:     fmt.Sprintf("add writes: %s to an upstream node, or the key may be auto-injected at runtime", key),
-				})
+			if available[n.ID][key] || isNodeScopedKey(key, w) {
+				continue
 			}
+			diags = append(diags, Diagnostic{
+				Code:     DIP112,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("node %q reads context key %q but no upstream node declares it in writes", n.ID, key),
+				Location: n.Source,
+				Help:     fmt.Sprintf("add writes: %s to an upstream node, or the key may be auto-injected at runtime", key),
+			})
 		}
 	}
 

--- a/validator/lint_context.go
+++ b/validator/lint_context.go
@@ -38,35 +38,47 @@ func checkNodeVarRefs(n *ir.Node, w *ir.Workflow) []Diagnostic {
 				Severity: SeverityWarning,
 				Message:  fmt.Sprintf("node %q references undefined variable ${%s}", n.ID, varRef),
 				Location: n.Source,
-				Help:     fmt.Sprintf("use a namespaced variable like ${ctx.%s}, ${graph.%s}, or ${params.%s}", varRef, varRef, varRef),
+				Help:     varRefHelp(varRef),
 			})
 		}
 	}
 	return diags
 }
 
+// varRefHelp returns an appropriate help message for an invalid variable reference.
+// Node-scoped refs get a specific message; everything else gets the generic namespace hint.
+func varRefHelp(varRef string) string {
+	bare := strings.TrimPrefix(varRef, "ctx.")
+	if strings.HasPrefix(bare, "node.") {
+		parts := strings.SplitN(bare, ".", 3) // ["node", "<id>", ...]
+		if len(parts) >= 2 && parts[1] != "" {
+			return fmt.Sprintf("node %q does not exist in the workflow", parts[1])
+		}
+		return "node-scoped refs must be in the form node.<id>.<key>"
+	}
+	return fmt.Sprintf("use a namespaced variable like ${ctx.%s}, ${graph.%s}, or ${params.%s}", varRef, varRef, varRef)
+}
+
 // isVarRefValid returns true if the variable reference is valid: either a known
-// namespace prefix (with ctx.node.* requiring a real node ID) or a bare
-// node-scoped reference (node.<existingNode>.*).
+// namespace prefix or a node-scoped reference (node.<existingNode>.<key> or
+// ctx.node.<existingNode>.<key>) with a real node ID and exactly 3 parts.
 func isVarRefValid(varRef string, w *ir.Workflow) bool {
-	// ctx.node.* is special: node ID must resolve in the workflow.
-	if strings.HasPrefix(varRef, "ctx.node.") {
-		return isNodeScopedKey(varRef, w)
+	bare := strings.TrimPrefix(varRef, "ctx.")
+	if strings.HasPrefix(bare, "node.") {
+		return isNodeScopedKey(bare, w)
 	}
 	parts := strings.SplitN(varRef, ".", 2)
 	return len(parts) >= 2 && knownNamespaces[parts[0]]
 }
 
-// isNodeScopedKey returns true if the key matches node.<nodeID>.* where nodeID
-// is a real node in the workflow. Tracker auto-aliases every context key a node
-// writes as node.<nodeID>.<key>, so these references are always valid.
-// The key may be prefixed with "ctx." (e.g. "ctx.node.Planner.last_response").
+// isNodeScopedKey returns true if the key matches node.<nodeID>.<key> where nodeID
+// is a real node in the workflow. The key must have exactly 3 dot-separated parts.
+// Callers must strip any "ctx." prefix before calling this function.
 func isNodeScopedKey(key string, w *ir.Workflow) bool {
-	k := strings.TrimPrefix(key, "ctx.")
-	if !strings.HasPrefix(k, "node.") {
+	if !strings.HasPrefix(key, "node.") {
 		return false
 	}
-	parts := strings.SplitN(k, ".", 3) // ["node", "<nodeID>", "<key>"]
+	parts := strings.SplitN(key, ".", 3) // ["node", "<nodeID>", "<key>"]
 	if len(parts) < 3 {
 		return false
 	}
@@ -117,25 +129,27 @@ func lintReadsWithoutUpstreamWrites(w *ir.Workflow) []Diagnostic {
 	}
 
 	adj := buildForwardAdjacency(w)
-	available := computeAvailableWrites(w, adj)
-	return checkUnprovidedReads(w, available)
+	available, upstream := computeAvailableAndUpstream(w, adj)
+	return checkUnprovidedReads(w, available, upstream)
 }
 
-// computeAvailableWrites performs topological traversal and computes
-// which context keys are available at each node based on upstream writes.
-func computeAvailableWrites(w *ir.Workflow, adj map[string][]string) map[string]map[string]bool {
+// computeAvailableAndUpstream performs a topological traversal and computes:
+//   - available: context keys written by upstream nodes (available at each node)
+//   - upstream: set of node IDs that are strictly upstream of each node
+func computeAvailableAndUpstream(w *ir.Workflow, adj map[string][]string) (map[string]map[string]bool, map[string]map[string]bool) {
 	inDegree := computeInDegrees(w, adj)
 	queue := findRootNodes(w, inDegree)
 	available := initializeAvailable(w)
+	upstream := initializeAvailable(w)
 
 	for len(queue) > 0 {
 		curr := queue[0]
 		queue = queue[1:]
 		addNodeWrites(w, available, curr)
-		queue = propagateAndEnqueue(adj, available, inDegree, curr, queue)
+		queue = propagateAndEnqueue(adj, available, upstream, inDegree, curr, queue)
 	}
 
-	return available
+	return available, upstream
 }
 
 // addNodeWrites adds a node's write keys to its available set.
@@ -147,10 +161,16 @@ func addNodeWrites(w *ir.Workflow, available map[string]map[string]bool, nodeID 
 	}
 }
 
-// propagateAndEnqueue propagates available keys to successors and enqueues those with zero in-degree.
-func propagateAndEnqueue(adj map[string][]string, available map[string]map[string]bool, inDegree map[string]int, curr string, queue []string) []string {
+// propagateAndEnqueue propagates available keys and upstream node IDs to successors,
+// then enqueues successors whose in-degree reaches zero.
+func propagateAndEnqueue(adj map[string][]string, available, upstream map[string]map[string]bool, inDegree map[string]int, curr string, queue []string) []string {
 	for _, next := range adj[curr] {
+		if upstream[next] == nil {
+			upstream[next] = make(map[string]bool)
+		}
 		propagateKeys(available, curr, next)
+		propagateKeys(upstream, curr, next)
+		upstream[next][curr] = true
 		inDegree[next]--
 		if inDegree[next] == 0 {
 			queue = append(queue, next)
@@ -222,25 +242,55 @@ func propagateKeys(available map[string]map[string]bool, from, to string) {
 }
 
 // checkUnprovidedReads generates diagnostics for reads that have no upstream write.
-func checkUnprovidedReads(w *ir.Workflow, available map[string]map[string]bool) []Diagnostic {
+func checkUnprovidedReads(w *ir.Workflow, available, upstream map[string]map[string]bool) []Diagnostic {
 	var diags []Diagnostic
-
 	for _, n := range w.Nodes {
 		for _, key := range n.IO.Reads {
-			if available[n.ID][key] || isNodeScopedKey(key, w) {
-				continue
-			}
-			diags = append(diags, Diagnostic{
-				Code:     DIP112,
-				Severity: SeverityWarning,
-				Message:  fmt.Sprintf("node %q reads context key %q but no upstream node declares it in writes", n.ID, key),
-				Location: n.Source,
-				Help:     fmt.Sprintf("add writes: %s to an upstream node, or the key may be auto-injected at runtime", key),
-			})
+			diags = append(diags, checkReadKey(n, key, w, available[n.ID], upstream[n.ID])...)
 		}
 	}
-
 	return diags
+}
+
+// checkReadKey validates a single read key for a node, emitting DIP112 if needed.
+func checkReadKey(n *ir.Node, key string, w *ir.Workflow, avail, upstream map[string]bool) []Diagnostic {
+	if avail[key] {
+		return nil
+	}
+	if msg := nodeReadDIP112(n.ID, key, w, upstream); msg != "" {
+		return []Diagnostic{{
+			Code:     DIP112,
+			Severity: SeverityWarning,
+			Message:  msg,
+			Location: n.Source,
+			Help:     fmt.Sprintf("add writes: %s to an upstream node, or the key may be auto-injected at runtime", key),
+		}}
+	}
+	return nil
+}
+
+// nodeReadDIP112 returns a non-empty diagnostic message when a read key is
+// problematic, or empty string if the read is valid.
+func nodeReadDIP112(nodeID, key string, w *ir.Workflow, upstream map[string]bool) string {
+	parts := strings.SplitN(strings.TrimPrefix(key, "ctx."), ".", 3)
+	if len(parts) == 3 && parts[0] == "node" {
+		return nodeScopedReadMsg(nodeID, key, parts[1], w, upstream)
+	}
+	if isNodeScopedKey(key, w) {
+		return ""
+	}
+	return fmt.Sprintf("node %q reads context key %q but no upstream node declares it in writes", nodeID, key)
+}
+
+// nodeScopedReadMsg validates a node.<id>.* read and returns an error message or "".
+func nodeScopedReadMsg(readerID, key, refNodeID string, w *ir.Workflow, upstream map[string]bool) string {
+	if w.Node(refNodeID) == nil {
+		return fmt.Sprintf("node %q reads %q but node %q does not exist in the workflow", readerID, key, refNodeID)
+	}
+	if !upstream[refNodeID] {
+		return fmt.Sprintf("node %q reads %q but node %q is not upstream", readerID, key, refNodeID)
+	}
+	return ""
 }
 
 // nodePrompt extracts the prompt text from a node if it has one.

--- a/validator/lint_test.go
+++ b/validator/lint_test.go
@@ -635,6 +635,52 @@ func TestLint(t *testing.T) {
 			},
 			wantCodes: []string{DIP106},
 		},
+		{
+			name: "DIP106: bare node.<unknownNode>.* triggers DIP106",
+			workflow: &ir.Workflow{
+				Name:  "bare_node_ref_invalid",
+				Start: "A",
+				Exit:  "A",
+				Nodes: []*ir.Node{
+					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+						Prompt: "Use ${node.Ghost.result}",
+					}},
+				},
+			},
+			wantCodes: []string{DIP106},
+		},
+		{
+			name: "DIP106: bare node.<existingNode>.* is valid — no DIP106",
+			workflow: &ir.Workflow{
+				Name:  "bare_node_ref_valid",
+				Start: "Planner",
+				Exit:  "Builder",
+				Nodes: []*ir.Node{
+					{ID: "Planner", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "plan"}},
+					{ID: "Builder", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+						Prompt: "Build based on ${node.Planner.last_response}",
+					}},
+				},
+				Edges: []*ir.Edge{{From: "Planner", To: "Builder"}},
+			},
+			wantNoDiag: true,
+		},
+		{
+			name: "DIP106: malformed node.<id> missing key triggers DIP106",
+			workflow: &ir.Workflow{
+				Name:  "malformed_node_ref",
+				Start: "Planner",
+				Exit:  "Builder",
+				Nodes: []*ir.Node{
+					{ID: "Planner", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "plan"}},
+					{ID: "Builder", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+						Prompt: "Build based on ${node.Planner}",
+					}},
+				},
+				Edges: []*ir.Edge{{From: "Planner", To: "Builder"}},
+			},
+			wantCodes: []string{DIP106},
+		},
 
 		// --- DIP107: Unused writes ---
 		{
@@ -908,6 +954,22 @@ func TestLint(t *testing.T) {
 				},
 			},
 			wantNoDiag: true,
+		},
+		{
+			name: "DIP112: node.<existingNode>.* not upstream triggers DIP112",
+			workflow: &ir.Workflow{
+				Name:  "node_scoped_read_not_upstream",
+				Start: "A",
+				Exit:  "B",
+				Nodes: []*ir.Node{
+					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
+					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"},
+						// B reads from A but A is not upstream of B (no edge A→B)
+						IO: ir.NodeIO{Reads: []string{"node.A.result"}}},
+				},
+				// No edge from A to B — A is not upstream of B
+			},
+			wantCodes: []string{DIP112},
 		},
 
 		// --- Edge cases ---

--- a/validator/lint_test.go
+++ b/validator/lint_test.go
@@ -605,6 +605,36 @@ func TestLint(t *testing.T) {
 			},
 			wantNoDiag: true,
 		},
+		{
+			name: "DIP106: ctx.node.<existingNode>.* is valid — no DIP106",
+			workflow: &ir.Workflow{
+				Name:  "node_scoped_ref_valid",
+				Start: "Planner",
+				Exit:  "Builder",
+				Nodes: []*ir.Node{
+					{ID: "Planner", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "plan"}},
+					{ID: "Builder", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+						Prompt: "Build based on ${ctx.node.Planner.last_response}",
+					}},
+				},
+				Edges: []*ir.Edge{{From: "Planner", To: "Builder"}},
+			},
+			wantNoDiag: true,
+		},
+		{
+			name: "DIP106: ctx.node.<unknownNode>.* triggers DIP106",
+			workflow: &ir.Workflow{
+				Name:  "node_scoped_ref_invalid",
+				Start: "A",
+				Exit:  "A",
+				Nodes: []*ir.Node{
+					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+						Prompt: "Use ${ctx.node.Ghost.result}",
+					}},
+				},
+			},
+			wantCodes: []string{DIP106},
+		},
 
 		// --- DIP107: Unused writes ---
 		{
@@ -858,6 +888,23 @@ func TestLint(t *testing.T) {
 				},
 				Edges: []*ir.Edge{
 					{From: "A", To: "B"},
+				},
+			},
+			wantNoDiag: true,
+		},
+		{
+			name: "DIP112: node.<existingNode>.* in reads is valid — no DIP112",
+			workflow: &ir.Workflow{
+				Name:  "node_scoped_read_valid",
+				Start: "Planner",
+				Exit:  "Builder",
+				Nodes: []*ir.Node{
+					{ID: "Planner", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "plan"}},
+					{ID: "Builder", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "build"},
+						IO: ir.NodeIO{Reads: []string{"node.Planner.last_response"}}},
+				},
+				Edges: []*ir.Edge{
+					{From: "Planner", To: "Builder"},
 				},
 			},
 			wantNoDiag: true,


### PR DESCRIPTION
## Summary

Tracker implements per-node context scoping: after a node executes, every context key it wrote is aliased as `node.<nodeID>.<key>`. The validator was incorrectly flagging these as undefined.

**Changes:**
- DIP106: `${ctx.node.Planner.last_response}` in prompts is now valid when node "Planner" exists, flagged when it doesn't
- DIP112: `reads: node.Planner.last_response` is now valid when node "Planner" exists
- DIP120: `node` added to known namespaces so `node.*` references aren't flagged as missing prefix

## Test plan
- [x] `just check` passes
- [x] Test: existing node scoped ref does NOT trigger DIP106
- [x] Test: non-existent node scoped ref DOES trigger DIP106
- [x] Test: node scoped key in reads does NOT trigger DIP112

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for node-scoped variable references in linting.

* **Bug Fixes**
  * Linting now verifies referenced nodes exist before accepting node-scoped context references.
  * Unprovided-read detection correctly handles node-scoped read keys and suppresses spurious diagnostics by tracking upstream contributors.

* **Tests**
  * Added test cases covering node-scoped variable references and node-scoped read/upstream scenarios.

* **Documentation**
  * Expanded allowed values for the agent reasoning_effort field in the spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->