### PR TITLE
feat(site): add agent-readiness discovery endpoints

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -49,6 +49,11 @@
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
 
 [[headers]]
+  for = "/"
+  [headers.values]
+    Link = '</.well-known/api-catalog>; rel="api-catalog", </.well-known/agent-skills/index.json>; rel="describedby", </llms.txt>; rel="describedby"; type="text/plain", </skill.md>; rel="describedby"; type="text/plain"'
+
+[[headers]]
   for = "/dippin.wasm"
   [headers.values]
     Content-Type = "application/wasm"
@@ -68,3 +73,18 @@
   for = "/llms-full.txt"
   [headers.values]
     Content-Type = "text/plain; charset=utf-8"
+
+[[headers]]
+  for = "/.well-known/api-catalog"
+  [headers.values]
+    Content-Type = "application/linkset+json"
+
+[[headers]]
+  for = "/.well-known/agent-skills/index.json"
+  [headers.values]
+    Content-Type = "application/json"
+
+[[headers]]
+  for = "/.well-known/mcp/server-card.json"
+  [headers.values]
+    Content-Type = "application/json"

--- a/site/static/.well-known/agent-skills/index.json
+++ b/site/static/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agentskills.io/schema/v0.2.0/index.json",
+  "skills": [
+    {
+      "name": "dippin-lang",
+      "type": "claude-code",
+      "description": "Author, validate, lint, and debug .dip AI pipeline workflow files using the dippin CLI and DSL",
+      "url": "https://dippin.org/skill.md",
+      "sha256": "fadaad34aff3d06ede8112d71459e9e6980d090fc73276d14531954d99cfd872"
+    }
+  ]
+}

--- a/site/static/.well-known/api-catalog
+++ b/site/static/.well-known/api-catalog
@@ -1,0 +1,27 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://dippin.org/",
+      "service-doc": [
+        {
+          "href": "https://dippin.org/language.html",
+          "type": "text/html"
+        }
+      ],
+      "describedby": [
+        {
+          "href": "https://dippin.org/llms.txt",
+          "type": "text/plain"
+        },
+        {
+          "href": "https://dippin.org/llms-full.txt",
+          "type": "text/plain"
+        },
+        {
+          "href": "https://dippin.org/skill.md",
+          "type": "text/plain"
+        }
+      ]
+    }
+  ]
+}

--- a/site/static/.well-known/mcp/server-card.json
+++ b/site/static/.well-known/mcp/server-card.json
@@ -1,0 +1,19 @@
+{
+  "serverInfo": {
+    "name": "dippin-lang",
+    "version": "0.12.0",
+    "description": "DSL and toolchain for AI pipeline workflows — parse, validate, lint, format, export, simulate, and analyze .dip files"
+  },
+  "homepageUrl": "https://dippin.org/",
+  "sourceUrl": "https://github.com/2389-research/dippin-lang",
+  "documentationUrl": "https://dippin.org/language.html",
+  "capabilities": {
+    "skills": true
+  },
+  "links": {
+    "skill": "https://dippin.org/skill.md",
+    "llms-txt": "https://dippin.org/llms.txt",
+    "llms-full-txt": "https://dippin.org/llms-full.txt",
+    "agent-skills": "https://dippin.org/.well-known/agent-skills/index.json"
+  }
+}

--- a/site/static/robots.txt
+++ b/site/static/robots.txt
@@ -20,4 +20,7 @@ Allow: /
 User-agent: Amazonbot
 Allow: /
 
+# Content usage preferences (contentsignals.org, draft-romm-aipref-contentsignals)
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
 Sitemap: https://dippin.org/sitemap.xml


### PR DESCRIPTION
## Summary

- Add `Content-Signal` directive to `robots.txt` for AI content usage preferences
- Add RFC 8288 `Link` headers on homepage pointing to api-catalog, agent-skills, llms.txt, and skill.md
- Add `/.well-known/agent-skills/index.json` discovery index referencing the existing `skill.md`
- Add `/.well-known/api-catalog` (RFC 9727) linkset JSON for API/docs discovery
- Add `/.well-known/mcp/server-card.json` with project info and agent-readable resource links
- Add Netlify headers for correct content types on all new `.well-known` endpoints

## Test plan
- [ ] Deploy preview serves `/.well-known/agent-skills/index.json` with `application/json`
- [ ] Deploy preview serves `/.well-known/api-catalog` with `application/linkset+json`
- [ ] Deploy preview serves `/.well-known/mcp/server-card.json` with `application/json`
- [ ] Homepage response includes `Link` header with all four entries
- [ ] Re-scan on isitagentready.com shows improved score

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AI agent integration with structured metadata declarations.
  * Added API catalog to improve service discoverability.
  * Added content usage preferences (AI training and search indexing consent).

* **Chores**
  * Configured HTTP response headers for well-known resource endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->