### PR TITLE
feat: add manager_loop node kind (issue #26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
 
   deploy-site:
     name: Deploy Site
-    needs: [test, lint, build, validate-examples]
+    needs: [test, lint, build, validate-examples, tree-sitter]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,36 @@ jobs:
             ./dippin optimize "$f" 2>&1 || true
           done
 
+  tree-sitter:
+    name: Tree-sitter parser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install tree-sitter-cli
+        run: npm install -g tree-sitter-cli@^0.24.0
+
+      - name: Regenerate parser from grammar.js
+        working-directory: editors/tree-sitter-dippin
+        run: tree-sitter generate
+
+      - name: Check for generated-file drift
+        run: |
+          if ! git diff --exit-code editors/tree-sitter-dippin/src; then
+            echo "::error::tree-sitter generated files are stale -- run 'just tree-sitter-generate' and commit"
+            exit 1
+          fi
+
+      - name: Run tree-sitter corpus tests
+        working-directory: editors/tree-sitter-dippin
+        run: tree-sitter test
+
   deploy-site:
     name: Deploy Site
     needs: [test, lint, build, validate-examples]

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ site/static/wasm_exec.js
 .DS_Store
 .worktrees/
 site/.hugo_build.lock
+
+# Tree-sitter build deps
+editors/tree-sitter-dippin/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **`manager_loop` node kind** for supervising a child sub-pipeline with polling and mid-run context steering. Maps to Tracker's `stack.manager_loop` and DOT `shape=house`. Fields: `subgraph_ref`, `poll_interval`, `max_cycles`, `stop_condition`, `steer_condition`, `steer_context` (inline `k=v,k=v` or block form). Round-trips losslessly through parser → formatter → DOT export → migrate. Requires a parallel Tracker adapter update. ([#26](https://github.com/2389-research/dippin-lang/issues/26))
+- **DIP135-137** lint codes for `manager_loop` validation: missing/nonexistent `subgraph_ref` (DIP135), invalid control field — negative `poll_interval` or `max_cycles` (DIP136), unbounded supervision with no `stop_condition` and no `max_cycles` (DIP137 — the manager_loop analog of DIP104).
+- **`stack.*` namespace** recognized by DIP120 so `stop_condition` and `steer_condition` can reference `stack.child.cycles`, `stack.child.outcome`, `stack.child.status` without namespace warnings.
+- **`dippin scaffold manager_loop`** template emits a starter supervisor workflow.
+- **Tree-sitter grammar** — `manager_loop` node rule, highlights coverage, corpus test, committed generated parser (`src/parser.c` et al.), new `just tree-sitter-generate` / `just tree-sitter-test` recipes, and CI drift check so generated files can't drift from `grammar.js` without being caught.
+- **VS Code TextMate grammar** — `manager_loop` keyword, new field names, `stack.*` namespace recognition.
+
+### Fixed
+- **Parser `steer_context` block-form routing** — a single-entry block-form `steer_context` (one `k: v` line under the indent) lexes without an embedded newline; the previous newline-based heuristic mis-routed it to the inline CSV handler. Replaced with a separator-position check (`:` before `=` means block, `=` before `:` means inline).
+- **VS Code TextMate node-declaration regex** was missing `parallel` and `fan_in`; block-form declarations of those kinds went unhighlighted. Bundled with the `manager_loop` grammar update.
+
 ## [v0.21.0] — 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 ## [Unreleased]
 
 ### Added
-- **`manager_loop` node kind** for supervising a child sub-pipeline with polling and mid-run context steering. Maps to Tracker's `stack.manager_loop` and DOT `shape=house`. Fields: `subgraph_ref`, `poll_interval`, `max_cycles`, `stop_condition`, `steer_condition`, `steer_context` (inline `k=v,k=v` or block form). Round-trips losslessly through parser → formatter → DOT export → migrate. Requires a parallel Tracker adapter update. ([#26](https://github.com/2389-research/dippin-lang/issues/26))
+- **`manager_loop` node kind** for supervising a child sub-pipeline with polling and mid-run context steering. Maps to Tracker's `stack.manager_loop` and DOT `shape=house`. Fields: `subgraph_ref`, `poll_interval`, `max_cycles`, `stop_condition`, `steer_condition`, `steer_context` (inline `k=v,k=v` or block form). Round-trips losslessly through parser → formatter → DOT export → migrate. Requires the parallel Tracker adapter update in tracker#162. ([#26](https://github.com/2389-research/dippin-lang/issues/26), [#27](https://github.com/2389-research/dippin-lang/pull/27))
 - **DIP135-137** lint codes for `manager_loop` validation: missing/nonexistent `subgraph_ref` (DIP135), invalid control field — negative `poll_interval` or `max_cycles` (DIP136), unbounded supervision with no `stop_condition` and no `max_cycles` (DIP137 — the manager_loop analog of DIP104).
 - **`stack.*` namespace** recognized by DIP120 so `stop_condition` and `steer_condition` can reference `stack.child.cycles`, `stack.child.outcome`, `stack.child.status` without namespace warnings.
 - **`dippin scaffold manager_loop`** template emits a starter supervisor workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ### Fixed
 - **Parser `steer_context` block-form routing** — a single-entry block-form `steer_context` (one `k: v` line under the indent) lexes without an embedded newline; the previous newline-based heuristic mis-routed it to the inline CSV handler. Replaced with a separator-position check (`:` before `=` means block, `=` before `:` means inline).
-- **VS Code TextMate node-declaration regex** was missing `parallel` and `fan_in`; block-form declarations of those kinds went unhighlighted. Bundled with the `manager_loop` grammar update.
 
 ## [v0.21.0] — 2026-04-20
 

--- a/Justfile
+++ b/Justfile
@@ -139,6 +139,14 @@ wasm:
     cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" site/static/wasm_exec.js
     @echo "WASM built: site/static/dippin.wasm"
 
+# Regenerate tree-sitter parser from grammar.js
+tree-sitter-generate:
+    cd editors/tree-sitter-dippin && npx tree-sitter generate
+
+# Run tree-sitter corpus tests (after regenerate)
+tree-sitter-test: tree-sitter-generate
+    cd editors/tree-sitter-dippin && npx tree-sitter test
+
 # Clean build artifacts
 clean:
     rm -f dippin cover.out cover_filtered.out cover_check.out site/static/dippin.wasm site/static/wasm_exec.js

--- a/Justfile
+++ b/Justfile
@@ -93,7 +93,7 @@ releasecheck:
     go test ./releasecheck/ -count=1 -race
 
 # Run the full pre-commit check suite (mirrors CI exactly)
-check: spec-check build vet fmt-check lint-go test-race releasecheck complexity validate-examples
+check: spec-check build vet fmt-check lint-go test-race releasecheck complexity validate-examples tree-sitter-test
     @echo "All checks passed."
 
 # Generate test coverage report (excludes untestable files: main.go, cmd_lsp.go)

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ workflow <Name>
 
 **`manager_loop`** — supervises a child sub-pipeline, polling it on a cadence and optionally steering it by injecting context during execution. Maps to Tracker's `stack.manager_loop` and DOT shape `house`.
 
-```
+```dippin
   manager_loop QualityGate
     label: "Quality Gate Supervisor"
     subgraph_ref: quality_loop.dip

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 | DIP126 | Subgraph ref file does not exist |
 | DIP135 | Manager loop subgraph_ref missing or file does not exist |
 | DIP136 | Manager loop control field has invalid value |
-| DIP137 | Manager loop with max_cycles: 0 (unbounded) |
+| DIP137 | Manager loop is unbounded (no `stop_condition` AND `max_cycles: 0`) |
 
 ## Simulation
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ graph LR
 | Shell scripts | `tool_command="#!/bin/sh\nset -eu\nif..."` | Real multiline, real syntax |
 | Model config | Untyped `llm_model="..."` attribute | Typed `model:` field with validation |
 | Branching | `condition="context.x!=y && context.a==b"` | `when ctx.x != "y" and ctx.a == "b"` |
-| Validation | Silent — typos in attrs are ignored | 42 diagnostic codes (DIP001–DIP009, DIP101–DIP137) |
+| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP009, DIP101–DIP137) |
 | Node types | Shape overloading (`box`=agent, `hexagon`=human) | Explicit `agent`, `tool`, `human` keywords |
 | Composition | No import/include system | `subgraph` with ref (v2) |
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ graph LR
 | Shell scripts | `tool_command="#!/bin/sh\nset -eu\nif..."` | Real multiline, real syntax |
 | Model config | Untyped `llm_model="..."` attribute | Typed `model:` field with validation |
 | Branching | `condition="context.x!=y && context.a==b"` | `when ctx.x != "y" and ctx.a == "b"` |
-| Validation | Silent — typos in attrs are ignored | 39 diagnostic codes (DIP001–DIP009, DIP101–DIP133) |
+| Validation | Silent — typos in attrs are ignored | 42 diagnostic codes (DIP001–DIP009, DIP101–DIP137) |
 | Node types | Shape overloading (`box`=agent, `hexagon`=human) | Explicit `agent`, `tool`, `human` keywords |
 | Composition | No import/include system | `subgraph` with ref (v2) |
 
@@ -251,6 +251,23 @@ workflow <Name>
     ref: other_workflow.dip
 ```
 
+**`manager_loop`** — supervises a child sub-pipeline, polling it on a cadence and optionally steering it by injecting context during execution. Maps to Tracker's `stack.manager_loop` and DOT shape `house`.
+
+```
+  manager_loop QualityGate
+    label: "Quality Gate Supervisor"
+    subgraph_ref: quality_loop.dip
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.outcome = success
+    steer_condition: stack.child.cycles = 5
+    steer_context:
+      hint: halfway_through
+      priority: high
+```
+
+See [`docs/nodes.md`](docs/nodes.md) for the full field reference and lint codes (DIP135–DIP137).
+
 ### Edges and Conditions
 
 ```
@@ -383,6 +400,9 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 | DIP124 | Tool command references runtime-only `${ctx.*}` variable |
 | DIP125 | Tool command binary not found on PATH |
 | DIP126 | Subgraph ref file does not exist |
+| DIP135 | Manager loop subgraph_ref missing or file does not exist |
+| DIP136 | Manager loop control field has invalid value |
+| DIP137 | Manager loop with max_cycles: 0 (unbounded) |
 
 ## Simulation
 

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -311,7 +311,7 @@ Inline syntax only. Every `parallel` must have a matching `fan_in` with identica
 
 Spawns a child `.dip` pipeline, polls it on a cadence, and can steer it by injecting context. Maps to `stack.manager_loop` in Tracker; DOT shape `house`. Full reference: [docs/nodes.md](https://github.com/2389-research/dippin-lang/blob/main/docs/nodes.md).
 
-```
+```dip
   manager_loop QualityGate
     label: "Quality Gate Supervisor"
     subgraph_ref: quality_loop.dip
@@ -438,7 +438,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP009) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001-DIP133) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001-DIP137) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -307,6 +307,34 @@ Inline syntax only. Every `parallel` must have a matching `fan_in` with identica
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
+### manager_loop — supervised child pipeline
+
+Spawns a child `.dip` pipeline, polls it on a cadence, and can steer it by injecting context. Maps to `stack.manager_loop` in Tracker; DOT shape `house`. Full reference: [docs/nodes.md](https://github.com/2389-research/dippin-lang/blob/main/docs/nodes.md).
+
+```
+  manager_loop QualityGate
+    label: "Quality Gate Supervisor"
+    subgraph_ref: quality_loop.dip
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.outcome = success
+    steer_condition: stack.child.cycles = 5
+    steer_context:
+      hint: halfway_through
+      priority: high
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `subgraph_ref` | string | **Required.** Path to child .dip file (DIP135 if missing/not found) |
+| `poll_interval` | duration | Poll cadence (e.g. `30s`). `0` = event-driven |
+| `max_cycles` | int | Max poll cycles. `0` = unbounded → DIP137 |
+| `stop_condition` | condition | Over `stack.child.*`; when true the loop exits |
+| `steer_condition` | condition | When true, inject `steer_context` into child |
+| `steer_context` | map[string]string | Inline `k=v, k=v` or block form. No commas in inline values |
+
+Runtime state: `stack.child.cycles`, `stack.child.outcome`, `stack.child.status`. Lint: DIP135 (bad ref), DIP136 (invalid field), DIP137 (unbounded).
+
 ## Common Fields (all block nodes)
 
 | Field | Notes |

--- a/docs/GRAMMAR.ebnf
+++ b/docs/GRAMMAR.ebnf
@@ -64,7 +64,8 @@ vars_field       = IDENTIFIER ":" field_value ;
 
 node_decl       = agent_node | human_node | tool_node
                 | subgraph_node | conditional_node
-                | parallel_node | fan_in_node ;
+                | parallel_node | fan_in_node
+                | manager_loop_node ;
 
 (* --- Agent Node ------------------------------------------- *)
 
@@ -121,6 +122,26 @@ params_block    = NEWLINE INDENT { IDENTIFIER ":" field_value } OUTDENT ;
 
 conditional_node = "conditional" IDENTIFIER NEWLINE
                    INDENT { common_field } OUTDENT ;
+
+(* --- Manager Loop Node ------------------------------------ *)
+
+(* manager_loop supervises a child subgraph with polling and optional     *)
+(* mid-run context injection. Maps to DOT shape=house.                    *)
+
+manager_loop_node = "manager_loop" IDENTIFIER NEWLINE
+                    INDENT { manager_loop_field | common_field } OUTDENT ;
+
+manager_loop_field = "subgraph_ref"    ":" field_value
+                   | "poll_interval"   ":" DURATION
+                   | "max_cycles"      ":" INTEGER
+                   | "stop_condition"  ":" field_value    (* condition expression, stored raw *)
+                   | "steer_condition" ":" field_value    (* condition expression, stored raw *)
+                   | "steer_context"   ":" steer_context_value ;
+
+(* steer_context accepts inline "k=v, k=v" CSV or a block of "k: v" lines. *)
+(* Inline form does not support values containing commas — use block form. *)
+steer_context_value = field_value                        (* inline "k=v, k=v" *)
+                    | params_block ;                     (* block of k: v lines *)
 
 (* --- Parallel / Fan-In (inline syntax) -------------------- *)
 
@@ -308,6 +329,9 @@ digit           = "0" | "1" | ... | "9" ;
 (* Human: label, mode, default, reads, writes                 *)
 (* Tool: label, timeout, reads, writes, command               *)
 (* Subgraph: label, ref                                       *)
+(* Manager loop: label, retry, reads, writes, subgraph_ref,   *)
+(*   poll_interval, max_cycles, stop_condition,               *)
+(*   steer_condition, steer_context                           *)
 (* Note: multiline fields (prompt, system_prompt, command)     *)
 (*   are always last in their node type                       *)
 
@@ -317,6 +341,7 @@ digit           = "0" | "1" | ... | "9" ;
 
 (* These identifiers have special meaning in context but can  *)
 (* be used as node IDs without conflict:                      *)
-(* workflow, agent, human, tool, subgraph, parallel, fan_in,  *)
-(* edges, defaults, vars, when, and, or, not, contains, startswith, *)
-(* endswith, in, true, false, restart, label, weight          *)
+(* workflow, agent, human, tool, subgraph, conditional,       *)
+(* parallel, fan_in, manager_loop, edges, defaults, vars,     *)
+(* when, and, or, not, contains, startswith, endswith, in,    *)
+(* true, false, restart, label, weight                        *)

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -450,7 +450,7 @@ Manager loop nodes supervise a child sub-pipeline, polling it on a cadence and o
 | `max_cycles` | Integer | No | Hard cap on child cycles. `0` means unbounded — unless `stop_condition` is set, this triggers DIP137. |
 | `stop_condition` | Condition | No | Terminates supervision when true. Uses `stack.child.*` runtime variables. |
 | `steer_condition` | Condition | No | Injects `steer_context` into the child when true. |
-| `steer_context` | Map | No | Key-value hints. Inline form (`key=val, key=val`) or block form (one `key: val` per line). Inline form does not support values containing commas — use the block form for such values. Keys and values must not contain `,` or `=` — these are reserved as flat-attr delimiters in DOT export. |
+| `steer_context` | Map | No | Key-value hints. Inline form (`key=val, key=val`) or block form (one `key: val` per line). Inline form does not support values containing commas — use the block form for such values. Keys must not contain `:` (it is the block-form separator); other reserved characters (`,`, `=`) are percent-encoded transparently at the DOT export/migrate boundary. |
 
 ### Supervisor State
 
@@ -465,7 +465,7 @@ Use these in `stop_condition` and `steer_condition` expressions.
 ### Lint Checks
 
 - **DIP135** — `subgraph_ref` missing or points to a nonexistent file
-- **DIP136** — invalid control field (negative `poll_interval` or `max_cycles`, or `steer_context` key/value containing reserved delimiter `,` or `=`)
+- **DIP136** — invalid control field (negative `poll_interval` or `max_cycles`)
 - **DIP137** — unbounded supervisor (no `stop_condition` and no `max_cycles`)
 
 See `examples/manager_loop_demo.dip` for a complete working example.

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -6,7 +6,7 @@ Nodes are the building blocks of a Dippin workflow. Each node represents a singl
 
 ## Node Kinds
 
-There are 6 node kinds, each with its own syntax and configuration:
+There are 8 node kinds, each with its own syntax and configuration:
 
 ```mermaid
 graph TB
@@ -18,9 +18,11 @@ graph TB
     subgraph Control Flow Nodes
         parallel["parallel<br>Fan-out"]
         fan_in["fan_in<br>Join"]
+        conditional["conditional<br>Pure branching"]
     end
     subgraph Composition Nodes
         subgraph_node["subgraph<br>Sub-pipeline"]
+        manager_loop["manager_loop<br>Supervisor"]
     end
 ```
 
@@ -31,7 +33,9 @@ graph TB
 | `tool` | Shell command execution | Block with command |
 | `parallel` | Fan-out to concurrent branches | Inline declaration |
 | `fan_in` | Join concurrent branches | Inline declaration |
+| `conditional` | Pure branching (no LLM call) | Block with label |
 | `subgraph` | Embed a sub-pipeline | Block with ref |
+| `manager_loop` | Supervise a child subgraph | Block with subgraph_ref |
 
 ---
 
@@ -417,6 +421,54 @@ The `interview_loop.dip` example is a pre-built subgraph that collects structure
 ```
 
 The subgraph handles the full interview lifecycle: generating questions with suggested options, collecting structured answers via `huh` forms, assessing completeness, and looping until requirements are clear. See `examples/interview_loop.dip` for the full source.
+
+---
+
+## Manager Loop Nodes
+
+Manager loop nodes supervise a child sub-pipeline, polling it on a cadence and optionally steering it by injecting context during execution. They map to Tracker's `stack.manager_loop` and DOT `shape=house`.
+
+```dippin
+  manager_loop QualityGate
+    label: "Quality Gate Supervisor"
+    subgraph_ref: quality_loop.dip
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.outcome = success
+    steer_condition: stack.child.cycles = 5
+    steer_context:
+      hint: halfway_through
+      priority: high
+```
+
+### Manager-Loop-Specific Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `subgraph_ref` | String | **Yes** | Path to the `.dip` file of the child pipeline to supervise. Lints DIP135 if missing or the file does not exist. |
+| `poll_interval` | Duration | No | How often the supervisor wakes to check child state (e.g., `30s`, `5m`). `0` means event-driven (no polling). |
+| `max_cycles` | Integer | No | Hard cap on child cycles. `0` means unbounded — unless `stop_condition` is set, this triggers DIP137. |
+| `stop_condition` | Condition | No | Terminates supervision when true. Uses `stack.child.*` runtime variables. |
+| `steer_condition` | Condition | No | Injects `steer_context` into the child when true. |
+| `steer_context` | Map | No | Key-value hints. Inline form (`key=val, key=val`) or block form (one `key: val` per line). Inline form does not support values containing commas — use the block form for such values. |
+
+### Supervisor State
+
+While supervision runs, the runtime exposes the child's state under the `stack.child.*` namespace:
+
+- `stack.child.cycles` — how many iterations the child has run
+- `stack.child.outcome` — the child's last reported outcome
+- `stack.child.status` — `running`, `stopped`, `failed`
+
+Use these in `stop_condition` and `steer_condition` expressions.
+
+### Lint Checks
+
+- **DIP135** — `subgraph_ref` missing or points to a nonexistent file
+- **DIP136** — invalid control field (negative `poll_interval` or `max_cycles`)
+- **DIP137** — unbounded supervisor (no `stop_condition` and no `max_cycles`)
+
+See `examples/manager_loop_demo.dip` for a complete working example.
 
 ---
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -450,7 +450,7 @@ Manager loop nodes supervise a child sub-pipeline, polling it on a cadence and o
 | `max_cycles` | Integer | No | Hard cap on child cycles. `0` means unbounded — unless `stop_condition` is set, this triggers DIP137. |
 | `stop_condition` | Condition | No | Terminates supervision when true. Uses `stack.child.*` runtime variables. |
 | `steer_condition` | Condition | No | Injects `steer_context` into the child when true. |
-| `steer_context` | Map | No | Key-value hints. Inline form (`key=val, key=val`) or block form (one `key: val` per line). Inline form does not support values containing commas — use the block form for such values. |
+| `steer_context` | Map | No | Key-value hints. Inline form (`key=val, key=val`) or block form (one `key: val` per line). Inline form does not support values containing commas — use the block form for such values. Keys and values must not contain `,` or `=` — these are reserved as flat-attr delimiters in DOT export. |
 
 ### Supervisor State
 
@@ -465,7 +465,7 @@ Use these in `stop_condition` and `steer_condition` expressions.
 ### Lint Checks
 
 - **DIP135** — `subgraph_ref` missing or points to a nonexistent file
-- **DIP136** — invalid control field (negative `poll_interval` or `max_cycles`)
+- **DIP136** — invalid control field (negative `poll_interval` or `max_cycles`, or `steer_context` key/value containing reserved delimiter `,` or `=`)
 - **DIP137** — unbounded supervisor (no `stop_condition` and no `max_cycles`)
 
 See `examples/manager_loop_demo.dip` for a complete working example.

--- a/editors/tree-sitter-dippin/grammar.js
+++ b/editors/tree-sitter-dippin/grammar.js
@@ -53,7 +53,8 @@ module.exports = grammar({
         $.subgraph_node,
         $.conditional_node,
         $.parallel_node,
-        $.fan_in_node
+        $.fan_in_node,
+        $.manager_loop_node
       ),
 
     agent_node: ($) =>
@@ -70,6 +71,9 @@ module.exports = grammar({
 
     conditional_node: ($) =>
       seq("conditional", $.identifier, $._indent, repeat1(choice($.node_field, $._newline)), $._dedent),
+
+    manager_loop_node: ($) =>
+      seq("manager_loop", $.identifier, $._indent, repeat1(choice($.node_field, $._newline)), $._dedent),
 
     parallel_node: ($) =>
       seq("parallel", $.identifier, "->", $.identifier_list, $._newline),

--- a/editors/tree-sitter-dippin/package-lock.json
+++ b/editors/tree-sitter-dippin/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "tree-sitter-dippin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tree-sitter-dippin",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.17.0"
+      },
+      "devDependencies": {
+        "tree-sitter-cli": "^0.24.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "license": "MIT"
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.7.tgz",
+      "integrity": "sha512-o4gnE82pVmMMhJbWwD6+I9yr4lXii5Ci5qEQ2pFpUbVy1YiD8cizTJaqdcznA0qEbo7l2OneI1GocChPrI4YGQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    }
+  }
+}

--- a/editors/tree-sitter-dippin/queries/highlights.scm
+++ b/editors/tree-sitter-dippin/queries/highlights.scm
@@ -15,6 +15,7 @@
   "conditional"
   "parallel"
   "fan_in"
+  "manager_loop"
 ] @type
 
 ; Edge / condition keywords
@@ -71,6 +72,8 @@
 (parallel_node
   (identifier) @function)
 (fan_in_node
+  (identifier) @function)
+(manager_loop_node
   (identifier) @function)
 
 ; Edge source/target

--- a/editors/tree-sitter-dippin/src/grammar.json
+++ b/editors/tree-sitter-dippin/src/grammar.json
@@ -1,0 +1,1080 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
+  "name": "dippin",
+  "word": "identifier",
+  "rules": {
+    "source_file": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_newline"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "workflow_decl"
+        }
+      ]
+    },
+    "workflow_decl": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "workflow"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "workflow_body"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "workflow_body": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "workflow_field"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "defaults_section"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "node_decl"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "edges_section"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "stylesheet_section"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_newline"
+          }
+        ]
+      }
+    },
+    "workflow_field": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "goal"
+            },
+            {
+              "type": "STRING",
+              "value": "start"
+            },
+            {
+              "type": "STRING",
+              "value": "exit"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "field_value"
+        }
+      ]
+    },
+    "defaults_section": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "defaults"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "defaults_field"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "defaults_field": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "field_name"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "field_value"
+        }
+      ]
+    },
+    "node_decl": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "agent_node"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "human_node"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tool_node"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "subgraph_node"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_node"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parallel_node"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fan_in_node"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "manager_loop_node"
+        }
+      ]
+    },
+    "agent_node": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "agent"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "node_field"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "human_node": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "human"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "node_field"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "tool_node": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "tool"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "node_field"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "subgraph_node": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "subgraph"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "node_field"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "conditional_node": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "conditional"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "node_field"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "manager_loop_node": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "manager_loop"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "node_field"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "parallel_node": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "parallel"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "->"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier_list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_newline"
+        }
+      ]
+    },
+    "fan_in_node": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "fan_in"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "<-"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier_list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_newline"
+        }
+      ]
+    },
+    "node_field": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "field_name"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "field_value"
+        }
+      ]
+    },
+    "edges_section": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "edges"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "edge_entry"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "edge_entry": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "->"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "edge_attr"
+          }
+        }
+      ]
+    },
+    "edge_attr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "when"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "condition"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "label"
+            },
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "field_value"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "weight"
+            },
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "field_value"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "restart"
+            },
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "field_value"
+            }
+          ]
+        }
+      ]
+    },
+    "condition": {
+      "type": "SYMBOL",
+      "name": "or_expr"
+    },
+    "or_expr": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "and_expr"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "or"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "and_expr"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "and_expr": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "compare_expr"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "and"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "compare_expr"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "compare_expr": {
+      "type": "PREC_LEFT",
+      "value": 3,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "operand"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "not"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "compare_op"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "operand"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "compare_op": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "=="
+        },
+        {
+          "type": "STRING",
+          "value": "!="
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "STRING",
+          "value": "contains"
+        },
+        {
+          "type": "STRING",
+          "value": "startswith"
+        },
+        {
+          "type": "STRING",
+          "value": "endswith"
+        },
+        {
+          "type": "STRING",
+          "value": "in"
+        }
+      ]
+    },
+    "operand": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "variable": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "stylesheet_section": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "stylesheet"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "stylesheet_rule"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "stylesheet_rule": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "selector"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "field_name"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ":"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "field_value"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "selector": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "#"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "field_name": {
+      "type": "SYMBOL",
+      "name": "identifier"
+    },
+    "field_value": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "multiline_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "raw_inline"
+        }
+      ]
+    },
+    "raw_inline": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -1,
+        "content": {
+          "type": "PATTERN",
+          "value": "[^\\n]+"
+        }
+      }
+    },
+    "multiline_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_content"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "block_content": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "block_line"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_newline"
+          }
+        ]
+      }
+    },
+    "block_line": {
+      "type": "PATTERN",
+      "value": "[^\\n]+"
+    },
+    "identifier_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "identifier": {
+      "type": "PATTERN",
+      "value": "[a-zA-Z0-9][a-zA-Z0-9_\\-]*"
+    },
+    "string": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\""
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[^\"\\\\]+"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\\\."
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "\""
+        }
+      ]
+    },
+    "comment": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "#"
+          },
+          {
+            "type": "PATTERN",
+            "value": ".*"
+          }
+        ]
+      }
+    }
+  },
+  "extras": [
+    {
+      "type": "PATTERN",
+      "value": "[ \\t\\r]"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "comment"
+    }
+  ],
+  "conflicts": [],
+  "precedences": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_indent"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_dedent"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_newline"
+    }
+  ],
+  "inline": [],
+  "supertypes": []
+}

--- a/editors/tree-sitter-dippin/src/node-types.json
+++ b/editors/tree-sitter-dippin/src/node-types.json
@@ -1,0 +1,796 @@
+[
+  {
+    "type": "agent_node",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "node_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "and_expr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "compare_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "block_content",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block_line",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "compare_expr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "compare_op",
+          "named": true
+        },
+        {
+          "type": "operand",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "compare_op",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "condition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "or_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "conditional_node",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "node_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "defaults_field",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "field_name",
+          "named": true
+        },
+        {
+          "type": "field_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "defaults_section",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "defaults_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "edge_attr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "condition",
+          "named": true
+        },
+        {
+          "type": "field_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "edge_entry",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "edge_attr",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "edges_section",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "edge_entry",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "fan_in_node",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "identifier_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "field_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "field_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "multiline_block",
+          "named": true
+        },
+        {
+          "type": "raw_inline",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "human_node",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "node_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "identifier_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "manager_loop_node",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "node_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "multiline_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block_content",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "node_decl",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "agent_node",
+          "named": true
+        },
+        {
+          "type": "conditional_node",
+          "named": true
+        },
+        {
+          "type": "fan_in_node",
+          "named": true
+        },
+        {
+          "type": "human_node",
+          "named": true
+        },
+        {
+          "type": "manager_loop_node",
+          "named": true
+        },
+        {
+          "type": "parallel_node",
+          "named": true
+        },
+        {
+          "type": "subgraph_node",
+          "named": true
+        },
+        {
+          "type": "tool_node",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "node_field",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "field_name",
+          "named": true
+        },
+        {
+          "type": "field_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "operand",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "variable",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "or_expr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "and_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "parallel_node",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "identifier_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "selector",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "source_file",
+    "named": true,
+    "root": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "workflow_decl",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "string",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "stylesheet_rule",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "field_name",
+          "named": true
+        },
+        {
+          "type": "field_value",
+          "named": true
+        },
+        {
+          "type": "selector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "stylesheet_section",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "stylesheet_rule",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subgraph_node",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "node_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "tool_node",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "node_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "variable",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "workflow_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "defaults_section",
+          "named": true
+        },
+        {
+          "type": "edges_section",
+          "named": true
+        },
+        {
+          "type": "node_decl",
+          "named": true
+        },
+        {
+          "type": "stylesheet_section",
+          "named": true
+        },
+        {
+          "type": "workflow_field",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "workflow_decl",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "workflow_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "workflow_field",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "field_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "!=",
+    "named": false
+  },
+  {
+    "type": "\"",
+    "named": false
+  },
+  {
+    "type": "#",
+    "named": false
+  },
+  {
+    "type": "*",
+    "named": false
+  },
+  {
+    "type": ",",
+    "named": false
+  },
+  {
+    "type": "->",
+    "named": false
+  },
+  {
+    "type": ".",
+    "named": false
+  },
+  {
+    "type": ":",
+    "named": false
+  },
+  {
+    "type": "<-",
+    "named": false
+  },
+  {
+    "type": "=",
+    "named": false
+  },
+  {
+    "type": "==",
+    "named": false
+  },
+  {
+    "type": "agent",
+    "named": false
+  },
+  {
+    "type": "and",
+    "named": false
+  },
+  {
+    "type": "block_line",
+    "named": true
+  },
+  {
+    "type": "comment",
+    "named": true
+  },
+  {
+    "type": "conditional",
+    "named": false
+  },
+  {
+    "type": "contains",
+    "named": false
+  },
+  {
+    "type": "defaults",
+    "named": false
+  },
+  {
+    "type": "edges",
+    "named": false
+  },
+  {
+    "type": "endswith",
+    "named": false
+  },
+  {
+    "type": "exit",
+    "named": false
+  },
+  {
+    "type": "fan_in",
+    "named": false
+  },
+  {
+    "type": "goal",
+    "named": false
+  },
+  {
+    "type": "human",
+    "named": false
+  },
+  {
+    "type": "identifier",
+    "named": true
+  },
+  {
+    "type": "in",
+    "named": false
+  },
+  {
+    "type": "label",
+    "named": false
+  },
+  {
+    "type": "manager_loop",
+    "named": false
+  },
+  {
+    "type": "not",
+    "named": false
+  },
+  {
+    "type": "or",
+    "named": false
+  },
+  {
+    "type": "parallel",
+    "named": false
+  },
+  {
+    "type": "raw_inline",
+    "named": true
+  },
+  {
+    "type": "restart",
+    "named": false
+  },
+  {
+    "type": "start",
+    "named": false
+  },
+  {
+    "type": "startswith",
+    "named": false
+  },
+  {
+    "type": "stylesheet",
+    "named": false
+  },
+  {
+    "type": "subgraph",
+    "named": false
+  },
+  {
+    "type": "tool",
+    "named": false
+  },
+  {
+    "type": "weight",
+    "named": false
+  },
+  {
+    "type": "when",
+    "named": false
+  },
+  {
+    "type": "workflow",
+    "named": false
+  }
+]

--- a/editors/tree-sitter-dippin/src/parser.c
+++ b/editors/tree-sitter-dippin/src/parser.c
@@ -1,0 +1,3934 @@
+#include "tree_sitter/parser.h"
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+#define LANGUAGE_VERSION 14
+#define STATE_COUNT 141
+#define LARGE_STATE_COUNT 2
+#define SYMBOL_COUNT 95
+#define ALIAS_COUNT 0
+#define TOKEN_COUNT 47
+#define EXTERNAL_TOKEN_COUNT 3
+#define FIELD_COUNT 0
+#define MAX_ALIAS_SEQUENCE_LENGTH 5
+#define PRODUCTION_ID_COUNT 1
+
+enum ts_symbol_identifiers {
+  sym_identifier = 1,
+  anon_sym_workflow = 2,
+  anon_sym_goal = 3,
+  anon_sym_start = 4,
+  anon_sym_exit = 5,
+  anon_sym_COLON = 6,
+  anon_sym_defaults = 7,
+  anon_sym_agent = 8,
+  anon_sym_human = 9,
+  anon_sym_tool = 10,
+  anon_sym_subgraph = 11,
+  anon_sym_conditional = 12,
+  anon_sym_manager_loop = 13,
+  anon_sym_parallel = 14,
+  anon_sym_DASH_GT = 15,
+  anon_sym_fan_in = 16,
+  anon_sym_LT_DASH = 17,
+  anon_sym_edges = 18,
+  anon_sym_when = 19,
+  anon_sym_label = 20,
+  anon_sym_weight = 21,
+  anon_sym_restart = 22,
+  anon_sym_or = 23,
+  anon_sym_and = 24,
+  anon_sym_not = 25,
+  anon_sym_EQ_EQ = 26,
+  anon_sym_BANG_EQ = 27,
+  anon_sym_EQ = 28,
+  anon_sym_contains = 29,
+  anon_sym_startswith = 30,
+  anon_sym_endswith = 31,
+  anon_sym_in = 32,
+  anon_sym_DOT = 33,
+  anon_sym_stylesheet = 34,
+  anon_sym_STAR = 35,
+  anon_sym_POUND = 36,
+  sym_raw_inline = 37,
+  sym_block_line = 38,
+  anon_sym_COMMA = 39,
+  anon_sym_DQUOTE = 40,
+  aux_sym_string_token1 = 41,
+  aux_sym_string_token2 = 42,
+  sym_comment = 43,
+  sym__indent = 44,
+  sym__dedent = 45,
+  sym__newline = 46,
+  sym_source_file = 47,
+  sym_workflow_decl = 48,
+  sym_workflow_body = 49,
+  sym_workflow_field = 50,
+  sym_defaults_section = 51,
+  sym_defaults_field = 52,
+  sym_node_decl = 53,
+  sym_agent_node = 54,
+  sym_human_node = 55,
+  sym_tool_node = 56,
+  sym_subgraph_node = 57,
+  sym_conditional_node = 58,
+  sym_manager_loop_node = 59,
+  sym_parallel_node = 60,
+  sym_fan_in_node = 61,
+  sym_node_field = 62,
+  sym_edges_section = 63,
+  sym_edge_entry = 64,
+  sym_edge_attr = 65,
+  sym_condition = 66,
+  sym_or_expr = 67,
+  sym_and_expr = 68,
+  sym_compare_expr = 69,
+  sym_compare_op = 70,
+  sym_operand = 71,
+  sym_variable = 72,
+  sym_stylesheet_section = 73,
+  sym_stylesheet_rule = 74,
+  sym_selector = 75,
+  sym_field_name = 76,
+  sym_field_value = 77,
+  sym_multiline_block = 78,
+  sym_block_content = 79,
+  sym_identifier_list = 80,
+  sym_string = 81,
+  aux_sym_source_file_repeat1 = 82,
+  aux_sym_workflow_body_repeat1 = 83,
+  aux_sym_defaults_section_repeat1 = 84,
+  aux_sym_agent_node_repeat1 = 85,
+  aux_sym_edges_section_repeat1 = 86,
+  aux_sym_edge_entry_repeat1 = 87,
+  aux_sym_or_expr_repeat1 = 88,
+  aux_sym_and_expr_repeat1 = 89,
+  aux_sym_stylesheet_section_repeat1 = 90,
+  aux_sym_stylesheet_rule_repeat1 = 91,
+  aux_sym_block_content_repeat1 = 92,
+  aux_sym_identifier_list_repeat1 = 93,
+  aux_sym_string_repeat1 = 94,
+};
+
+static const char * const ts_symbol_names[] = {
+  [ts_builtin_sym_end] = "end",
+  [sym_identifier] = "identifier",
+  [anon_sym_workflow] = "workflow",
+  [anon_sym_goal] = "goal",
+  [anon_sym_start] = "start",
+  [anon_sym_exit] = "exit",
+  [anon_sym_COLON] = ":",
+  [anon_sym_defaults] = "defaults",
+  [anon_sym_agent] = "agent",
+  [anon_sym_human] = "human",
+  [anon_sym_tool] = "tool",
+  [anon_sym_subgraph] = "subgraph",
+  [anon_sym_conditional] = "conditional",
+  [anon_sym_manager_loop] = "manager_loop",
+  [anon_sym_parallel] = "parallel",
+  [anon_sym_DASH_GT] = "->",
+  [anon_sym_fan_in] = "fan_in",
+  [anon_sym_LT_DASH] = "<-",
+  [anon_sym_edges] = "edges",
+  [anon_sym_when] = "when",
+  [anon_sym_label] = "label",
+  [anon_sym_weight] = "weight",
+  [anon_sym_restart] = "restart",
+  [anon_sym_or] = "or",
+  [anon_sym_and] = "and",
+  [anon_sym_not] = "not",
+  [anon_sym_EQ_EQ] = "==",
+  [anon_sym_BANG_EQ] = "!=",
+  [anon_sym_EQ] = "=",
+  [anon_sym_contains] = "contains",
+  [anon_sym_startswith] = "startswith",
+  [anon_sym_endswith] = "endswith",
+  [anon_sym_in] = "in",
+  [anon_sym_DOT] = ".",
+  [anon_sym_stylesheet] = "stylesheet",
+  [anon_sym_STAR] = "*",
+  [anon_sym_POUND] = "#",
+  [sym_raw_inline] = "raw_inline",
+  [sym_block_line] = "block_line",
+  [anon_sym_COMMA] = ",",
+  [anon_sym_DQUOTE] = "\"",
+  [aux_sym_string_token1] = "string_token1",
+  [aux_sym_string_token2] = "string_token2",
+  [sym_comment] = "comment",
+  [sym__indent] = "_indent",
+  [sym__dedent] = "_dedent",
+  [sym__newline] = "_newline",
+  [sym_source_file] = "source_file",
+  [sym_workflow_decl] = "workflow_decl",
+  [sym_workflow_body] = "workflow_body",
+  [sym_workflow_field] = "workflow_field",
+  [sym_defaults_section] = "defaults_section",
+  [sym_defaults_field] = "defaults_field",
+  [sym_node_decl] = "node_decl",
+  [sym_agent_node] = "agent_node",
+  [sym_human_node] = "human_node",
+  [sym_tool_node] = "tool_node",
+  [sym_subgraph_node] = "subgraph_node",
+  [sym_conditional_node] = "conditional_node",
+  [sym_manager_loop_node] = "manager_loop_node",
+  [sym_parallel_node] = "parallel_node",
+  [sym_fan_in_node] = "fan_in_node",
+  [sym_node_field] = "node_field",
+  [sym_edges_section] = "edges_section",
+  [sym_edge_entry] = "edge_entry",
+  [sym_edge_attr] = "edge_attr",
+  [sym_condition] = "condition",
+  [sym_or_expr] = "or_expr",
+  [sym_and_expr] = "and_expr",
+  [sym_compare_expr] = "compare_expr",
+  [sym_compare_op] = "compare_op",
+  [sym_operand] = "operand",
+  [sym_variable] = "variable",
+  [sym_stylesheet_section] = "stylesheet_section",
+  [sym_stylesheet_rule] = "stylesheet_rule",
+  [sym_selector] = "selector",
+  [sym_field_name] = "field_name",
+  [sym_field_value] = "field_value",
+  [sym_multiline_block] = "multiline_block",
+  [sym_block_content] = "block_content",
+  [sym_identifier_list] = "identifier_list",
+  [sym_string] = "string",
+  [aux_sym_source_file_repeat1] = "source_file_repeat1",
+  [aux_sym_workflow_body_repeat1] = "workflow_body_repeat1",
+  [aux_sym_defaults_section_repeat1] = "defaults_section_repeat1",
+  [aux_sym_agent_node_repeat1] = "agent_node_repeat1",
+  [aux_sym_edges_section_repeat1] = "edges_section_repeat1",
+  [aux_sym_edge_entry_repeat1] = "edge_entry_repeat1",
+  [aux_sym_or_expr_repeat1] = "or_expr_repeat1",
+  [aux_sym_and_expr_repeat1] = "and_expr_repeat1",
+  [aux_sym_stylesheet_section_repeat1] = "stylesheet_section_repeat1",
+  [aux_sym_stylesheet_rule_repeat1] = "stylesheet_rule_repeat1",
+  [aux_sym_block_content_repeat1] = "block_content_repeat1",
+  [aux_sym_identifier_list_repeat1] = "identifier_list_repeat1",
+  [aux_sym_string_repeat1] = "string_repeat1",
+};
+
+static const TSSymbol ts_symbol_map[] = {
+  [ts_builtin_sym_end] = ts_builtin_sym_end,
+  [sym_identifier] = sym_identifier,
+  [anon_sym_workflow] = anon_sym_workflow,
+  [anon_sym_goal] = anon_sym_goal,
+  [anon_sym_start] = anon_sym_start,
+  [anon_sym_exit] = anon_sym_exit,
+  [anon_sym_COLON] = anon_sym_COLON,
+  [anon_sym_defaults] = anon_sym_defaults,
+  [anon_sym_agent] = anon_sym_agent,
+  [anon_sym_human] = anon_sym_human,
+  [anon_sym_tool] = anon_sym_tool,
+  [anon_sym_subgraph] = anon_sym_subgraph,
+  [anon_sym_conditional] = anon_sym_conditional,
+  [anon_sym_manager_loop] = anon_sym_manager_loop,
+  [anon_sym_parallel] = anon_sym_parallel,
+  [anon_sym_DASH_GT] = anon_sym_DASH_GT,
+  [anon_sym_fan_in] = anon_sym_fan_in,
+  [anon_sym_LT_DASH] = anon_sym_LT_DASH,
+  [anon_sym_edges] = anon_sym_edges,
+  [anon_sym_when] = anon_sym_when,
+  [anon_sym_label] = anon_sym_label,
+  [anon_sym_weight] = anon_sym_weight,
+  [anon_sym_restart] = anon_sym_restart,
+  [anon_sym_or] = anon_sym_or,
+  [anon_sym_and] = anon_sym_and,
+  [anon_sym_not] = anon_sym_not,
+  [anon_sym_EQ_EQ] = anon_sym_EQ_EQ,
+  [anon_sym_BANG_EQ] = anon_sym_BANG_EQ,
+  [anon_sym_EQ] = anon_sym_EQ,
+  [anon_sym_contains] = anon_sym_contains,
+  [anon_sym_startswith] = anon_sym_startswith,
+  [anon_sym_endswith] = anon_sym_endswith,
+  [anon_sym_in] = anon_sym_in,
+  [anon_sym_DOT] = anon_sym_DOT,
+  [anon_sym_stylesheet] = anon_sym_stylesheet,
+  [anon_sym_STAR] = anon_sym_STAR,
+  [anon_sym_POUND] = anon_sym_POUND,
+  [sym_raw_inline] = sym_raw_inline,
+  [sym_block_line] = sym_block_line,
+  [anon_sym_COMMA] = anon_sym_COMMA,
+  [anon_sym_DQUOTE] = anon_sym_DQUOTE,
+  [aux_sym_string_token1] = aux_sym_string_token1,
+  [aux_sym_string_token2] = aux_sym_string_token2,
+  [sym_comment] = sym_comment,
+  [sym__indent] = sym__indent,
+  [sym__dedent] = sym__dedent,
+  [sym__newline] = sym__newline,
+  [sym_source_file] = sym_source_file,
+  [sym_workflow_decl] = sym_workflow_decl,
+  [sym_workflow_body] = sym_workflow_body,
+  [sym_workflow_field] = sym_workflow_field,
+  [sym_defaults_section] = sym_defaults_section,
+  [sym_defaults_field] = sym_defaults_field,
+  [sym_node_decl] = sym_node_decl,
+  [sym_agent_node] = sym_agent_node,
+  [sym_human_node] = sym_human_node,
+  [sym_tool_node] = sym_tool_node,
+  [sym_subgraph_node] = sym_subgraph_node,
+  [sym_conditional_node] = sym_conditional_node,
+  [sym_manager_loop_node] = sym_manager_loop_node,
+  [sym_parallel_node] = sym_parallel_node,
+  [sym_fan_in_node] = sym_fan_in_node,
+  [sym_node_field] = sym_node_field,
+  [sym_edges_section] = sym_edges_section,
+  [sym_edge_entry] = sym_edge_entry,
+  [sym_edge_attr] = sym_edge_attr,
+  [sym_condition] = sym_condition,
+  [sym_or_expr] = sym_or_expr,
+  [sym_and_expr] = sym_and_expr,
+  [sym_compare_expr] = sym_compare_expr,
+  [sym_compare_op] = sym_compare_op,
+  [sym_operand] = sym_operand,
+  [sym_variable] = sym_variable,
+  [sym_stylesheet_section] = sym_stylesheet_section,
+  [sym_stylesheet_rule] = sym_stylesheet_rule,
+  [sym_selector] = sym_selector,
+  [sym_field_name] = sym_field_name,
+  [sym_field_value] = sym_field_value,
+  [sym_multiline_block] = sym_multiline_block,
+  [sym_block_content] = sym_block_content,
+  [sym_identifier_list] = sym_identifier_list,
+  [sym_string] = sym_string,
+  [aux_sym_source_file_repeat1] = aux_sym_source_file_repeat1,
+  [aux_sym_workflow_body_repeat1] = aux_sym_workflow_body_repeat1,
+  [aux_sym_defaults_section_repeat1] = aux_sym_defaults_section_repeat1,
+  [aux_sym_agent_node_repeat1] = aux_sym_agent_node_repeat1,
+  [aux_sym_edges_section_repeat1] = aux_sym_edges_section_repeat1,
+  [aux_sym_edge_entry_repeat1] = aux_sym_edge_entry_repeat1,
+  [aux_sym_or_expr_repeat1] = aux_sym_or_expr_repeat1,
+  [aux_sym_and_expr_repeat1] = aux_sym_and_expr_repeat1,
+  [aux_sym_stylesheet_section_repeat1] = aux_sym_stylesheet_section_repeat1,
+  [aux_sym_stylesheet_rule_repeat1] = aux_sym_stylesheet_rule_repeat1,
+  [aux_sym_block_content_repeat1] = aux_sym_block_content_repeat1,
+  [aux_sym_identifier_list_repeat1] = aux_sym_identifier_list_repeat1,
+  [aux_sym_string_repeat1] = aux_sym_string_repeat1,
+};
+
+static const TSSymbolMetadata ts_symbol_metadata[] = {
+  [ts_builtin_sym_end] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_identifier] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_workflow] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_goal] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_start] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_exit] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_COLON] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_defaults] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_agent] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_human] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_tool] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_subgraph] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_conditional] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_manager_loop] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_parallel] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DASH_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_fan_in] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LT_DASH] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_edges] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_when] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_label] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_weight] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_restart] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_or] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_and] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_not] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_EQ_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_BANG_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_contains] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_startswith] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_endswith] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_in] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DOT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_stylesheet] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_STAR] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUND] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_raw_inline] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_block_line] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_COMMA] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DQUOTE] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_string_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_string_token2] = {
+    .visible = false,
+    .named = false,
+  },
+  [sym_comment] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym__indent] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym__dedent] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym__newline] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_source_file] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_workflow_decl] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_workflow_body] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_workflow_field] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_defaults_section] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_defaults_field] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_node_decl] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_agent_node] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_human_node] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_tool_node] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_subgraph_node] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_conditional_node] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_manager_loop_node] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_parallel_node] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_fan_in_node] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_node_field] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_edges_section] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_edge_entry] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_edge_attr] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_condition] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_or_expr] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_and_expr] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_compare_expr] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_compare_op] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_operand] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_variable] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_stylesheet_section] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_stylesheet_rule] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_selector] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_field_name] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_field_value] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_multiline_block] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_block_content] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_identifier_list] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_string] = {
+    .visible = true,
+    .named = true,
+  },
+  [aux_sym_source_file_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_workflow_body_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_defaults_section_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_agent_node_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_edges_section_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_edge_entry_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_or_expr_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_and_expr_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_stylesheet_section_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_stylesheet_rule_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_block_content_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_identifier_list_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_string_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+};
+
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
+  [0] = {0},
+};
+
+static const uint16_t ts_non_terminal_alias_map[] = {
+  0,
+};
+
+static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
+  [0] = 0,
+  [1] = 1,
+  [2] = 2,
+  [3] = 3,
+  [4] = 4,
+  [5] = 5,
+  [6] = 6,
+  [7] = 7,
+  [8] = 8,
+  [9] = 9,
+  [10] = 10,
+  [11] = 11,
+  [12] = 12,
+  [13] = 13,
+  [14] = 14,
+  [15] = 15,
+  [16] = 16,
+  [17] = 17,
+  [18] = 18,
+  [19] = 19,
+  [20] = 20,
+  [21] = 21,
+  [22] = 22,
+  [23] = 23,
+  [24] = 24,
+  [25] = 25,
+  [26] = 26,
+  [27] = 27,
+  [28] = 28,
+  [29] = 29,
+  [30] = 30,
+  [31] = 31,
+  [32] = 32,
+  [33] = 33,
+  [34] = 34,
+  [35] = 35,
+  [36] = 36,
+  [37] = 37,
+  [38] = 38,
+  [39] = 39,
+  [40] = 40,
+  [41] = 41,
+  [42] = 42,
+  [43] = 43,
+  [44] = 44,
+  [45] = 45,
+  [46] = 46,
+  [47] = 47,
+  [48] = 48,
+  [49] = 49,
+  [50] = 50,
+  [51] = 51,
+  [52] = 52,
+  [53] = 53,
+  [54] = 54,
+  [55] = 55,
+  [56] = 56,
+  [57] = 57,
+  [58] = 58,
+  [59] = 59,
+  [60] = 60,
+  [61] = 61,
+  [62] = 62,
+  [63] = 63,
+  [64] = 64,
+  [65] = 65,
+  [66] = 66,
+  [67] = 67,
+  [68] = 68,
+  [69] = 69,
+  [70] = 70,
+  [71] = 71,
+  [72] = 72,
+  [73] = 73,
+  [74] = 74,
+  [75] = 75,
+  [76] = 76,
+  [77] = 77,
+  [78] = 78,
+  [79] = 79,
+  [80] = 80,
+  [81] = 81,
+  [82] = 82,
+  [83] = 83,
+  [84] = 84,
+  [85] = 85,
+  [86] = 86,
+  [87] = 87,
+  [88] = 88,
+  [89] = 89,
+  [90] = 90,
+  [91] = 91,
+  [92] = 92,
+  [93] = 93,
+  [94] = 94,
+  [95] = 95,
+  [96] = 96,
+  [97] = 97,
+  [98] = 98,
+  [99] = 99,
+  [100] = 100,
+  [101] = 101,
+  [102] = 102,
+  [103] = 103,
+  [104] = 104,
+  [105] = 105,
+  [106] = 106,
+  [107] = 107,
+  [108] = 108,
+  [109] = 109,
+  [110] = 110,
+  [111] = 111,
+  [112] = 112,
+  [113] = 113,
+  [114] = 114,
+  [115] = 115,
+  [116] = 116,
+  [117] = 117,
+  [118] = 118,
+  [119] = 119,
+  [120] = 120,
+  [121] = 121,
+  [122] = 122,
+  [123] = 123,
+  [124] = 124,
+  [125] = 125,
+  [126] = 126,
+  [127] = 127,
+  [128] = 128,
+  [129] = 129,
+  [130] = 130,
+  [131] = 131,
+  [132] = 132,
+  [133] = 133,
+  [134] = 134,
+  [135] = 135,
+  [136] = 136,
+  [137] = 137,
+  [138] = 138,
+  [139] = 139,
+  [140] = 140,
+};
+
+static bool ts_lex(TSLexer *lexer, TSStateId state) {
+  START_LEXER();
+  eof = lexer->eof(lexer);
+  switch (state) {
+    case 0:
+      if (eof) ADVANCE(9);
+      ADVANCE_MAP(
+        '!', 5,
+        '"', 25,
+        '#', 18,
+        '*', 17,
+        ',', 23,
+        '-', 6,
+        '.', 16,
+        ':', 10,
+        '<', 4,
+        '=', 15,
+        '\\', 7,
+      );
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(0);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(24);
+      END_STATE();
+    case 1:
+      if (lookahead == '"') ADVANCE(25);
+      if (lookahead == '#') ADVANCE(30);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(19);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(20);
+      END_STATE();
+    case 2:
+      if (lookahead == '"') ADVANCE(25);
+      if (lookahead == '#') ADVANCE(26);
+      if (lookahead == '\\') ADVANCE(7);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(27);
+      if (lookahead != 0) ADVANCE(28);
+      END_STATE();
+    case 3:
+      if (lookahead == '#') ADVANCE(22);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(22);
+      END_STATE();
+    case 4:
+      if (lookahead == '-') ADVANCE(12);
+      END_STATE();
+    case 5:
+      if (lookahead == '=') ADVANCE(14);
+      END_STATE();
+    case 6:
+      if (lookahead == '>') ADVANCE(11);
+      END_STATE();
+    case 7:
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(29);
+      END_STATE();
+    case 8:
+      if (eof) ADVANCE(9);
+      ADVANCE_MAP(
+        '!', 5,
+        '"', 25,
+        '#', 30,
+        ',', 23,
+        '-', 6,
+        '.', 16,
+        ':', 10,
+        '<', 4,
+        '=', 15,
+      );
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(8);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(24);
+      END_STATE();
+    case 9:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 10:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 11:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      END_STATE();
+    case 12:
+      ACCEPT_TOKEN(anon_sym_LT_DASH);
+      END_STATE();
+    case 13:
+      ACCEPT_TOKEN(anon_sym_EQ_EQ);
+      END_STATE();
+    case 14:
+      ACCEPT_TOKEN(anon_sym_BANG_EQ);
+      END_STATE();
+    case 15:
+      ACCEPT_TOKEN(anon_sym_EQ);
+      if (lookahead == '=') ADVANCE(13);
+      END_STATE();
+    case 16:
+      ACCEPT_TOKEN(anon_sym_DOT);
+      END_STATE();
+    case 17:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      END_STATE();
+    case 18:
+      ACCEPT_TOKEN(anon_sym_POUND);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(30);
+      END_STATE();
+    case 19:
+      ACCEPT_TOKEN(sym_raw_inline);
+      if (lookahead == '"') ADVANCE(25);
+      if (lookahead == '#') ADVANCE(30);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(19);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(20);
+      END_STATE();
+    case 20:
+      ACCEPT_TOKEN(sym_raw_inline);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(20);
+      END_STATE();
+    case 21:
+      ACCEPT_TOKEN(sym_block_line);
+      if (lookahead == '#') ADVANCE(22);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(21);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(22);
+      END_STATE();
+    case 22:
+      ACCEPT_TOKEN(sym_block_line);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(22);
+      END_STATE();
+    case 23:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 24:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(24);
+      END_STATE();
+    case 25:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 26:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '\n') ADVANCE(28);
+      if (lookahead == '"' ||
+          lookahead == '\\') ADVANCE(30);
+      if (lookahead != 0) ADVANCE(26);
+      END_STATE();
+    case 27:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '#') ADVANCE(26);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(27);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '#' &&
+          lookahead != '\\') ADVANCE(28);
+      END_STATE();
+    case 28:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(28);
+      END_STATE();
+    case 29:
+      ACCEPT_TOKEN(aux_sym_string_token2);
+      END_STATE();
+    case 30:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(30);
+      END_STATE();
+    default:
+      return false;
+  }
+}
+
+static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
+  START_LEXER();
+  eof = lexer->eof(lexer);
+  switch (state) {
+    case 0:
+      ADVANCE_MAP(
+        'a', 1,
+        'c', 2,
+        'd', 3,
+        'e', 4,
+        'f', 5,
+        'g', 6,
+        'h', 7,
+        'i', 8,
+        'l', 9,
+        'm', 10,
+        'n', 11,
+        'o', 12,
+        'p', 13,
+        'r', 14,
+        's', 15,
+        't', 16,
+        'w', 17,
+      );
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(0);
+      END_STATE();
+    case 1:
+      if (lookahead == 'g') ADVANCE(18);
+      if (lookahead == 'n') ADVANCE(19);
+      END_STATE();
+    case 2:
+      if (lookahead == 'o') ADVANCE(20);
+      END_STATE();
+    case 3:
+      if (lookahead == 'e') ADVANCE(21);
+      END_STATE();
+    case 4:
+      if (lookahead == 'd') ADVANCE(22);
+      if (lookahead == 'n') ADVANCE(23);
+      if (lookahead == 'x') ADVANCE(24);
+      END_STATE();
+    case 5:
+      if (lookahead == 'a') ADVANCE(25);
+      END_STATE();
+    case 6:
+      if (lookahead == 'o') ADVANCE(26);
+      END_STATE();
+    case 7:
+      if (lookahead == 'u') ADVANCE(27);
+      END_STATE();
+    case 8:
+      if (lookahead == 'n') ADVANCE(28);
+      END_STATE();
+    case 9:
+      if (lookahead == 'a') ADVANCE(29);
+      END_STATE();
+    case 10:
+      if (lookahead == 'a') ADVANCE(30);
+      END_STATE();
+    case 11:
+      if (lookahead == 'o') ADVANCE(31);
+      END_STATE();
+    case 12:
+      if (lookahead == 'r') ADVANCE(32);
+      END_STATE();
+    case 13:
+      if (lookahead == 'a') ADVANCE(33);
+      END_STATE();
+    case 14:
+      if (lookahead == 'e') ADVANCE(34);
+      END_STATE();
+    case 15:
+      if (lookahead == 't') ADVANCE(35);
+      if (lookahead == 'u') ADVANCE(36);
+      END_STATE();
+    case 16:
+      if (lookahead == 'o') ADVANCE(37);
+      END_STATE();
+    case 17:
+      if (lookahead == 'e') ADVANCE(38);
+      if (lookahead == 'h') ADVANCE(39);
+      if (lookahead == 'o') ADVANCE(40);
+      END_STATE();
+    case 18:
+      if (lookahead == 'e') ADVANCE(41);
+      END_STATE();
+    case 19:
+      if (lookahead == 'd') ADVANCE(42);
+      END_STATE();
+    case 20:
+      if (lookahead == 'n') ADVANCE(43);
+      END_STATE();
+    case 21:
+      if (lookahead == 'f') ADVANCE(44);
+      END_STATE();
+    case 22:
+      if (lookahead == 'g') ADVANCE(45);
+      END_STATE();
+    case 23:
+      if (lookahead == 'd') ADVANCE(46);
+      END_STATE();
+    case 24:
+      if (lookahead == 'i') ADVANCE(47);
+      END_STATE();
+    case 25:
+      if (lookahead == 'n') ADVANCE(48);
+      END_STATE();
+    case 26:
+      if (lookahead == 'a') ADVANCE(49);
+      END_STATE();
+    case 27:
+      if (lookahead == 'm') ADVANCE(50);
+      END_STATE();
+    case 28:
+      ACCEPT_TOKEN(anon_sym_in);
+      END_STATE();
+    case 29:
+      if (lookahead == 'b') ADVANCE(51);
+      END_STATE();
+    case 30:
+      if (lookahead == 'n') ADVANCE(52);
+      END_STATE();
+    case 31:
+      if (lookahead == 't') ADVANCE(53);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(anon_sym_or);
+      END_STATE();
+    case 33:
+      if (lookahead == 'r') ADVANCE(54);
+      END_STATE();
+    case 34:
+      if (lookahead == 's') ADVANCE(55);
+      END_STATE();
+    case 35:
+      if (lookahead == 'a') ADVANCE(56);
+      if (lookahead == 'y') ADVANCE(57);
+      END_STATE();
+    case 36:
+      if (lookahead == 'b') ADVANCE(58);
+      END_STATE();
+    case 37:
+      if (lookahead == 'o') ADVANCE(59);
+      END_STATE();
+    case 38:
+      if (lookahead == 'i') ADVANCE(60);
+      END_STATE();
+    case 39:
+      if (lookahead == 'e') ADVANCE(61);
+      END_STATE();
+    case 40:
+      if (lookahead == 'r') ADVANCE(62);
+      END_STATE();
+    case 41:
+      if (lookahead == 'n') ADVANCE(63);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(anon_sym_and);
+      END_STATE();
+    case 43:
+      if (lookahead == 'd') ADVANCE(64);
+      if (lookahead == 't') ADVANCE(65);
+      END_STATE();
+    case 44:
+      if (lookahead == 'a') ADVANCE(66);
+      END_STATE();
+    case 45:
+      if (lookahead == 'e') ADVANCE(67);
+      END_STATE();
+    case 46:
+      if (lookahead == 's') ADVANCE(68);
+      END_STATE();
+    case 47:
+      if (lookahead == 't') ADVANCE(69);
+      END_STATE();
+    case 48:
+      if (lookahead == '_') ADVANCE(70);
+      END_STATE();
+    case 49:
+      if (lookahead == 'l') ADVANCE(71);
+      END_STATE();
+    case 50:
+      if (lookahead == 'a') ADVANCE(72);
+      END_STATE();
+    case 51:
+      if (lookahead == 'e') ADVANCE(73);
+      END_STATE();
+    case 52:
+      if (lookahead == 'a') ADVANCE(74);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(anon_sym_not);
+      END_STATE();
+    case 54:
+      if (lookahead == 'a') ADVANCE(75);
+      END_STATE();
+    case 55:
+      if (lookahead == 't') ADVANCE(76);
+      END_STATE();
+    case 56:
+      if (lookahead == 'r') ADVANCE(77);
+      END_STATE();
+    case 57:
+      if (lookahead == 'l') ADVANCE(78);
+      END_STATE();
+    case 58:
+      if (lookahead == 'g') ADVANCE(79);
+      END_STATE();
+    case 59:
+      if (lookahead == 'l') ADVANCE(80);
+      END_STATE();
+    case 60:
+      if (lookahead == 'g') ADVANCE(81);
+      END_STATE();
+    case 61:
+      if (lookahead == 'n') ADVANCE(82);
+      END_STATE();
+    case 62:
+      if (lookahead == 'k') ADVANCE(83);
+      END_STATE();
+    case 63:
+      if (lookahead == 't') ADVANCE(84);
+      END_STATE();
+    case 64:
+      if (lookahead == 'i') ADVANCE(85);
+      END_STATE();
+    case 65:
+      if (lookahead == 'a') ADVANCE(86);
+      END_STATE();
+    case 66:
+      if (lookahead == 'u') ADVANCE(87);
+      END_STATE();
+    case 67:
+      if (lookahead == 's') ADVANCE(88);
+      END_STATE();
+    case 68:
+      if (lookahead == 'w') ADVANCE(89);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(anon_sym_exit);
+      END_STATE();
+    case 70:
+      if (lookahead == 'i') ADVANCE(90);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(anon_sym_goal);
+      END_STATE();
+    case 72:
+      if (lookahead == 'n') ADVANCE(91);
+      END_STATE();
+    case 73:
+      if (lookahead == 'l') ADVANCE(92);
+      END_STATE();
+    case 74:
+      if (lookahead == 'g') ADVANCE(93);
+      END_STATE();
+    case 75:
+      if (lookahead == 'l') ADVANCE(94);
+      END_STATE();
+    case 76:
+      if (lookahead == 'a') ADVANCE(95);
+      END_STATE();
+    case 77:
+      if (lookahead == 't') ADVANCE(96);
+      END_STATE();
+    case 78:
+      if (lookahead == 'e') ADVANCE(97);
+      END_STATE();
+    case 79:
+      if (lookahead == 'r') ADVANCE(98);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(anon_sym_tool);
+      END_STATE();
+    case 81:
+      if (lookahead == 'h') ADVANCE(99);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(anon_sym_when);
+      END_STATE();
+    case 83:
+      if (lookahead == 'f') ADVANCE(100);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(anon_sym_agent);
+      END_STATE();
+    case 85:
+      if (lookahead == 't') ADVANCE(101);
+      END_STATE();
+    case 86:
+      if (lookahead == 'i') ADVANCE(102);
+      END_STATE();
+    case 87:
+      if (lookahead == 'l') ADVANCE(103);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(anon_sym_edges);
+      END_STATE();
+    case 89:
+      if (lookahead == 'i') ADVANCE(104);
+      END_STATE();
+    case 90:
+      if (lookahead == 'n') ADVANCE(105);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(anon_sym_human);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(anon_sym_label);
+      END_STATE();
+    case 93:
+      if (lookahead == 'e') ADVANCE(106);
+      END_STATE();
+    case 94:
+      if (lookahead == 'l') ADVANCE(107);
+      END_STATE();
+    case 95:
+      if (lookahead == 'r') ADVANCE(108);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(anon_sym_start);
+      if (lookahead == 's') ADVANCE(109);
+      END_STATE();
+    case 97:
+      if (lookahead == 's') ADVANCE(110);
+      END_STATE();
+    case 98:
+      if (lookahead == 'a') ADVANCE(111);
+      END_STATE();
+    case 99:
+      if (lookahead == 't') ADVANCE(112);
+      END_STATE();
+    case 100:
+      if (lookahead == 'l') ADVANCE(113);
+      END_STATE();
+    case 101:
+      if (lookahead == 'i') ADVANCE(114);
+      END_STATE();
+    case 102:
+      if (lookahead == 'n') ADVANCE(115);
+      END_STATE();
+    case 103:
+      if (lookahead == 't') ADVANCE(116);
+      END_STATE();
+    case 104:
+      if (lookahead == 't') ADVANCE(117);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(anon_sym_fan_in);
+      END_STATE();
+    case 106:
+      if (lookahead == 'r') ADVANCE(118);
+      END_STATE();
+    case 107:
+      if (lookahead == 'e') ADVANCE(119);
+      END_STATE();
+    case 108:
+      if (lookahead == 't') ADVANCE(120);
+      END_STATE();
+    case 109:
+      if (lookahead == 'w') ADVANCE(121);
+      END_STATE();
+    case 110:
+      if (lookahead == 'h') ADVANCE(122);
+      END_STATE();
+    case 111:
+      if (lookahead == 'p') ADVANCE(123);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(anon_sym_weight);
+      END_STATE();
+    case 113:
+      if (lookahead == 'o') ADVANCE(124);
+      END_STATE();
+    case 114:
+      if (lookahead == 'o') ADVANCE(125);
+      END_STATE();
+    case 115:
+      if (lookahead == 's') ADVANCE(126);
+      END_STATE();
+    case 116:
+      if (lookahead == 's') ADVANCE(127);
+      END_STATE();
+    case 117:
+      if (lookahead == 'h') ADVANCE(128);
+      END_STATE();
+    case 118:
+      if (lookahead == '_') ADVANCE(129);
+      END_STATE();
+    case 119:
+      if (lookahead == 'l') ADVANCE(130);
+      END_STATE();
+    case 120:
+      ACCEPT_TOKEN(anon_sym_restart);
+      END_STATE();
+    case 121:
+      if (lookahead == 'i') ADVANCE(131);
+      END_STATE();
+    case 122:
+      if (lookahead == 'e') ADVANCE(132);
+      END_STATE();
+    case 123:
+      if (lookahead == 'h') ADVANCE(133);
+      END_STATE();
+    case 124:
+      if (lookahead == 'w') ADVANCE(134);
+      END_STATE();
+    case 125:
+      if (lookahead == 'n') ADVANCE(135);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(anon_sym_contains);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(anon_sym_defaults);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(anon_sym_endswith);
+      END_STATE();
+    case 129:
+      if (lookahead == 'l') ADVANCE(136);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(anon_sym_parallel);
+      END_STATE();
+    case 131:
+      if (lookahead == 't') ADVANCE(137);
+      END_STATE();
+    case 132:
+      if (lookahead == 'e') ADVANCE(138);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(anon_sym_subgraph);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(anon_sym_workflow);
+      END_STATE();
+    case 135:
+      if (lookahead == 'a') ADVANCE(139);
+      END_STATE();
+    case 136:
+      if (lookahead == 'o') ADVANCE(140);
+      END_STATE();
+    case 137:
+      if (lookahead == 'h') ADVANCE(141);
+      END_STATE();
+    case 138:
+      if (lookahead == 't') ADVANCE(142);
+      END_STATE();
+    case 139:
+      if (lookahead == 'l') ADVANCE(143);
+      END_STATE();
+    case 140:
+      if (lookahead == 'o') ADVANCE(144);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(anon_sym_startswith);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(anon_sym_stylesheet);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(anon_sym_conditional);
+      END_STATE();
+    case 144:
+      if (lookahead == 'p') ADVANCE(145);
+      END_STATE();
+    case 145:
+      ACCEPT_TOKEN(anon_sym_manager_loop);
+      END_STATE();
+    default:
+      return false;
+  }
+}
+
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
+  [0] = {.lex_state = 0, .external_lex_state = 1},
+  [1] = {.lex_state = 8, .external_lex_state = 2},
+  [2] = {.lex_state = 8, .external_lex_state = 3},
+  [3] = {.lex_state = 8, .external_lex_state = 3},
+  [4] = {.lex_state = 8, .external_lex_state = 3},
+  [5] = {.lex_state = 8, .external_lex_state = 3},
+  [6] = {.lex_state = 8, .external_lex_state = 2},
+  [7] = {.lex_state = 8, .external_lex_state = 3},
+  [8] = {.lex_state = 8, .external_lex_state = 3},
+  [9] = {.lex_state = 8, .external_lex_state = 3},
+  [10] = {.lex_state = 8, .external_lex_state = 3},
+  [11] = {.lex_state = 8, .external_lex_state = 3},
+  [12] = {.lex_state = 8, .external_lex_state = 3},
+  [13] = {.lex_state = 8, .external_lex_state = 3},
+  [14] = {.lex_state = 8, .external_lex_state = 3},
+  [15] = {.lex_state = 8, .external_lex_state = 3},
+  [16] = {.lex_state = 8, .external_lex_state = 3},
+  [17] = {.lex_state = 8, .external_lex_state = 3},
+  [18] = {.lex_state = 8, .external_lex_state = 3},
+  [19] = {.lex_state = 8, .external_lex_state = 3},
+  [20] = {.lex_state = 8, .external_lex_state = 3},
+  [21] = {.lex_state = 8, .external_lex_state = 3},
+  [22] = {.lex_state = 8, .external_lex_state = 3},
+  [23] = {.lex_state = 8, .external_lex_state = 3},
+  [24] = {.lex_state = 8, .external_lex_state = 3},
+  [25] = {.lex_state = 8, .external_lex_state = 3},
+  [26] = {.lex_state = 8, .external_lex_state = 3},
+  [27] = {.lex_state = 8, .external_lex_state = 3},
+  [28] = {.lex_state = 8, .external_lex_state = 3},
+  [29] = {.lex_state = 0, .external_lex_state = 3},
+  [30] = {.lex_state = 8, .external_lex_state = 3},
+  [31] = {.lex_state = 8, .external_lex_state = 3},
+  [32] = {.lex_state = 8, .external_lex_state = 3},
+  [33] = {.lex_state = 0, .external_lex_state = 3},
+  [34] = {.lex_state = 8, .external_lex_state = 3},
+  [35] = {.lex_state = 8},
+  [36] = {.lex_state = 8, .external_lex_state = 3},
+  [37] = {.lex_state = 8, .external_lex_state = 3},
+  [38] = {.lex_state = 8, .external_lex_state = 3},
+  [39] = {.lex_state = 8, .external_lex_state = 3},
+  [40] = {.lex_state = 8, .external_lex_state = 3},
+  [41] = {.lex_state = 0, .external_lex_state = 2},
+  [42] = {.lex_state = 8},
+  [43] = {.lex_state = 8, .external_lex_state = 3},
+  [44] = {.lex_state = 8, .external_lex_state = 3},
+  [45] = {.lex_state = 8},
+  [46] = {.lex_state = 8, .external_lex_state = 3},
+  [47] = {.lex_state = 8, .external_lex_state = 3},
+  [48] = {.lex_state = 8, .external_lex_state = 3},
+  [49] = {.lex_state = 1, .external_lex_state = 4},
+  [50] = {.lex_state = 8, .external_lex_state = 3},
+  [51] = {.lex_state = 8, .external_lex_state = 3},
+  [52] = {.lex_state = 1, .external_lex_state = 4},
+  [53] = {.lex_state = 0, .external_lex_state = 3},
+  [54] = {.lex_state = 8, .external_lex_state = 3},
+  [55] = {.lex_state = 8},
+  [56] = {.lex_state = 8, .external_lex_state = 3},
+  [57] = {.lex_state = 8, .external_lex_state = 3},
+  [58] = {.lex_state = 1, .external_lex_state = 4},
+  [59] = {.lex_state = 1, .external_lex_state = 4},
+  [60] = {.lex_state = 8, .external_lex_state = 3},
+  [61] = {.lex_state = 8, .external_lex_state = 3},
+  [62] = {.lex_state = 8, .external_lex_state = 3},
+  [63] = {.lex_state = 1, .external_lex_state = 4},
+  [64] = {.lex_state = 8, .external_lex_state = 3},
+  [65] = {.lex_state = 8},
+  [66] = {.lex_state = 8, .external_lex_state = 2},
+  [67] = {.lex_state = 8, .external_lex_state = 3},
+  [68] = {.lex_state = 8},
+  [69] = {.lex_state = 8, .external_lex_state = 2},
+  [70] = {.lex_state = 8, .external_lex_state = 2},
+  [71] = {.lex_state = 8, .external_lex_state = 2},
+  [72] = {.lex_state = 8, .external_lex_state = 2},
+  [73] = {.lex_state = 8, .external_lex_state = 2},
+  [74] = {.lex_state = 8, .external_lex_state = 2},
+  [75] = {.lex_state = 8, .external_lex_state = 3},
+  [76] = {.lex_state = 8, .external_lex_state = 3},
+  [77] = {.lex_state = 3, .external_lex_state = 3},
+  [78] = {.lex_state = 8, .external_lex_state = 2},
+  [79] = {.lex_state = 2},
+  [80] = {.lex_state = 8, .external_lex_state = 2},
+  [81] = {.lex_state = 8, .external_lex_state = 2},
+  [82] = {.lex_state = 3, .external_lex_state = 2},
+  [83] = {.lex_state = 2},
+  [84] = {.lex_state = 3, .external_lex_state = 3},
+  [85] = {.lex_state = 2},
+  [86] = {.lex_state = 8, .external_lex_state = 3},
+  [87] = {.lex_state = 8, .external_lex_state = 2},
+  [88] = {.lex_state = 8, .external_lex_state = 2},
+  [89] = {.lex_state = 8, .external_lex_state = 3},
+  [90] = {.lex_state = 8, .external_lex_state = 2},
+  [91] = {.lex_state = 8, .external_lex_state = 2},
+  [92] = {.lex_state = 8, .external_lex_state = 3},
+  [93] = {.lex_state = 8, .external_lex_state = 2},
+  [94] = {.lex_state = 8},
+  [95] = {.lex_state = 8},
+  [96] = {.lex_state = 8},
+  [97] = {.lex_state = 8},
+  [98] = {.lex_state = 8, .external_lex_state = 4},
+  [99] = {.lex_state = 8},
+  [100] = {.lex_state = 8},
+  [101] = {.lex_state = 8, .external_lex_state = 4},
+  [102] = {.lex_state = 8, .external_lex_state = 5},
+  [103] = {.lex_state = 8},
+  [104] = {.lex_state = 8, .external_lex_state = 4},
+  [105] = {.lex_state = 8, .external_lex_state = 4},
+  [106] = {.lex_state = 8},
+  [107] = {.lex_state = 8},
+  [108] = {.lex_state = 8},
+  [109] = {.lex_state = 8},
+  [110] = {.lex_state = 8},
+  [111] = {.lex_state = 8},
+  [112] = {.lex_state = 8},
+  [113] = {.lex_state = 8},
+  [114] = {.lex_state = 8},
+  [115] = {.lex_state = 8},
+  [116] = {.lex_state = 8, .external_lex_state = 4},
+  [117] = {.lex_state = 8},
+  [118] = {.lex_state = 8, .external_lex_state = 2},
+  [119] = {.lex_state = 8, .external_lex_state = 4},
+  [120] = {.lex_state = 8, .external_lex_state = 4},
+  [121] = {.lex_state = 8, .external_lex_state = 4},
+  [122] = {.lex_state = 8},
+  [123] = {.lex_state = 8, .external_lex_state = 4},
+  [124] = {.lex_state = 8, .external_lex_state = 4},
+  [125] = {.lex_state = 8},
+  [126] = {.lex_state = 8, .external_lex_state = 4},
+  [127] = {.lex_state = 8},
+  [128] = {.lex_state = 8},
+  [129] = {.lex_state = 8},
+  [130] = {.lex_state = 8, .external_lex_state = 5},
+  [131] = {.lex_state = 8, .external_lex_state = 2},
+  [132] = {.lex_state = 8},
+  [133] = {.lex_state = 8, .external_lex_state = 4},
+  [134] = {.lex_state = 8},
+  [135] = {.lex_state = 8},
+  [136] = {.lex_state = 8},
+  [137] = {.lex_state = 8, .external_lex_state = 4},
+  [138] = {.lex_state = 8},
+  [139] = {.lex_state = 8},
+  [140] = {.lex_state = 8},
+};
+
+static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
+  [0] = {
+    [ts_builtin_sym_end] = ACTIONS(1),
+    [sym_identifier] = ACTIONS(1),
+    [anon_sym_workflow] = ACTIONS(1),
+    [anon_sym_goal] = ACTIONS(1),
+    [anon_sym_start] = ACTIONS(1),
+    [anon_sym_exit] = ACTIONS(1),
+    [anon_sym_COLON] = ACTIONS(1),
+    [anon_sym_defaults] = ACTIONS(1),
+    [anon_sym_agent] = ACTIONS(1),
+    [anon_sym_human] = ACTIONS(1),
+    [anon_sym_tool] = ACTIONS(1),
+    [anon_sym_subgraph] = ACTIONS(1),
+    [anon_sym_conditional] = ACTIONS(1),
+    [anon_sym_manager_loop] = ACTIONS(1),
+    [anon_sym_parallel] = ACTIONS(1),
+    [anon_sym_DASH_GT] = ACTIONS(1),
+    [anon_sym_fan_in] = ACTIONS(1),
+    [anon_sym_LT_DASH] = ACTIONS(1),
+    [anon_sym_edges] = ACTIONS(1),
+    [anon_sym_when] = ACTIONS(1),
+    [anon_sym_label] = ACTIONS(1),
+    [anon_sym_weight] = ACTIONS(1),
+    [anon_sym_restart] = ACTIONS(1),
+    [anon_sym_or] = ACTIONS(1),
+    [anon_sym_and] = ACTIONS(1),
+    [anon_sym_not] = ACTIONS(1),
+    [anon_sym_EQ_EQ] = ACTIONS(1),
+    [anon_sym_BANG_EQ] = ACTIONS(1),
+    [anon_sym_EQ] = ACTIONS(1),
+    [anon_sym_contains] = ACTIONS(1),
+    [anon_sym_startswith] = ACTIONS(1),
+    [anon_sym_endswith] = ACTIONS(1),
+    [anon_sym_in] = ACTIONS(1),
+    [anon_sym_DOT] = ACTIONS(1),
+    [anon_sym_stylesheet] = ACTIONS(1),
+    [anon_sym_STAR] = ACTIONS(1),
+    [anon_sym_POUND] = ACTIONS(1),
+    [anon_sym_COMMA] = ACTIONS(1),
+    [anon_sym_DQUOTE] = ACTIONS(1),
+    [aux_sym_string_token2] = ACTIONS(1),
+    [sym_comment] = ACTIONS(3),
+    [sym__indent] = ACTIONS(1),
+    [sym__dedent] = ACTIONS(1),
+    [sym__newline] = ACTIONS(1),
+  },
+  [1] = {
+    [sym_source_file] = STATE(109),
+    [sym_workflow_decl] = STATE(110),
+    [aux_sym_source_file_repeat1] = STATE(78),
+    [anon_sym_workflow] = ACTIONS(5),
+    [sym_comment] = ACTIONS(7),
+    [sym__newline] = ACTIONS(9),
+  },
+};
+
+static const uint16_t ts_small_parse_table[] = {
+  [0] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(13), 4,
+      sym__dedent,
+      sym__newline,
+      anon_sym_EQ_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(11), 27,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      anon_sym_not,
+      anon_sym_EQ,
+      anon_sym_contains,
+      anon_sym_startswith,
+      anon_sym_endswith,
+      anon_sym_in,
+      anon_sym_stylesheet,
+      sym_identifier,
+  [39] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(17), 4,
+      sym__dedent,
+      sym__newline,
+      anon_sym_EQ_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(15), 27,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      anon_sym_not,
+      anon_sym_EQ,
+      anon_sym_contains,
+      anon_sym_startswith,
+      anon_sym_endswith,
+      anon_sym_in,
+      anon_sym_stylesheet,
+      sym_identifier,
+  [78] = 17,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(21), 1,
+      anon_sym_defaults,
+    ACTIONS(23), 1,
+      anon_sym_agent,
+    ACTIONS(25), 1,
+      anon_sym_human,
+    ACTIONS(27), 1,
+      anon_sym_tool,
+    ACTIONS(29), 1,
+      anon_sym_subgraph,
+    ACTIONS(31), 1,
+      anon_sym_conditional,
+    ACTIONS(33), 1,
+      anon_sym_manager_loop,
+    ACTIONS(35), 1,
+      anon_sym_parallel,
+    ACTIONS(37), 1,
+      anon_sym_fan_in,
+    ACTIONS(39), 1,
+      anon_sym_edges,
+    ACTIONS(41), 1,
+      anon_sym_stylesheet,
+    ACTIONS(43), 1,
+      sym__dedent,
+    ACTIONS(45), 1,
+      sym__newline,
+    ACTIONS(19), 3,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+    STATE(5), 6,
+      sym_workflow_field,
+      sym_defaults_section,
+      sym_node_decl,
+      sym_edges_section,
+      sym_stylesheet_section,
+      aux_sym_workflow_body_repeat1,
+    STATE(16), 8,
+      sym_agent_node,
+      sym_human_node,
+      sym_tool_node,
+      sym_subgraph_node,
+      sym_conditional_node,
+      sym_manager_loop_node,
+      sym_parallel_node,
+      sym_fan_in_node,
+  [144] = 17,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(50), 1,
+      anon_sym_defaults,
+    ACTIONS(53), 1,
+      anon_sym_agent,
+    ACTIONS(56), 1,
+      anon_sym_human,
+    ACTIONS(59), 1,
+      anon_sym_tool,
+    ACTIONS(62), 1,
+      anon_sym_subgraph,
+    ACTIONS(65), 1,
+      anon_sym_conditional,
+    ACTIONS(68), 1,
+      anon_sym_manager_loop,
+    ACTIONS(71), 1,
+      anon_sym_parallel,
+    ACTIONS(74), 1,
+      anon_sym_fan_in,
+    ACTIONS(77), 1,
+      anon_sym_edges,
+    ACTIONS(80), 1,
+      anon_sym_stylesheet,
+    ACTIONS(83), 1,
+      sym__dedent,
+    ACTIONS(85), 1,
+      sym__newline,
+    ACTIONS(47), 3,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+    STATE(5), 6,
+      sym_workflow_field,
+      sym_defaults_section,
+      sym_node_decl,
+      sym_edges_section,
+      sym_stylesheet_section,
+      aux_sym_workflow_body_repeat1,
+    STATE(16), 8,
+      sym_agent_node,
+      sym_human_node,
+      sym_tool_node,
+      sym_subgraph_node,
+      sym_conditional_node,
+      sym_manager_loop_node,
+      sym_parallel_node,
+      sym_fan_in_node,
+  [210] = 17,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(21), 1,
+      anon_sym_defaults,
+    ACTIONS(23), 1,
+      anon_sym_agent,
+    ACTIONS(25), 1,
+      anon_sym_human,
+    ACTIONS(27), 1,
+      anon_sym_tool,
+    ACTIONS(29), 1,
+      anon_sym_subgraph,
+    ACTIONS(31), 1,
+      anon_sym_conditional,
+    ACTIONS(33), 1,
+      anon_sym_manager_loop,
+    ACTIONS(35), 1,
+      anon_sym_parallel,
+    ACTIONS(37), 1,
+      anon_sym_fan_in,
+    ACTIONS(39), 1,
+      anon_sym_edges,
+    ACTIONS(41), 1,
+      anon_sym_stylesheet,
+    ACTIONS(88), 1,
+      sym__newline,
+    STATE(102), 1,
+      sym_workflow_body,
+    ACTIONS(19), 3,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+    STATE(4), 6,
+      sym_workflow_field,
+      sym_defaults_section,
+      sym_node_decl,
+      sym_edges_section,
+      sym_stylesheet_section,
+      aux_sym_workflow_body_repeat1,
+    STATE(16), 8,
+      sym_agent_node,
+      sym_human_node,
+      sym_tool_node,
+      sym_subgraph_node,
+      sym_conditional_node,
+      sym_manager_loop_node,
+      sym_parallel_node,
+      sym_fan_in_node,
+  [276] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(92), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(90), 19,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_stylesheet,
+      sym_identifier,
+  [305] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(96), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(94), 19,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_stylesheet,
+      sym_identifier,
+  [334] = 4,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(102), 1,
+      anon_sym_DOT,
+    ACTIONS(100), 4,
+      sym__dedent,
+      sym__newline,
+      anon_sym_EQ_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(98), 13,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      anon_sym_not,
+      anon_sym_EQ,
+      anon_sym_contains,
+      anon_sym_startswith,
+      anon_sym_endswith,
+      anon_sym_in,
+      sym_identifier,
+  [362] = 7,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(106), 1,
+      anon_sym_not,
+    STATE(68), 1,
+      sym_compare_op,
+    ACTIONS(108), 2,
+      anon_sym_EQ_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(112), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(110), 5,
+      anon_sym_EQ,
+      anon_sym_contains,
+      anon_sym_startswith,
+      anon_sym_endswith,
+      anon_sym_in,
+    ACTIONS(104), 7,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      sym_identifier,
+  [396] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(100), 4,
+      sym__dedent,
+      sym__newline,
+      anon_sym_EQ_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(98), 13,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      anon_sym_not,
+      anon_sym_EQ,
+      anon_sym_contains,
+      anon_sym_startswith,
+      anon_sym_endswith,
+      anon_sym_in,
+      sym_identifier,
+  [421] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(116), 4,
+      sym__dedent,
+      sym__newline,
+      anon_sym_EQ_EQ,
+      anon_sym_BANG_EQ,
+    ACTIONS(114), 13,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      anon_sym_not,
+      anon_sym_EQ,
+      anon_sym_contains,
+      anon_sym_startswith,
+      anon_sym_endswith,
+      anon_sym_in,
+      sym_identifier,
+  [446] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(118), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [468] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(120), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [490] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(122), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [512] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(124), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [534] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(126), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [556] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(128), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [578] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(130), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [600] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(132), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [622] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(134), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [644] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(136), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [666] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(138), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [688] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(140), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [710] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(142), 16,
+      sym__dedent,
+      sym__newline,
+      anon_sym_goal,
+      anon_sym_start,
+      anon_sym_exit,
+      anon_sym_defaults,
+      anon_sym_agent,
+      anon_sym_human,
+      anon_sym_tool,
+      anon_sym_subgraph,
+      anon_sym_conditional,
+      anon_sym_manager_loop,
+      anon_sym_parallel,
+      anon_sym_fan_in,
+      anon_sym_edges,
+      anon_sym_stylesheet,
+  [732] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(146), 1,
+      anon_sym_and,
+    STATE(28), 1,
+      aux_sym_and_expr_repeat1,
+    ACTIONS(148), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(144), 6,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      sym_identifier,
+  [754] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(146), 1,
+      anon_sym_and,
+    STATE(26), 1,
+      aux_sym_and_expr_repeat1,
+    ACTIONS(152), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(150), 6,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      sym_identifier,
+  [776] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(156), 1,
+      anon_sym_and,
+    STATE(28), 1,
+      aux_sym_and_expr_repeat1,
+    ACTIONS(159), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(154), 6,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      sym_identifier,
+  [798] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(163), 1,
+      anon_sym_DOT,
+    ACTIONS(165), 1,
+      anon_sym_POUND,
+    ACTIONS(167), 1,
+      sym__dedent,
+    ACTIONS(169), 1,
+      sym__newline,
+    STATE(105), 1,
+      sym_selector,
+    ACTIONS(161), 2,
+      anon_sym_STAR,
+      sym_identifier,
+    STATE(33), 2,
+      sym_stylesheet_rule,
+      aux_sym_stylesheet_section_repeat1,
+  [825] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(173), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(171), 7,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      sym_identifier,
+  [842] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(175), 1,
+      sym_identifier,
+    ACTIONS(177), 1,
+      anon_sym_when,
+    ACTIONS(181), 2,
+      sym__dedent,
+      sym__newline,
+    STATE(34), 2,
+      sym_edge_attr,
+      aux_sym_edge_entry_repeat1,
+    ACTIONS(179), 3,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+  [865] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(185), 1,
+      anon_sym_or,
+    STATE(36), 1,
+      aux_sym_or_expr_repeat1,
+    ACTIONS(187), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(183), 5,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      sym_identifier,
+  [886] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(192), 1,
+      anon_sym_DOT,
+    ACTIONS(195), 1,
+      anon_sym_POUND,
+    ACTIONS(198), 1,
+      sym__dedent,
+    ACTIONS(200), 1,
+      sym__newline,
+    STATE(105), 1,
+      sym_selector,
+    ACTIONS(189), 2,
+      anon_sym_STAR,
+      sym_identifier,
+    STATE(33), 2,
+      sym_stylesheet_rule,
+      aux_sym_stylesheet_section_repeat1,
+  [913] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(177), 1,
+      anon_sym_when,
+    ACTIONS(203), 1,
+      sym_identifier,
+    ACTIONS(205), 2,
+      sym__dedent,
+      sym__newline,
+    STATE(37), 2,
+      sym_edge_attr,
+      aux_sym_edge_entry_repeat1,
+    ACTIONS(179), 3,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+  [936] = 9,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(207), 1,
+      sym_identifier,
+    ACTIONS(209), 1,
+      anon_sym_DQUOTE,
+    STATE(10), 1,
+      sym_operand,
+    STATE(27), 1,
+      sym_compare_expr,
+    STATE(32), 1,
+      sym_and_expr,
+    STATE(46), 1,
+      sym_condition,
+    STATE(47), 1,
+      sym_or_expr,
+    STATE(11), 2,
+      sym_variable,
+      sym_string,
+  [965] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(185), 1,
+      anon_sym_or,
+    STATE(39), 1,
+      aux_sym_or_expr_repeat1,
+    ACTIONS(213), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(211), 5,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      sym_identifier,
+  [986] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(215), 1,
+      sym_identifier,
+    ACTIONS(217), 1,
+      anon_sym_when,
+    ACTIONS(223), 2,
+      sym__dedent,
+      sym__newline,
+    STATE(37), 2,
+      sym_edge_attr,
+      aux_sym_edge_entry_repeat1,
+    ACTIONS(220), 3,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+  [1009] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(159), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(154), 7,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      sym_identifier,
+  [1026] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(227), 1,
+      anon_sym_or,
+    STATE(39), 1,
+      aux_sym_or_expr_repeat1,
+    ACTIONS(230), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(225), 5,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      sym_identifier,
+  [1047] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(234), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(232), 7,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      anon_sym_and,
+      sym_identifier,
+  [1064] = 7,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(163), 1,
+      anon_sym_DOT,
+    ACTIONS(165), 1,
+      anon_sym_POUND,
+    ACTIONS(236), 1,
+      sym__newline,
+    STATE(105), 1,
+      sym_selector,
+    ACTIONS(161), 2,
+      anon_sym_STAR,
+      sym_identifier,
+    STATE(29), 2,
+      sym_stylesheet_rule,
+      aux_sym_stylesheet_section_repeat1,
+  [1088] = 4,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(110), 1,
+      anon_sym_EQ,
+    STATE(65), 1,
+      sym_compare_op,
+    ACTIONS(108), 6,
+      anon_sym_EQ_EQ,
+      anon_sym_BANG_EQ,
+      anon_sym_contains,
+      anon_sym_startswith,
+      anon_sym_endswith,
+      anon_sym_in,
+  [1106] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(230), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(225), 6,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      anon_sym_or,
+      sym_identifier,
+  [1122] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(240), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(238), 5,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      sym_identifier,
+  [1137] = 7,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(207), 1,
+      sym_identifier,
+    ACTIONS(209), 1,
+      anon_sym_DQUOTE,
+    STATE(10), 1,
+      sym_operand,
+    STATE(27), 1,
+      sym_compare_expr,
+    STATE(43), 1,
+      sym_and_expr,
+    STATE(11), 2,
+      sym_variable,
+      sym_string,
+  [1160] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(244), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(242), 5,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      sym_identifier,
+  [1175] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(248), 2,
+      sym__dedent,
+      sym__newline,
+    ACTIONS(246), 5,
+      anon_sym_when,
+      anon_sym_label,
+      anon_sym_weight,
+      anon_sym_restart,
+      sym_identifier,
+  [1190] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(252), 1,
+      sym__dedent,
+    ACTIONS(254), 1,
+      sym__newline,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(62), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1210] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(256), 1,
+      sym_raw_inline,
+    ACTIONS(258), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(260), 1,
+      sym__indent,
+    STATE(44), 1,
+      sym_field_value,
+    STATE(7), 2,
+      sym_multiline_block,
+      sym_string,
+  [1230] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(254), 1,
+      sym__newline,
+    ACTIONS(262), 1,
+      sym__dedent,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(62), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1250] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(254), 1,
+      sym__newline,
+    ACTIONS(264), 1,
+      sym__dedent,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(62), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1270] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(256), 1,
+      sym_raw_inline,
+    ACTIONS(258), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(260), 1,
+      sym__indent,
+    STATE(92), 1,
+      sym_field_value,
+    STATE(7), 2,
+      sym_multiline_block,
+      sym_string,
+  [1290] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(268), 1,
+      anon_sym_POUND,
+    ACTIONS(266), 5,
+      sym__dedent,
+      sym__newline,
+      anon_sym_DOT,
+      anon_sym_STAR,
+      sym_identifier,
+  [1304] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(270), 1,
+      sym__dedent,
+    ACTIONS(272), 1,
+      sym__newline,
+    STATE(113), 1,
+      sym_field_name,
+    STATE(57), 2,
+      sym_defaults_field,
+      aux_sym_defaults_section_repeat1,
+  [1324] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(207), 1,
+      sym_identifier,
+    ACTIONS(209), 1,
+      anon_sym_DQUOTE,
+    STATE(10), 1,
+      sym_operand,
+    STATE(38), 1,
+      sym_compare_expr,
+    STATE(11), 2,
+      sym_variable,
+      sym_string,
+  [1344] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(254), 1,
+      sym__newline,
+    ACTIONS(274), 1,
+      sym__dedent,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(62), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1364] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(276), 1,
+      sym_identifier,
+    ACTIONS(279), 1,
+      sym__dedent,
+    ACTIONS(281), 1,
+      sym__newline,
+    STATE(113), 1,
+      sym_field_name,
+    STATE(57), 2,
+      sym_defaults_field,
+      aux_sym_defaults_section_repeat1,
+  [1384] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(256), 1,
+      sym_raw_inline,
+    ACTIONS(258), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(260), 1,
+      sym__indent,
+    STATE(89), 1,
+      sym_field_value,
+    STATE(7), 2,
+      sym_multiline_block,
+      sym_string,
+  [1404] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(256), 1,
+      sym_raw_inline,
+    ACTIONS(258), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(260), 1,
+      sym__indent,
+    STATE(13), 1,
+      sym_field_value,
+    STATE(7), 2,
+      sym_multiline_block,
+      sym_string,
+  [1424] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(254), 1,
+      sym__newline,
+    ACTIONS(284), 1,
+      sym__dedent,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(62), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1444] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(254), 1,
+      sym__newline,
+    ACTIONS(286), 1,
+      sym__dedent,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(62), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1464] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(288), 1,
+      sym_identifier,
+    ACTIONS(291), 1,
+      sym__dedent,
+    ACTIONS(293), 1,
+      sym__newline,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(62), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1484] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(256), 1,
+      sym_raw_inline,
+    ACTIONS(258), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(260), 1,
+      sym__indent,
+    STATE(86), 1,
+      sym_field_value,
+    STATE(7), 2,
+      sym_multiline_block,
+      sym_string,
+  [1504] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(296), 1,
+      sym_identifier,
+    ACTIONS(299), 1,
+      sym__dedent,
+    ACTIONS(301), 1,
+      sym__newline,
+    STATE(64), 2,
+      sym_edge_entry,
+      aux_sym_edges_section_repeat1,
+  [1521] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(207), 1,
+      sym_identifier,
+    ACTIONS(209), 1,
+      anon_sym_DQUOTE,
+    STATE(30), 1,
+      sym_operand,
+    STATE(11), 2,
+      sym_variable,
+      sym_string,
+  [1538] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(304), 1,
+      sym__newline,
+    STATE(113), 1,
+      sym_field_name,
+    STATE(54), 2,
+      sym_defaults_field,
+      aux_sym_defaults_section_repeat1,
+  [1555] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(306), 1,
+      sym__dedent,
+    ACTIONS(308), 1,
+      sym__newline,
+    STATE(75), 1,
+      aux_sym_stylesheet_rule_repeat1,
+    STATE(108), 1,
+      sym_field_name,
+  [1574] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(207), 1,
+      sym_identifier,
+    ACTIONS(209), 1,
+      anon_sym_DQUOTE,
+    STATE(40), 1,
+      sym_operand,
+    STATE(11), 2,
+      sym_variable,
+      sym_string,
+  [1591] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(310), 1,
+      sym__newline,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(60), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1608] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(312), 1,
+      sym__newline,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(48), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1625] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(314), 1,
+      sym__newline,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(61), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1642] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(316), 1,
+      sym__newline,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(51), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1659] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(318), 1,
+      sym__newline,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(50), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1676] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(320), 1,
+      sym__newline,
+    STATE(139), 1,
+      sym_field_name,
+    STATE(56), 2,
+      sym_node_field,
+      aux_sym_agent_node_repeat1,
+  [1693] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(322), 1,
+      sym_identifier,
+    ACTIONS(325), 1,
+      sym__dedent,
+    ACTIONS(327), 1,
+      sym__newline,
+    STATE(75), 1,
+      aux_sym_stylesheet_rule_repeat1,
+    STATE(108), 1,
+      sym_field_name,
+  [1712] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(330), 1,
+      sym_identifier,
+    ACTIONS(332), 1,
+      sym__dedent,
+    ACTIONS(334), 1,
+      sym__newline,
+    STATE(64), 2,
+      sym_edge_entry,
+      aux_sym_edges_section_repeat1,
+  [1729] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(339), 1,
+      sym__dedent,
+    STATE(77), 1,
+      aux_sym_block_content_repeat1,
+    ACTIONS(336), 2,
+      sym__newline,
+      sym_block_line,
+  [1743] = 5,
+    ACTIONS(5), 1,
+      anon_sym_workflow,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(341), 1,
+      sym__newline,
+    STATE(91), 1,
+      aux_sym_source_file_repeat1,
+    STATE(97), 1,
+      sym_workflow_decl,
+  [1759] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(343), 1,
+      anon_sym_DQUOTE,
+    STATE(79), 1,
+      aux_sym_string_repeat1,
+    ACTIONS(345), 2,
+      aux_sym_string_token1,
+      aux_sym_string_token2,
+  [1773] = 5,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(348), 1,
+      sym__newline,
+    STATE(67), 1,
+      aux_sym_stylesheet_rule_repeat1,
+    STATE(108), 1,
+      sym_field_name,
+  [1789] = 4,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(330), 1,
+      sym_identifier,
+    ACTIONS(350), 1,
+      sym__newline,
+    STATE(76), 2,
+      sym_edge_entry,
+      aux_sym_edges_section_repeat1,
+  [1803] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    STATE(84), 1,
+      aux_sym_block_content_repeat1,
+    STATE(130), 1,
+      sym_block_content,
+    ACTIONS(352), 2,
+      sym__newline,
+      sym_block_line,
+  [1817] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(354), 1,
+      anon_sym_DQUOTE,
+    STATE(85), 1,
+      aux_sym_string_repeat1,
+    ACTIONS(356), 2,
+      aux_sym_string_token1,
+      aux_sym_string_token2,
+  [1831] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(360), 1,
+      sym__dedent,
+    STATE(77), 1,
+      aux_sym_block_content_repeat1,
+    ACTIONS(358), 2,
+      sym__newline,
+      sym_block_line,
+  [1845] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(362), 1,
+      anon_sym_DQUOTE,
+    STATE(79), 1,
+      aux_sym_string_repeat1,
+    ACTIONS(364), 2,
+      aux_sym_string_token1,
+      aux_sym_string_token2,
+  [1859] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(366), 3,
+      sym__dedent,
+      sym__newline,
+      sym_identifier,
+  [1868] = 4,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(368), 1,
+      anon_sym_COMMA,
+    ACTIONS(370), 1,
+      sym__newline,
+    STATE(88), 1,
+      aux_sym_identifier_list_repeat1,
+  [1881] = 4,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(368), 1,
+      anon_sym_COMMA,
+    ACTIONS(372), 1,
+      sym__newline,
+    STATE(90), 1,
+      aux_sym_identifier_list_repeat1,
+  [1894] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(374), 3,
+      sym__dedent,
+      sym__newline,
+      sym_identifier,
+  [1903] = 4,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(376), 1,
+      anon_sym_COMMA,
+    ACTIONS(379), 1,
+      sym__newline,
+    STATE(90), 1,
+      aux_sym_identifier_list_repeat1,
+  [1916] = 4,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(381), 1,
+      anon_sym_workflow,
+    ACTIONS(383), 1,
+      sym__newline,
+    STATE(91), 1,
+      aux_sym_source_file_repeat1,
+  [1929] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(386), 3,
+      sym__dedent,
+      sym__newline,
+      sym_identifier,
+  [1938] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(379), 2,
+      sym__newline,
+      anon_sym_COMMA,
+  [1946] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(388), 1,
+      sym_identifier,
+    STATE(131), 1,
+      sym_identifier_list,
+  [1956] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(388), 1,
+      sym_identifier,
+    STATE(118), 1,
+      sym_identifier_list,
+  [1966] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(390), 2,
+      sym_identifier,
+      anon_sym_DQUOTE,
+  [1974] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(392), 1,
+      ts_builtin_sym_end,
+  [1981] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(394), 1,
+      sym__indent,
+  [1988] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(396), 1,
+      anon_sym_COLON,
+  [1995] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(398), 1,
+      ts_builtin_sym_end,
+  [2002] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(400), 1,
+      sym__indent,
+  [2009] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(402), 1,
+      sym__dedent,
+  [2016] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(404), 1,
+      sym_identifier,
+  [2023] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(406), 1,
+      sym__indent,
+  [2030] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(408), 1,
+      sym__indent,
+  [2037] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(410), 1,
+      anon_sym_COLON,
+  [2044] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(412), 1,
+      sym_identifier,
+  [2051] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(414), 1,
+      anon_sym_COLON,
+  [2058] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(416), 1,
+      ts_builtin_sym_end,
+  [2065] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(418), 1,
+      ts_builtin_sym_end,
+  [2072] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(420), 1,
+      sym_identifier,
+  [2079] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(422), 1,
+      anon_sym_COLON,
+  [2086] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(424), 1,
+      anon_sym_COLON,
+  [2093] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(426), 1,
+      sym_identifier,
+  [2100] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(428), 1,
+      sym_identifier,
+  [2107] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(430), 1,
+      sym__indent,
+  [2114] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(432), 1,
+      sym_identifier,
+  [2121] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__newline,
+  [2128] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(436), 1,
+      sym__indent,
+  [2135] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(438), 1,
+      sym__indent,
+  [2142] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(440), 1,
+      sym__indent,
+  [2149] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(442), 1,
+      sym_identifier,
+  [2156] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(444), 1,
+      sym__indent,
+  [2163] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(446), 1,
+      sym__indent,
+  [2170] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(448), 1,
+      anon_sym_DASH_GT,
+  [2177] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(450), 1,
+      sym__indent,
+  [2184] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(452), 1,
+      anon_sym_COLON,
+  [2191] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(454), 1,
+      anon_sym_DASH_GT,
+  [2198] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(456), 1,
+      sym_identifier,
+  [2205] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(458), 1,
+      sym__dedent,
+  [2212] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(460), 1,
+      sym__newline,
+  [2219] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(462), 1,
+      anon_sym_LT_DASH,
+  [2226] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(464), 1,
+      sym__indent,
+  [2233] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(466), 1,
+      sym_identifier,
+  [2240] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(468), 1,
+      sym_identifier,
+  [2247] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(470), 1,
+      sym_identifier,
+  [2254] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(472), 1,
+      sym__indent,
+  [2261] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(474), 1,
+      sym_identifier,
+  [2268] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(476), 1,
+      anon_sym_COLON,
+  [2275] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(478), 1,
+      sym_identifier,
+};
+
+static const uint32_t ts_small_parse_table_map[] = {
+  [SMALL_STATE(2)] = 0,
+  [SMALL_STATE(3)] = 39,
+  [SMALL_STATE(4)] = 78,
+  [SMALL_STATE(5)] = 144,
+  [SMALL_STATE(6)] = 210,
+  [SMALL_STATE(7)] = 276,
+  [SMALL_STATE(8)] = 305,
+  [SMALL_STATE(9)] = 334,
+  [SMALL_STATE(10)] = 362,
+  [SMALL_STATE(11)] = 396,
+  [SMALL_STATE(12)] = 421,
+  [SMALL_STATE(13)] = 446,
+  [SMALL_STATE(14)] = 468,
+  [SMALL_STATE(15)] = 490,
+  [SMALL_STATE(16)] = 512,
+  [SMALL_STATE(17)] = 534,
+  [SMALL_STATE(18)] = 556,
+  [SMALL_STATE(19)] = 578,
+  [SMALL_STATE(20)] = 600,
+  [SMALL_STATE(21)] = 622,
+  [SMALL_STATE(22)] = 644,
+  [SMALL_STATE(23)] = 666,
+  [SMALL_STATE(24)] = 688,
+  [SMALL_STATE(25)] = 710,
+  [SMALL_STATE(26)] = 732,
+  [SMALL_STATE(27)] = 754,
+  [SMALL_STATE(28)] = 776,
+  [SMALL_STATE(29)] = 798,
+  [SMALL_STATE(30)] = 825,
+  [SMALL_STATE(31)] = 842,
+  [SMALL_STATE(32)] = 865,
+  [SMALL_STATE(33)] = 886,
+  [SMALL_STATE(34)] = 913,
+  [SMALL_STATE(35)] = 936,
+  [SMALL_STATE(36)] = 965,
+  [SMALL_STATE(37)] = 986,
+  [SMALL_STATE(38)] = 1009,
+  [SMALL_STATE(39)] = 1026,
+  [SMALL_STATE(40)] = 1047,
+  [SMALL_STATE(41)] = 1064,
+  [SMALL_STATE(42)] = 1088,
+  [SMALL_STATE(43)] = 1106,
+  [SMALL_STATE(44)] = 1122,
+  [SMALL_STATE(45)] = 1137,
+  [SMALL_STATE(46)] = 1160,
+  [SMALL_STATE(47)] = 1175,
+  [SMALL_STATE(48)] = 1190,
+  [SMALL_STATE(49)] = 1210,
+  [SMALL_STATE(50)] = 1230,
+  [SMALL_STATE(51)] = 1250,
+  [SMALL_STATE(52)] = 1270,
+  [SMALL_STATE(53)] = 1290,
+  [SMALL_STATE(54)] = 1304,
+  [SMALL_STATE(55)] = 1324,
+  [SMALL_STATE(56)] = 1344,
+  [SMALL_STATE(57)] = 1364,
+  [SMALL_STATE(58)] = 1384,
+  [SMALL_STATE(59)] = 1404,
+  [SMALL_STATE(60)] = 1424,
+  [SMALL_STATE(61)] = 1444,
+  [SMALL_STATE(62)] = 1464,
+  [SMALL_STATE(63)] = 1484,
+  [SMALL_STATE(64)] = 1504,
+  [SMALL_STATE(65)] = 1521,
+  [SMALL_STATE(66)] = 1538,
+  [SMALL_STATE(67)] = 1555,
+  [SMALL_STATE(68)] = 1574,
+  [SMALL_STATE(69)] = 1591,
+  [SMALL_STATE(70)] = 1608,
+  [SMALL_STATE(71)] = 1625,
+  [SMALL_STATE(72)] = 1642,
+  [SMALL_STATE(73)] = 1659,
+  [SMALL_STATE(74)] = 1676,
+  [SMALL_STATE(75)] = 1693,
+  [SMALL_STATE(76)] = 1712,
+  [SMALL_STATE(77)] = 1729,
+  [SMALL_STATE(78)] = 1743,
+  [SMALL_STATE(79)] = 1759,
+  [SMALL_STATE(80)] = 1773,
+  [SMALL_STATE(81)] = 1789,
+  [SMALL_STATE(82)] = 1803,
+  [SMALL_STATE(83)] = 1817,
+  [SMALL_STATE(84)] = 1831,
+  [SMALL_STATE(85)] = 1845,
+  [SMALL_STATE(86)] = 1859,
+  [SMALL_STATE(87)] = 1868,
+  [SMALL_STATE(88)] = 1881,
+  [SMALL_STATE(89)] = 1894,
+  [SMALL_STATE(90)] = 1903,
+  [SMALL_STATE(91)] = 1916,
+  [SMALL_STATE(92)] = 1929,
+  [SMALL_STATE(93)] = 1938,
+  [SMALL_STATE(94)] = 1946,
+  [SMALL_STATE(95)] = 1956,
+  [SMALL_STATE(96)] = 1966,
+  [SMALL_STATE(97)] = 1974,
+  [SMALL_STATE(98)] = 1981,
+  [SMALL_STATE(99)] = 1988,
+  [SMALL_STATE(100)] = 1995,
+  [SMALL_STATE(101)] = 2002,
+  [SMALL_STATE(102)] = 2009,
+  [SMALL_STATE(103)] = 2016,
+  [SMALL_STATE(104)] = 2023,
+  [SMALL_STATE(105)] = 2030,
+  [SMALL_STATE(106)] = 2037,
+  [SMALL_STATE(107)] = 2044,
+  [SMALL_STATE(108)] = 2051,
+  [SMALL_STATE(109)] = 2058,
+  [SMALL_STATE(110)] = 2065,
+  [SMALL_STATE(111)] = 2072,
+  [SMALL_STATE(112)] = 2079,
+  [SMALL_STATE(113)] = 2086,
+  [SMALL_STATE(114)] = 2093,
+  [SMALL_STATE(115)] = 2100,
+  [SMALL_STATE(116)] = 2107,
+  [SMALL_STATE(117)] = 2114,
+  [SMALL_STATE(118)] = 2121,
+  [SMALL_STATE(119)] = 2128,
+  [SMALL_STATE(120)] = 2135,
+  [SMALL_STATE(121)] = 2142,
+  [SMALL_STATE(122)] = 2149,
+  [SMALL_STATE(123)] = 2156,
+  [SMALL_STATE(124)] = 2163,
+  [SMALL_STATE(125)] = 2170,
+  [SMALL_STATE(126)] = 2177,
+  [SMALL_STATE(127)] = 2184,
+  [SMALL_STATE(128)] = 2191,
+  [SMALL_STATE(129)] = 2198,
+  [SMALL_STATE(130)] = 2205,
+  [SMALL_STATE(131)] = 2212,
+  [SMALL_STATE(132)] = 2219,
+  [SMALL_STATE(133)] = 2226,
+  [SMALL_STATE(134)] = 2233,
+  [SMALL_STATE(135)] = 2240,
+  [SMALL_STATE(136)] = 2247,
+  [SMALL_STATE(137)] = 2254,
+  [SMALL_STATE(138)] = 2261,
+  [SMALL_STATE(139)] = 2268,
+  [SMALL_STATE(140)] = 2275,
+};
+
+static const TSParseActionEntry ts_parse_actions[] = {
+  [0] = {.entry = {.count = 0, .reusable = false}},
+  [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
+  [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [11] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2, 0, 0),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2, 0, 0),
+  [15] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3, 0, 0),
+  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_workflow_body, 1, 0, 0),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [47] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(127),
+  [50] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(133),
+  [53] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(135),
+  [56] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(136),
+  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(138),
+  [62] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(107),
+  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(117),
+  [68] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(140),
+  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(111),
+  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(115),
+  [77] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(116),
+  [80] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(99),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0),
+  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_workflow_body_repeat1, 2, 0, 0), SHIFT_REPEAT(5),
+  [88] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_field_value, 1, 0, 0),
+  [92] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_field_value, 1, 0, 0),
+  [94] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_multiline_block, 3, 0, 0),
+  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_multiline_block, 3, 0, 0),
+  [98] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_operand, 1, 0, 0),
+  [100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_operand, 1, 0, 0),
+  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [104] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_compare_expr, 1, 0, 0),
+  [106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [110] = {.entry = {.count = 1, .reusable = false}}, SHIFT(96),
+  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_compare_expr, 1, 0, 0),
+  [114] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 3, 0, 0),
+  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 3, 0, 0),
+  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_workflow_field, 3, 0, 0),
+  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fan_in_node, 5, 0, 0),
+  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_edges_section, 4, 0, 0),
+  [124] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_decl, 1, 0, 0),
+  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tool_node, 5, 0, 0),
+  [128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parallel_node, 5, 0, 0),
+  [130] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_agent_node, 5, 0, 0),
+  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_human_node, 5, 0, 0),
+  [134] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditional_node, 5, 0, 0),
+  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subgraph_node, 5, 0, 0),
+  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_manager_loop_node, 5, 0, 0),
+  [140] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_stylesheet_section, 5, 0, 0),
+  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_defaults_section, 4, 0, 0),
+  [144] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_and_expr, 2, 0, 0),
+  [146] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
+  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_and_expr, 2, 0, 0),
+  [150] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_and_expr, 1, 0, 0),
+  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_and_expr, 1, 0, 0),
+  [154] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_and_expr_repeat1, 2, 0, 0),
+  [156] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_and_expr_repeat1, 2, 0, 0), SHIFT_REPEAT(55),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_and_expr_repeat1, 2, 0, 0),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [165] = {.entry = {.count = 1, .reusable = false}}, SHIFT(103),
+  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [171] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_compare_expr, 4, 0, 0),
+  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_compare_expr, 4, 0, 0),
+  [175] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_edge_entry, 3, 0, 0),
+  [177] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
+  [179] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
+  [181] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_edge_entry, 3, 0, 0),
+  [183] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_or_expr, 1, 0, 0),
+  [185] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_or_expr, 1, 0, 0),
+  [189] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_section_repeat1, 2, 0, 0), SHIFT_REPEAT(104),
+  [192] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_section_repeat1, 2, 0, 0), SHIFT_REPEAT(103),
+  [195] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_stylesheet_section_repeat1, 2, 0, 0), SHIFT_REPEAT(103),
+  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_stylesheet_section_repeat1, 2, 0, 0),
+  [200] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_section_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
+  [203] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_edge_entry, 4, 0, 0),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_edge_entry, 4, 0, 0),
+  [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [211] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_or_expr, 2, 0, 0),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_or_expr, 2, 0, 0),
+  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_edge_entry_repeat1, 2, 0, 0),
+  [217] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_edge_entry_repeat1, 2, 0, 0), SHIFT_REPEAT(35),
+  [220] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_edge_entry_repeat1, 2, 0, 0), SHIFT_REPEAT(106),
+  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_edge_entry_repeat1, 2, 0, 0),
+  [225] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_or_expr_repeat1, 2, 0, 0),
+  [227] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_or_expr_repeat1, 2, 0, 0), SHIFT_REPEAT(45),
+  [230] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_or_expr_repeat1, 2, 0, 0),
+  [232] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_compare_expr, 3, 0, 0),
+  [234] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_compare_expr, 3, 0, 0),
+  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [238] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_edge_attr, 3, 0, 0),
+  [240] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_edge_attr, 3, 0, 0),
+  [242] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_edge_attr, 2, 0, 0),
+  [244] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_edge_attr, 2, 0, 0),
+  [246] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_condition, 1, 0, 0),
+  [248] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_condition, 1, 0, 0),
+  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [256] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
+  [258] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
+  [260] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [262] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_stylesheet_rule, 4, 0, 0),
+  [268] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_stylesheet_rule, 4, 0, 0),
+  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [276] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_defaults_section_repeat1, 2, 0, 0), SHIFT_REPEAT(112),
+  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_defaults_section_repeat1, 2, 0, 0),
+  [281] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_defaults_section_repeat1, 2, 0, 0), SHIFT_REPEAT(57),
+  [284] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [288] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_agent_node_repeat1, 2, 0, 0), SHIFT_REPEAT(112),
+  [291] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_agent_node_repeat1, 2, 0, 0),
+  [293] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_agent_node_repeat1, 2, 0, 0), SHIFT_REPEAT(62),
+  [296] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_edges_section_repeat1, 2, 0, 0), SHIFT_REPEAT(125),
+  [299] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_edges_section_repeat1, 2, 0, 0),
+  [301] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_edges_section_repeat1, 2, 0, 0), SHIFT_REPEAT(64),
+  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [318] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [322] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_rule_repeat1, 2, 0, 0), SHIFT_REPEAT(112),
+  [325] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_stylesheet_rule_repeat1, 2, 0, 0),
+  [327] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_stylesheet_rule_repeat1, 2, 0, 0), SHIFT_REPEAT(75),
+  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [332] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [334] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [336] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_content_repeat1, 2, 0, 0), SHIFT_REPEAT(77),
+  [339] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_content_repeat1, 2, 0, 0),
+  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [343] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0),
+  [345] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, 0, 0), SHIFT_REPEAT(79),
+  [348] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [350] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [352] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
+  [356] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
+  [358] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [360] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block_content, 1, 0, 0),
+  [362] = {.entry = {.count = 1, .reusable = false}}, SHIFT(3),
+  [364] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [366] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_defaults_field, 3, 0, 0),
+  [368] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier_list, 1, 0, 0),
+  [372] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier_list, 2, 0, 0),
+  [374] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_field, 3, 0, 0),
+  [376] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_identifier_list_repeat1, 2, 0, 0), SHIFT_REPEAT(129),
+  [379] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_identifier_list_repeat1, 2, 0, 0),
+  [381] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
+  [383] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(91),
+  [386] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_stylesheet_rule_repeat1, 3, 0, 0),
+  [388] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [390] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_compare_op, 1, 0, 0),
+  [392] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 2, 0, 0),
+  [394] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_selector, 2, 0, 0),
+  [396] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [398] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_workflow_decl, 5, 0, 0),
+  [400] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [402] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [404] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [406] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_selector, 1, 0, 0),
+  [408] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [410] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [412] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [414] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [416] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [418] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
+  [420] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [422] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_field_name, 1, 0, 0),
+  [424] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [426] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
+  [430] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [434] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [438] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [440] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [442] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [444] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [446] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [448] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
+  [450] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [452] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [454] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [456] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [458] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [460] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [462] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [464] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [466] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [468] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [470] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [472] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [474] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+};
+
+enum ts_external_scanner_symbol_identifiers {
+  ts_external_token__indent = 0,
+  ts_external_token__dedent = 1,
+  ts_external_token__newline = 2,
+};
+
+static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
+  [ts_external_token__indent] = sym__indent,
+  [ts_external_token__dedent] = sym__dedent,
+  [ts_external_token__newline] = sym__newline,
+};
+
+static const bool ts_external_scanner_states[6][EXTERNAL_TOKEN_COUNT] = {
+  [1] = {
+    [ts_external_token__indent] = true,
+    [ts_external_token__dedent] = true,
+    [ts_external_token__newline] = true,
+  },
+  [2] = {
+    [ts_external_token__newline] = true,
+  },
+  [3] = {
+    [ts_external_token__dedent] = true,
+    [ts_external_token__newline] = true,
+  },
+  [4] = {
+    [ts_external_token__indent] = true,
+  },
+  [5] = {
+    [ts_external_token__dedent] = true,
+  },
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void *tree_sitter_dippin_external_scanner_create(void);
+void tree_sitter_dippin_external_scanner_destroy(void *);
+bool tree_sitter_dippin_external_scanner_scan(void *, TSLexer *, const bool *);
+unsigned tree_sitter_dippin_external_scanner_serialize(void *, char *);
+void tree_sitter_dippin_external_scanner_deserialize(void *, const char *, unsigned);
+
+#ifdef TREE_SITTER_HIDE_SYMBOLS
+#define TS_PUBLIC
+#elif defined(_WIN32)
+#define TS_PUBLIC __declspec(dllexport)
+#else
+#define TS_PUBLIC __attribute__((visibility("default")))
+#endif
+
+TS_PUBLIC const TSLanguage *tree_sitter_dippin(void) {
+  static const TSLanguage language = {
+    .version = LANGUAGE_VERSION,
+    .symbol_count = SYMBOL_COUNT,
+    .alias_count = ALIAS_COUNT,
+    .token_count = TOKEN_COUNT,
+    .external_token_count = EXTERNAL_TOKEN_COUNT,
+    .state_count = STATE_COUNT,
+    .large_state_count = LARGE_STATE_COUNT,
+    .production_id_count = PRODUCTION_ID_COUNT,
+    .field_count = FIELD_COUNT,
+    .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
+    .parse_table = &ts_parse_table[0][0],
+    .small_parse_table = ts_small_parse_table,
+    .small_parse_table_map = ts_small_parse_table_map,
+    .parse_actions = ts_parse_actions,
+    .symbol_names = ts_symbol_names,
+    .symbol_metadata = ts_symbol_metadata,
+    .public_symbol_map = ts_symbol_map,
+    .alias_map = ts_non_terminal_alias_map,
+    .alias_sequences = &ts_alias_sequences[0][0],
+    .lex_modes = ts_lex_modes,
+    .lex_fn = ts_lex,
+    .keyword_lex_fn = ts_lex_keywords,
+    .keyword_capture_token = sym_identifier,
+    .external_scanner = {
+      &ts_external_scanner_states[0][0],
+      ts_external_scanner_symbol_map,
+      tree_sitter_dippin_external_scanner_create,
+      tree_sitter_dippin_external_scanner_destroy,
+      tree_sitter_dippin_external_scanner_scan,
+      tree_sitter_dippin_external_scanner_serialize,
+      tree_sitter_dippin_external_scanner_deserialize,
+    },
+    .primary_state_ids = ts_primary_state_ids,
+  };
+  return &language;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/editors/tree-sitter-dippin/src/tree_sitter/alloc.h
+++ b/editors/tree-sitter-dippin/src/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/editors/tree-sitter-dippin/src/tree_sitter/array.h
+++ b/editors/tree-sitter-dippin/src/tree_sitter/array.h
@@ -1,0 +1,291 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/editors/tree-sitter-dippin/src/tree_sitter/parser.h
+++ b/editors/tree-sitter-dippin/src/tree_sitter/parser.h
@@ -1,0 +1,266 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/editors/tree-sitter-dippin/test/corpus/basic.txt
+++ b/editors/tree-sitter-dippin/test/corpus/basic.txt
@@ -174,6 +174,46 @@ workflow Cond
                     (operand (identifier))))))))))))
 
 ================================================================================
+Manager loop node
+================================================================================
+
+workflow Sup
+  start: M
+  exit: Done
+
+  manager_loop M
+    subgraph_ref: inner
+    poll_interval: 30s
+    max_cycles: 12
+
+  agent Done
+    prompt: done
+
+  edges
+    M -> Done
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (workflow_decl
+    (identifier)
+    (workflow_body
+      (workflow_field (field_value (raw_inline)))
+      (workflow_field (field_value (raw_inline)))
+      (node_decl
+        (manager_loop_node
+          (identifier)
+          (node_field (field_name (identifier)) (field_value (raw_inline)))
+          (node_field (field_name (identifier)) (field_value (raw_inline)))
+          (node_field (field_name (identifier)) (field_value (raw_inline)))))
+      (node_decl
+        (agent_node
+          (identifier)
+          (node_field (field_name (identifier)) (field_value (raw_inline)))))
+      (edges_section
+        (edge_entry (identifier) (identifier))))))
+
+================================================================================
 Conditional node
 ================================================================================
 

--- a/editors/tree-sitter-dippin/tree-sitter.json
+++ b/editors/tree-sitter-dippin/tree-sitter.json
@@ -1,0 +1,30 @@
+{
+  "grammars": [
+    {
+      "name": "dippin",
+      "camelcase": "Dippin",
+      "scope": "source.dippin",
+      "path": ".",
+      "file-types": [
+        "dip"
+      ],
+      "highlights": "queries/highlights.scm"
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "MIT",
+    "description": "Tree-sitter grammar for the Dippin workflow language",
+    "links": {
+      "repository": "https://github.com/2389-research/dippin-lang"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -27,7 +27,7 @@
     },
 
     "node-declaration": {
-      "match": "^\\s*(agent|tool|human|subgraph|conditional|parallel|fan_in|manager_loop)\\s+(\\w+)",
+      "match": "^\\s*(agent|tool|human|subgraph|conditional|manager_loop)\\s+(\\w+)",
       "captures": {
         "1": { "name": "keyword.control.node.dippin" },
         "2": { "name": "entity.name.function.node.dippin" }

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -27,7 +27,7 @@
     },
 
     "node-declaration": {
-      "match": "^\\s*(agent|tool|human|subgraph|conditional)\\s+(\\w+)",
+      "match": "^\\s*(agent|tool|human|subgraph|conditional|parallel|fan_in|manager_loop)\\s+(\\w+)",
       "captures": {
         "1": { "name": "keyword.control.node.dippin" },
         "2": { "name": "entity.name.function.node.dippin" }
@@ -118,7 +118,7 @@
           "name": "keyword.operator.comparison.dippin"
         },
         {
-          "match": "\\b(ctx|graph|params)(\\.)([\\w.-]+)\\b",
+          "match": "\\b(ctx|graph|params|stack)(\\.)([\\w.-]+)\\b",
           "captures": {
             "1": { "name": "variable.language.namespace.dippin" },
             "2": { "name": "punctuation.accessor.dippin" },
@@ -145,7 +145,7 @@
           }
         },
         {
-          "match": "^\\s*(label|model|provider|mode|default|ref|timeout|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|class|reads|writes)\\s*(:)",
+          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|class|reads|writes)\\s*(:)",
           "captures": {
             "1": { "name": "entity.name.tag.field.dippin" },
             "2": { "name": "punctuation.separator.key-value.dippin" }

--- a/examples/child_pipeline.dip
+++ b/examples/child_pipeline.dip
@@ -1,0 +1,17 @@
+workflow ChildPipeline
+  goal: "A minimal child pipeline supervised by manager_loop_demo."
+  start: DoWork
+  exit: Done
+
+  agent DoWork
+    auto_status: true
+    prompt:
+      Perform one cycle of supervised work.
+      End your response with STATUS: success if done, STATUS: fail if more cycles are needed.
+
+  agent Done
+    prompt:
+      Finalize this cycle's result.
+
+  edges
+    DoWork -> Done

--- a/examples/manager_loop_demo.dip
+++ b/examples/manager_loop_demo.dip
@@ -1,0 +1,22 @@
+workflow ManagerLoopDemo
+  goal: "Supervise a child pipeline with periodic steering."
+  start: Supervise
+  exit: Done
+
+  manager_loop Supervise
+    label: "Quality Gate Supervisor"
+    subgraph_ref: child_pipeline.dip
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.outcome = success
+    steer_condition: stack.child.cycles = 5
+    steer_context:
+      hint: halfway_through
+      priority: high
+
+  agent Done
+    prompt:
+      Summarize the supervised run's final outcome.
+
+  edges
+    Supervise -> Done

--- a/export/dot.go
+++ b/export/dot.go
@@ -633,6 +633,8 @@ func applyManagerLoopAttrs(attrs map[string]string, cfg ir.ManagerLoopConfig) {
 
 // flattenSteerContext produces canonical sorted "k=v,k=v" from the map.
 // Empty map returns empty string (caller suppresses the attr).
+// Callers must validate that keys/values contain no ',' or '='; the linter
+// catches this at DIP136.
 func flattenSteerContext(m map[string]string) string {
 	if len(m) == 0 {
 		return ""

--- a/export/dot.go
+++ b/export/dot.go
@@ -109,7 +109,8 @@ func buildExecOrder(path []string) map[string][]int {
 
 // nodeShapes maps NodeKind to the corresponding DOT shape attribute.
 // Per §15: agent→box, human→hexagon, tool→parallelogram,
-// parallel→component, fan_in→tripleoctagon, subgraph→tab, conditional→diamond.
+// parallel→component, fan_in→tripleoctagon, subgraph→tab, conditional→diamond,
+// manager_loop→house.
 var nodeShapes = map[ir.NodeKind]string{
 	ir.NodeAgent:       "box",
 	ir.NodeHuman:       "hexagon",
@@ -118,6 +119,7 @@ var nodeShapes = map[ir.NodeKind]string{
 	ir.NodeFanIn:       "tripleoctagon",
 	ir.NodeSubgraph:    "tab",
 	ir.NodeConditional: "diamond",
+	ir.NodeManagerLoop: "house",
 }
 
 // nodeShape returns the DOT shape for a given NodeKind.
@@ -213,7 +215,7 @@ func applySemanticNodeAttrs(attrs map[string]string, cfg interface{}) bool {
 	return true
 }
 
-// applySemanticStructuralAttrs handles subgraph, parallel, and fan-in semantic attrs.
+// applySemanticStructuralAttrs handles subgraph, parallel, fan-in, and manager_loop semantic attrs.
 func applySemanticStructuralAttrs(attrs map[string]string, cfg interface{}) {
 	switch c := cfg.(type) {
 	case ir.SubgraphConfig:
@@ -222,6 +224,8 @@ func applySemanticStructuralAttrs(attrs map[string]string, cfg interface{}) {
 		applyParallelAttrs(attrs, c)
 	case ir.FanInConfig:
 		applyFanInAttrs(attrs, c)
+	case ir.ManagerLoopConfig:
+		applyManagerLoopAttrs(attrs, c)
 	}
 }
 
@@ -575,4 +579,56 @@ func sortStrings(s []string) {
 			s[j], s[j-1] = s[j-1], s[j]
 		}
 	}
+}
+
+// applyManagerLoopScalarAttrs writes scalar manager_loop config fields as DOT node attributes.
+func applyManagerLoopScalarAttrs(attrs map[string]string, cfg ir.ManagerLoopConfig) {
+	if cfg.SubgraphRef != "" {
+		attrs["subgraph_ref"] = cfg.SubgraphRef
+	}
+	if cfg.PollInterval != 0 {
+		attrs["poll_interval"] = formatDuration(cfg.PollInterval)
+	}
+	if cfg.MaxCycles != 0 {
+		attrs["max_cycles"] = fmt.Sprintf("%d", cfg.MaxCycles)
+	}
+	if s := flattenSteerContext(cfg.SteerContext); s != "" {
+		attrs["steer_context"] = s
+	}
+}
+
+// applyManagerLoopConditionAttrs writes condition manager_loop config fields as DOT node attributes.
+func applyManagerLoopConditionAttrs(attrs map[string]string, cfg ir.ManagerLoopConfig) {
+	if cfg.StopCondition != nil && cfg.StopCondition.Raw != "" {
+		attrs["stop_condition"] = cfg.StopCondition.Raw
+	}
+	if cfg.SteerCondition != nil && cfg.SteerCondition.Raw != "" {
+		attrs["steer_condition"] = cfg.SteerCondition.Raw
+	}
+}
+
+// applyManagerLoopAttrs writes manager_loop config fields as DOT node attributes.
+// The steer_context map is flattened to canonical sorted "k=v,k=v" so the
+// round-trip through DOT → migrate → IR is lossless.
+func applyManagerLoopAttrs(attrs map[string]string, cfg ir.ManagerLoopConfig) {
+	applyManagerLoopScalarAttrs(attrs, cfg)
+	applyManagerLoopConditionAttrs(attrs, cfg)
+}
+
+// flattenSteerContext produces canonical sorted "k=v,k=v" from the map.
+// Empty map returns empty string (caller suppresses the attr).
+func flattenSteerContext(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+m[k])
+	}
+	return strings.Join(parts, ",")
 }

--- a/export/dot.go
+++ b/export/dot.go
@@ -631,10 +631,30 @@ func applyManagerLoopAttrs(attrs map[string]string, cfg ir.ManagerLoopConfig) {
 	applyManagerLoopConditionAttrs(attrs, cfg)
 }
 
+// steerContextEncoder replaces reserved steer_context delimiter characters with
+// their percent-encoded equivalents. '%' must be replaced first so it is not
+// double-encoded.
+var steerContextEncoder = strings.NewReplacer(
+	"%", "%25",
+	",", "%2C",
+	"=", "%3D",
+)
+
+// encodeSteerContextToken percent-encodes the three reserved characters
+// used as delimiters in the flattened steer_context representation (',', '=')
+// and the escape character itself ('%'). This keeps DOT round-trip lossless
+// even when keys or values contain reserved characters.
+func encodeSteerContextToken(s string) string {
+	if !strings.ContainsAny(s, ",=%") {
+		return s
+	}
+	return steerContextEncoder.Replace(s)
+}
+
 // flattenSteerContext produces canonical sorted "k=v,k=v" from the map.
 // Empty map returns empty string (caller suppresses the attr).
-// Callers must validate that keys/values contain no ',' or '='; the linter
-// catches this at DIP136.
+// Reserved characters (',', '=', '%') in keys and values are percent-encoded
+// so the round-trip through DOT → migrate stays lossless.
 func flattenSteerContext(m map[string]string) string {
 	if len(m) == 0 {
 		return ""
@@ -646,7 +666,7 @@ func flattenSteerContext(m map[string]string) string {
 	sortStrings(keys)
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
-		parts = append(parts, k+"="+m[k])
+		parts = append(parts, encodeSteerContextToken(k)+"="+encodeSteerContextToken(m[k]))
 	}
 	return strings.Join(parts, ",")
 }

--- a/export/dot.go
+++ b/export/dot.go
@@ -599,12 +599,28 @@ func applyManagerLoopScalarAttrs(attrs map[string]string, cfg ir.ManagerLoopConf
 
 // applyManagerLoopConditionAttrs writes condition manager_loop config fields as DOT node attributes.
 func applyManagerLoopConditionAttrs(attrs map[string]string, cfg ir.ManagerLoopConfig) {
-	if cfg.StopCondition != nil && cfg.StopCondition.Raw != "" {
-		attrs["stop_condition"] = cfg.StopCondition.Raw
+	if s := dotManagerLoopConditionText(cfg.StopCondition); s != "" {
+		attrs["stop_condition"] = s
 	}
-	if cfg.SteerCondition != nil && cfg.SteerCondition.Raw != "" {
-		attrs["steer_condition"] = cfg.SteerCondition.Raw
+	if s := dotManagerLoopConditionText(cfg.SteerCondition); s != "" {
+		attrs["steer_condition"] = s
 	}
+}
+
+// dotManagerLoopConditionText returns the best textual form of a node condition:
+// prefers Raw when populated; otherwise formats Parsed via formatConditionExpr.
+// Returns "" when the condition is nil/empty.
+func dotManagerLoopConditionText(c *ir.Condition) string {
+	if c == nil {
+		return ""
+	}
+	if c.Raw != "" {
+		return c.Raw
+	}
+	if c.Parsed != nil {
+		return formatCondition(c.Parsed)
+	}
+	return ""
 }
 
 // applyManagerLoopAttrs writes manager_loop config fields as DOT node attributes.

--- a/export/dot_test.go
+++ b/export/dot_test.go
@@ -1226,6 +1226,67 @@ func TestExportVarsAsGraphAttrs(t *testing.T) {
 	}
 }
 
+func TestExportDOT_ManagerLoop(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "S",
+		Exit:  "E",
+		Nodes: []*ir.Node{
+			{ID: "S", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "start"}},
+			{ID: "M", Kind: ir.NodeManagerLoop, Label: "Supervisor", Config: ir.ManagerLoopConfig{
+				SubgraphRef:    "inner",
+				PollInterval:   30 * time.Second,
+				MaxCycles:      12,
+				StopCondition:  &ir.Condition{Raw: "stack.child.cycles = 10"},
+				SteerCondition: &ir.Condition{Raw: "stack.child.cycles = 5"},
+				SteerContext:   map[string]string{"hint": "speed_up", "priority": "high"},
+			}},
+			{ID: "E", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "end"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "S", To: "M"},
+			{From: "M", To: "E"},
+		},
+	}
+	out := ExportDOT(w, ExportOptions{})
+	assertContains(t, out, `shape="house"`)
+	assertContains(t, out, `subgraph_ref="inner"`)
+	assertContains(t, out, `poll_interval="30s"`)
+	assertContains(t, out, `max_cycles="12"`)
+	assertContains(t, out, `stop_condition="stack.child.cycles = 10"`)
+	assertContains(t, out, `steer_condition="stack.child.cycles = 5"`)
+	// steer_context flattens to canonical sorted "k=v,k=v"
+	assertContains(t, out, `steer_context="hint=speed_up,priority=high"`)
+}
+
+func TestExportDOT_ManagerLoop_MinimalOmitsEmptyAttrs(t *testing.T) {
+	// A manager_loop with only subgraph_ref set should emit shape=house and
+	// subgraph_ref but no poll_interval, max_cycles, stop/steer_condition,
+	// or steer_context attrs. Exercises the guard clauses in
+	// applyManagerLoopScalarAttrs and applyManagerLoopConditionAttrs.
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "S",
+		Exit:  "E",
+		Nodes: []*ir.Node{
+			{ID: "S", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{ID: "M", Kind: ir.NodeManagerLoop, Config: ir.ManagerLoopConfig{
+				SubgraphRef: "inner",
+			}},
+			{ID: "E", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+		},
+		Edges: []*ir.Edge{{From: "S", To: "M"}, {From: "M", To: "E"}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+	assertContains(t, out, `shape="house"`)
+	assertContains(t, out, `subgraph_ref="inner"`)
+	for _, attr := range []string{"poll_interval", "max_cycles", "stop_condition", "steer_condition", "steer_context"} {
+		if strings.Contains(out, attr+"=") {
+			t.Errorf("unexpected %s attr in minimal output:\n%s", attr, out)
+		}
+	}
+}
+
 func TestExportVarsSkipsDefaultsCollision(t *testing.T) {
 	w := &ir.Workflow{
 		Name:  "Test",

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -292,13 +292,15 @@ func writePrimaryConfigFields(wr *writer, n *ir.Node) bool {
 	return true
 }
 
-// writeSecondaryConfigFields handles tool, subgraph, and conditional config.
+// writeSecondaryConfigFields handles tool, subgraph, manager_loop, and conditional config.
 func writeSecondaryConfigFields(wr *writer, n *ir.Node) {
 	switch cfg := n.Config.(type) {
 	case ir.ToolConfig:
 		writeToolFields(wr, n, cfg)
 	case ir.SubgraphConfig:
 		writeSubgraphFields(wr, n, cfg)
+	case ir.ManagerLoopConfig:
+		writeManagerLoopFields(wr, n, cfg)
 	case ir.ConditionalConfig:
 		writeConditionalFields(wr, n)
 	}
@@ -313,7 +315,7 @@ func writeAgentFields(wr *writer, n *ir.Node, cfg ir.AgentConfig) {
 	writeAgentCompactionFields(wr, cfg)
 	writeRetryFields(wr, n)
 	writeIOFields(wr, n)
-	writeSubgraphParams(wr, cfg.Params)
+	writeSortedMapBlock(wr, "params", cfg.Params)
 
 	if cfg.Prompt != "" {
 		wr.multilineBlock("prompt", cfg.Prompt)
@@ -493,25 +495,58 @@ func writeSubgraphFields(wr *writer, n *ir.Node, cfg ir.SubgraphConfig) {
 	if cfg.Ref != "" {
 		wr.line("ref: %s", quoteValue(cfg.Ref))
 	}
-	writeSubgraphParams(wr, cfg.Params)
+	writeSortedMapBlock(wr, "params", cfg.Params)
 }
 
-// writeSubgraphParams writes sorted params block if non-empty.
-func writeSubgraphParams(wr *writer, params map[string]string) {
-	if len(params) == 0 {
+// writeSortedMapBlock emits a named block containing sorted "key: value"
+// lines. Used for any map[string]string field (subgraph params, manager_loop
+// steer_context) so the output is deterministic and idempotent.
+func writeSortedMapBlock(wr *writer, header string, m map[string]string) {
+	if len(m) == 0 {
 		return
 	}
-	wr.line("params:")
+	wr.line("%s:", header)
 	wr.push()
-	keys := make([]string, 0, len(params))
-	for k := range params {
+	keys := make([]string, 0, len(m))
+	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		wr.line("%s: %s", k, quoteValue(params[k]))
+		wr.line("%s: %s", k, quoteValue(m[k]))
 	}
 	wr.pop()
+}
+
+// writeManagerLoopFields writes the fields of a manager_loop node in canonical order.
+func writeManagerLoopFields(wr *writer, n *ir.Node, cfg ir.ManagerLoopConfig) {
+	writeCommonNodeFields(wr, n)
+	writeRetryFields(wr, n)
+	writeIOFields(wr, n)
+	if cfg.SubgraphRef != "" {
+		wr.line("subgraph_ref: %s", quoteValue(cfg.SubgraphRef))
+	}
+	if cfg.PollInterval != 0 {
+		wr.line("poll_interval: %s", formatDuration(cfg.PollInterval))
+	}
+	if cfg.MaxCycles != 0 {
+		wr.line("max_cycles: %d", cfg.MaxCycles)
+	}
+	writeManagerLoopConditions(wr, cfg)
+	writeSortedMapBlock(wr, "steer_context", cfg.SteerContext)
+}
+
+// writeManagerLoopConditions writes stop_condition and steer_condition if set.
+// Raw is emitted unquoted; unquoteRaw has already stripped any surrounding
+// quotes at parse time, and condition expressions do not admit embedded
+// quotes (same invariant the edge formatter relies on).
+func writeManagerLoopConditions(wr *writer, cfg ir.ManagerLoopConfig) {
+	if cfg.StopCondition != nil && cfg.StopCondition.Raw != "" {
+		wr.line("stop_condition: %s", cfg.StopCondition.Raw)
+	}
+	if cfg.SteerCondition != nil && cfg.SteerCondition.Raw != "" {
+		wr.line("steer_condition: %s", cfg.SteerCondition.Raw)
+	}
 }
 
 // selectorSpecificity returns a numeric specificity for sorting.

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -537,16 +537,32 @@ func writeManagerLoopFields(wr *writer, n *ir.Node, cfg ir.ManagerLoopConfig) {
 }
 
 // writeManagerLoopConditions writes stop_condition and steer_condition if set.
-// Raw is emitted unquoted; unquoteRaw has already stripped any surrounding
-// quotes at parse time, and condition expressions do not admit embedded
-// quotes (same invariant the edge formatter relies on).
+// Raw already contains any quoting/escaping required by the condition-expression
+// syntax (e.g., "success" as a literal), so it is emitted as-is without
+// additional quoting.
 func writeManagerLoopConditions(wr *writer, cfg ir.ManagerLoopConfig) {
-	if cfg.StopCondition != nil && cfg.StopCondition.Raw != "" {
-		wr.line("stop_condition: %s", cfg.StopCondition.Raw)
+	if s := managerLoopConditionText(cfg.StopCondition); s != "" {
+		wr.line("stop_condition: %s", s)
 	}
-	if cfg.SteerCondition != nil && cfg.SteerCondition.Raw != "" {
-		wr.line("steer_condition: %s", cfg.SteerCondition.Raw)
+	if s := managerLoopConditionText(cfg.SteerCondition); s != "" {
+		wr.line("steer_condition: %s", s)
 	}
+}
+
+// managerLoopConditionText returns the best textual form of a node condition:
+// prefers Raw when populated; otherwise formats Parsed via the same helper
+// the edge path uses. Returns "" when the condition is nil/empty.
+func managerLoopConditionText(c *ir.Condition) string {
+	if c == nil {
+		return ""
+	}
+	if c.Raw != "" {
+		return c.Raw
+	}
+	if c.Parsed != nil {
+		return formatCondition(c.Parsed)
+	}
+	return ""
 }
 
 // selectorSpecificity returns a numeric specificity for sorting.

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -1799,3 +1799,36 @@ func TestFormatManagerLoop_RoundTrip(t *testing.T) {
 		t.Errorf("format is not idempotent\n---first---\n%s\n---second---\n%s", out, Format(w2))
 	}
 }
+
+// TestFormatManagerLoop_ParsedConditionFallback verifies that a ManagerLoopConfig
+// with only Parsed (no Raw) on StopCondition still emits a stop_condition line.
+// This covers programmatically-built IR where Raw is never populated.
+func TestFormatManagerLoop_ParsedConditionFallback(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "M",
+		Exit:  "M",
+		Nodes: []*ir.Node{
+			{
+				ID:   "M",
+				Kind: ir.NodeManagerLoop,
+				Config: ir.ManagerLoopConfig{
+					SubgraphRef: "inner.dip",
+					MaxCycles:   5,
+					// Parsed set, Raw intentionally empty — simulates programmatic IR construction.
+					StopCondition: &ir.Condition{
+						Parsed: ir.CondCompare{Variable: "stack.child.outcome", Op: "=", Value: "success"},
+					},
+				},
+			},
+		},
+		Edges: []*ir.Edge{{From: "M", To: "M"}},
+	}
+	out := Format(w)
+	if !strings.Contains(out, "stop_condition:") {
+		t.Errorf("expected stop_condition in formatted output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "stack.child.outcome = success") {
+		t.Errorf("expected condition text in output, got:\n%s", out)
+	}
+}

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -1768,9 +1768,13 @@ func TestFormatManagerLoop_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reparse of formatted output: err=%v\n%s", err, out)
 	}
-	cfg, ok := w2.Nodes[0].Config.(ir.ManagerLoopConfig)
+	mNode := w2.Node("M")
+	if mNode == nil {
+		t.Fatalf("node M not found after round-trip")
+	}
+	cfg, ok := mNode.Config.(ir.ManagerLoopConfig)
 	if !ok {
-		t.Fatalf("Config = %T, want ManagerLoopConfig", w2.Nodes[0].Config)
+		t.Fatalf("Config = %T, want ManagerLoopConfig", mNode.Config)
 	}
 	if cfg.SubgraphRef != "quality_loop" {
 		t.Errorf("SubgraphRef = %q", cfg.SubgraphRef)
@@ -1790,8 +1794,8 @@ func TestFormatManagerLoop_RoundTrip(t *testing.T) {
 	if cfg.SteerContext["hint"] != "speed_up" || cfg.SteerContext["priority"] != "high" || cfg.SteerContext["urgency"] != "low" {
 		t.Errorf("SteerContext round-trip failed: %v", cfg.SteerContext)
 	}
-	if w2.Nodes[0].Label != "Quality Gate" {
-		t.Errorf("Label = %q, want %q", w2.Nodes[0].Label, "Quality Gate")
+	if mNode.Label != "Quality Gate" {
+		t.Errorf("Label = %q, want %q", mNode.Label, "Quality Gate")
 	}
 
 	// Idempotency: formatting the formatted output produces the same string.

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -1737,3 +1737,65 @@ func TestFormatVarsEmptyOmitted(t *testing.T) {
 		t.Errorf("expected no vars block for empty vars map, got:\n%s", out)
 	}
 }
+
+func TestFormatManagerLoop_RoundTrip(t *testing.T) {
+	src := `workflow W
+  start: M
+  exit: M
+
+  manager_loop M
+    label: "Quality Gate"
+    subgraph_ref: quality_loop
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.cycles = 10
+    steer_condition: stack.child.cycles = 5
+    steer_context: hint=speed_up, priority=high, urgency=low
+
+  edges
+    M -> M
+`
+	p := parser.NewParser(src, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	out := Format(w)
+
+	// Round-trip: reparse the formatted output.
+	p2 := parser.NewParser(out, "formatted.dip")
+	w2, err := p2.Parse()
+	if err != nil {
+		t.Fatalf("reparse of formatted output: err=%v\n%s", err, out)
+	}
+	cfg, ok := w2.Nodes[0].Config.(ir.ManagerLoopConfig)
+	if !ok {
+		t.Fatalf("Config = %T, want ManagerLoopConfig", w2.Nodes[0].Config)
+	}
+	if cfg.SubgraphRef != "quality_loop" {
+		t.Errorf("SubgraphRef = %q", cfg.SubgraphRef)
+	}
+	if cfg.MaxCycles != 12 {
+		t.Errorf("MaxCycles = %d", cfg.MaxCycles)
+	}
+	if cfg.PollInterval != 30*time.Second {
+		t.Errorf("PollInterval = %v", cfg.PollInterval)
+	}
+	if cfg.StopCondition == nil || cfg.StopCondition.Raw != "stack.child.cycles = 10" {
+		t.Errorf("StopCondition = %+v", cfg.StopCondition)
+	}
+	if cfg.SteerCondition == nil || cfg.SteerCondition.Raw != "stack.child.cycles = 5" {
+		t.Errorf("SteerCondition = %+v", cfg.SteerCondition)
+	}
+	if cfg.SteerContext["hint"] != "speed_up" || cfg.SteerContext["priority"] != "high" || cfg.SteerContext["urgency"] != "low" {
+		t.Errorf("SteerContext round-trip failed: %v", cfg.SteerContext)
+	}
+	if w2.Nodes[0].Label != "Quality Gate" {
+		t.Errorf("Label = %q, want %q", w2.Nodes[0].Label, "Quality Gate")
+	}
+
+	// Idempotency: formatting the formatted output produces the same string.
+	if Format(w2) != out {
+		t.Errorf("format is not idempotent\n---first---\n%s\n---second---\n%s", out, Format(w2))
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -75,6 +75,7 @@ const (
 	NodeFanIn       NodeKind = "fan_in"
 	NodeSubgraph    NodeKind = "subgraph"
 	NodeConditional NodeKind = "conditional"
+	NodeManagerLoop NodeKind = "manager_loop"
 )
 
 // NodeConfig is implemented by kind-specific configuration types.
@@ -165,6 +166,21 @@ func (SubgraphConfig) nodeConfig() {}
 type ConditionalConfig struct{}
 
 func (ConditionalConfig) nodeConfig() {}
+
+// ManagerLoopConfig holds configuration for manager_loop supervisor nodes.
+// A manager_loop runs a child subgraph, polls at PollInterval, and may
+// steer the child by injecting SteerContext when SteerCondition evaluates
+// true against stack.child.* variables exposed by the runtime.
+type ManagerLoopConfig struct {
+	SubgraphRef    string            // Child subgraph to supervise (required)
+	PollInterval   time.Duration     // Polling cadence; 0 = event-driven
+	MaxCycles      int               // Hard cap on child cycles; 0 = unbounded
+	StopCondition  *Condition        // Terminate supervision when true
+	SteerCondition *Condition        // Inject SteerContext when true
+	SteerContext   map[string]string // Key-value hints injected into child
+}
+
+func (ManagerLoopConfig) nodeConfig() {}
 
 // RetryConfig specifies retry behavior for a node.
 type RetryConfig struct {

--- a/ir/ir_test.go
+++ b/ir/ir_test.go
@@ -385,3 +385,43 @@ func TestNodeIDs(t *testing.T) {
 		t.Errorf("NodeIDs() = %v, want [Begin End]", ids)
 	}
 }
+
+func TestManagerLoopConfig_ImplementsNodeConfig(t *testing.T) {
+	// Compile-time interface satisfaction check; if ManagerLoopConfig does
+	// not implement NodeConfig, this assignment won't compile.
+	var _ ir.NodeConfig = ir.ManagerLoopConfig{}
+
+	cfg := ir.ManagerLoopConfig{
+		SubgraphRef:    "quality_loop",
+		PollInterval:   30 * time.Second,
+		MaxCycles:      12,
+		StopCondition:  &ir.Condition{Raw: "stack.child.cycles = 10"},
+		SteerCondition: &ir.Condition{Raw: "stack.child.cycles = 5"},
+		SteerContext:   map[string]string{"hint": "speed_up", "priority": "high"},
+	}
+
+	if cfg.SubgraphRef != "quality_loop" {
+		t.Errorf("SubgraphRef = %q, want %q", cfg.SubgraphRef, "quality_loop")
+	}
+	if cfg.PollInterval != 30*time.Second {
+		t.Errorf("PollInterval = %v, want 30s", cfg.PollInterval)
+	}
+	if got := cfg.SteerContext["hint"]; got != "speed_up" {
+		t.Errorf("SteerContext[hint] = %q, want %q", got, "speed_up")
+	}
+	if cfg.MaxCycles != 12 {
+		t.Errorf("MaxCycles = %d, want 12", cfg.MaxCycles)
+	}
+	if cfg.StopCondition == nil || cfg.StopCondition.Raw != "stack.child.cycles = 10" {
+		t.Errorf("StopCondition.Raw = %q, want %q", cfg.StopCondition.Raw, "stack.child.cycles = 10")
+	}
+	if cfg.SteerCondition == nil || cfg.SteerCondition.Raw != "stack.child.cycles = 5" {
+		t.Errorf("SteerCondition.Raw = %q, want %q", cfg.SteerCondition.Raw, "stack.child.cycles = 5")
+	}
+}
+
+func TestNodeManagerLoop_IsNodeKind(t *testing.T) {
+	if ir.NodeManagerLoop != "manager_loop" {
+		t.Errorf("NodeManagerLoop = %q, want %q", ir.NodeManagerLoop, "manager_loop")
+	}
+}

--- a/lsp/symbols.go
+++ b/lsp/symbols.go
@@ -71,6 +71,7 @@ var nodeSymbolKinds = map[ir.NodeKind]protocol.SymbolKind{
 	ir.NodeParallel:    protocol.SymbolKindStruct,
 	ir.NodeFanIn:       protocol.SymbolKindStruct,
 	ir.NodeConditional: protocol.SymbolKindEnum,
+	ir.NodeManagerLoop: protocol.SymbolKindClass,
 }
 
 // nodeSymbolKind maps a node kind to its LSP symbol kind.

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -294,13 +294,34 @@ func resolveKind(shape string, attrs map[string]string) ir.NodeKind {
 	return ir.NodeAgent
 }
 
+// hasManagerLoopAttrs reports whether attrs contain any manager_loop-specific
+// key. Used to detect manager_loop nodes when their kind-based shape was
+// overridden to Mdiamond/Msquare by start/exit marker export.
+func hasManagerLoopAttrs(attrs map[string]string) bool {
+	managerLoopKeys := []string{
+		"subgraph_ref",
+		"poll_interval",
+		"max_cycles",
+		"stop_condition",
+		"steer_condition",
+		"steer_context",
+	}
+	for _, key := range managerLoopKeys {
+		if _, ok := attrs[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveStartExitKind disambiguates start/exit-marker shapes (Mdiamond, Msquare)
-// by checking for kind-specific attributes. Start/exit override the kind-based
-// shape in export, so migrate has to recover the original kind from attrs.
-// Currently manager_loop is the only non-agent kind that can be at start/exit
-// (via subgraph_ref); other kinds fall through to agent (legacy behavior).
+// by checking for any manager_loop-specific attribute. Start/exit override the
+// kind-based shape in export, so migrate has to recover the original kind from
+// attrs. Checking any manager_loop key (not just subgraph_ref) ensures partial
+// configurations (e.g., poll_interval set but subgraph_ref missing) are not
+// silently downgraded to NodeAgent, losing all configured fields.
 func resolveStartExitKind(attrs map[string]string) ir.NodeKind {
-	if _, hasSubgraphRef := attrs["subgraph_ref"]; hasSubgraphRef {
+	if hasManagerLoopAttrs(attrs) {
 		return ir.NodeManagerLoop
 	}
 	return ir.NodeAgent

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -283,13 +283,25 @@ func buildFlowControlConfig(kind ir.NodeKind, attrs map[string]string) ir.NodeCo
 // resolveKind determines the IR node kind from the DOT shape and attributes.
 func resolveKind(shape string, attrs map[string]string) ir.NodeKind {
 	if shape == "Mdiamond" || shape == "Msquare" {
-		return ir.NodeAgent
+		return resolveStartExitKind(attrs)
 	}
 	if shape == "diamond" {
 		return resolveDiamondKind(attrs)
 	}
 	if kind, ok := shapeToKind[shape]; ok {
 		return kind
+	}
+	return ir.NodeAgent
+}
+
+// resolveStartExitKind disambiguates start/exit-marker shapes (Mdiamond, Msquare)
+// by checking for kind-specific attributes. Start/exit override the kind-based
+// shape in export, so migrate has to recover the original kind from attrs.
+// Currently manager_loop is the only non-agent kind that can be at start/exit
+// (via subgraph_ref); other kinds fall through to agent (legacy behavior).
+func resolveStartExitKind(attrs map[string]string) ir.NodeKind {
+	if _, hasSubgraphRef := attrs["subgraph_ref"]; hasSubgraphRef {
+		return ir.NodeManagerLoop
 	}
 	return ir.NodeAgent
 }
@@ -546,10 +558,42 @@ func applyManagerLoopConditionMigrate(cfg *ir.ManagerLoopConfig, attrs map[strin
 	}
 }
 
+// decodeSteerContextToken reverses encodeSteerContextToken from export.
+// Returns the input unchanged when it contains no '%' escapes.
+func decodeSteerContextToken(s string) string {
+	if !strings.Contains(s, "%") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if i+3 <= len(s) && s[i] == '%' {
+			switch s[i : i+3] {
+			case "%25":
+				b.WriteByte('%')
+				i += 3
+				continue
+			case "%2C":
+				b.WriteByte(',')
+				i += 3
+				continue
+			case "%3D":
+				b.WriteByte('=')
+				i += 3
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
 // parseFlattenedSteerContext splits "k=v,k=v" (canonical form from DOT export)
 // into a map. Malformed entries are silently skipped — they cannot occur from
 // our own exporter and strict rejection would break migrations of manually
-// edited DOT files.
+// edited DOT files. Percent-encoded tokens (produced by encodeSteerContextToken
+// in export) are decoded back to their original values.
 func parseFlattenedSteerContext(s string) map[string]string {
 	out := map[string]string{}
 	for _, part := range strings.Split(s, ",") {
@@ -557,7 +601,9 @@ func parseFlattenedSteerContext(s string) map[string]string {
 		if len(kv) != 2 {
 			continue
 		}
-		out[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		k := decodeSteerContextToken(strings.TrimSpace(kv[0]))
+		v := decodeSteerContextToken(strings.TrimSpace(kv[1]))
+		out[k] = v
 	}
 	return out
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -558,35 +558,21 @@ func applyManagerLoopConditionMigrate(cfg *ir.ManagerLoopConfig, attrs map[strin
 	}
 }
 
+// steerContextDecoder reverses steerContextEncoder from export/dot.go.
+// Sequences are listed longest-first so the replacer matches greedily.
+var steerContextDecoder = strings.NewReplacer(
+	"%25", "%",
+	"%2C", ",",
+	"%3D", "=",
+)
+
 // decodeSteerContextToken reverses encodeSteerContextToken from export.
 // Returns the input unchanged when it contains no '%' escapes.
 func decodeSteerContextToken(s string) string {
 	if !strings.Contains(s, "%") {
 		return s
 	}
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); {
-		if i+3 <= len(s) && s[i] == '%' {
-			switch s[i : i+3] {
-			case "%25":
-				b.WriteByte('%')
-				i += 3
-				continue
-			case "%2C":
-				b.WriteByte(',')
-				i += 3
-				continue
-			case "%3D":
-				b.WriteByte('=')
-				i += 3
-				continue
-			}
-		}
-		b.WriteByte(s[i])
-		i++
-	}
-	return b.String()
+	return steerContextDecoder.Replace(s)
 }
 
 // parseFlattenedSteerContext splits "k=v,k=v" (canonical form from DOT export)

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -48,6 +48,7 @@ var shapeToKind = map[string]ir.NodeKind{
 	"component":     ir.NodeParallel,
 	"tripleoctagon": ir.NodeFanIn,
 	"tab":           ir.NodeSubgraph,
+	"house":         ir.NodeManagerLoop,
 }
 
 // convertDOTGraph transforms a parsed DOT graph into an IR workflow.
@@ -253,7 +254,7 @@ func buildNodeConfig(node *ir.Node, kind ir.NodeKind, attrs map[string]string) (
 	}
 }
 
-// buildOtherConfig builds config for parallel, fan_in, subgraph, conditional, or fallback.
+// buildOtherConfig builds config for parallel, fan_in, subgraph, conditional, manager_loop, or fallback.
 func buildOtherConfig(kind ir.NodeKind, attrs map[string]string) ir.NodeConfig {
 	switch kind {
 	case ir.NodeParallel:
@@ -262,8 +263,18 @@ func buildOtherConfig(kind ir.NodeKind, attrs map[string]string) ir.NodeConfig {
 		return buildFanInConfig(attrs)
 	case ir.NodeSubgraph:
 		return buildSubgraphConfig(attrs)
+	default:
+		return buildFlowControlConfig(kind, attrs)
+	}
+}
+
+// buildFlowControlConfig handles conditional, manager_loop, and the agent fallback.
+func buildFlowControlConfig(kind ir.NodeKind, attrs map[string]string) ir.NodeConfig {
+	switch kind {
 	case ir.NodeConditional:
 		return ir.ConditionalConfig{}
+	case ir.NodeManagerLoop:
+		return buildManagerLoopConfig(attrs)
 	default:
 		return ir.AgentConfig{}
 	}
@@ -484,6 +495,71 @@ func buildSubgraphConfig(attrs map[string]string) ir.SubgraphConfig {
 		cfg.Ref = v
 	}
 	return cfg
+}
+
+// buildManagerLoopConfig constructs a ManagerLoopConfig from DOT node attrs.
+// Mirrors the flat-attr format produced by export.applyManagerLoopAttrs.
+func buildManagerLoopConfig(attrs map[string]string) ir.ManagerLoopConfig {
+	cfg := ir.ManagerLoopConfig{SteerContext: map[string]string{}}
+	applyManagerLoopScalarMigrate(&cfg, attrs)
+	applyManagerLoopConditionMigrate(&cfg, attrs)
+	return cfg
+}
+
+// applyManagerLoopScalarMigrate populates subgraph_ref, poll_interval,
+// max_cycles, and steer_context (flattened form) from DOT attrs.
+func applyManagerLoopScalarMigrate(cfg *ir.ManagerLoopConfig, attrs map[string]string) {
+	if v, ok := attrs["subgraph_ref"]; ok {
+		cfg.SubgraphRef = v
+	}
+	applyScalarDuration(&cfg.PollInterval, attrs, "poll_interval")
+	applyScalarInt(&cfg.MaxCycles, attrs, "max_cycles")
+	if v, ok := attrs["steer_context"]; ok && v != "" {
+		cfg.SteerContext = parseFlattenedSteerContext(v)
+	}
+}
+
+// applyScalarDuration reads attrs[key] and parses into *target if present and valid.
+// Thin wrapper over tryApplyDurationDefault that also handles the attr-lookup.
+func applyScalarDuration(target *time.Duration, attrs map[string]string, key string) {
+	if v, ok := attrs[key]; ok {
+		_ = tryApplyDurationDefault(v, target)
+	}
+}
+
+// applyScalarInt reads attrs[key] and parses into *target if present and valid.
+// Thin wrapper over tryApplyIntDefault that also handles the attr-lookup.
+func applyScalarInt(target *int, attrs map[string]string, key string) {
+	if v, ok := attrs[key]; ok {
+		_ = tryApplyIntDefault(v, target)
+	}
+}
+
+// applyManagerLoopConditionMigrate populates StopCondition and SteerCondition
+// as *ir.Condition with Raw set; Parsed remains nil until simulate.EnsureConditionsParsed runs.
+func applyManagerLoopConditionMigrate(cfg *ir.ManagerLoopConfig, attrs map[string]string) {
+	if v, ok := attrs["stop_condition"]; ok && v != "" {
+		cfg.StopCondition = &ir.Condition{Raw: v}
+	}
+	if v, ok := attrs["steer_condition"]; ok && v != "" {
+		cfg.SteerCondition = &ir.Condition{Raw: v}
+	}
+}
+
+// parseFlattenedSteerContext splits "k=v,k=v" (canonical form from DOT export)
+// into a map. Malformed entries are silently skipped — they cannot occur from
+// our own exporter and strict rejection would break migrations of manually
+// edited DOT files.
+func parseFlattenedSteerContext(s string) map[string]string {
+	out := map[string]string{}
+	for _, part := range strings.Split(s, ",") {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		out[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+	}
+	return out
 }
 
 func buildRetryConfig(attrs map[string]string) ir.RetryConfig {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2476,3 +2476,22 @@ func TestMigrate_ManagerLoop_AsStartNode(t *testing.T) {
 		t.Errorf("fields lost on migrate through Mdiamond: %+v", cfg)
 	}
 }
+
+func TestMigrate_ManagerLoop_PartialConfigAtStartNode(t *testing.T) {
+	// A manager_loop with only poll_interval + max_cycles set (no subgraph_ref yet)
+	// must still be recognized as NodeManagerLoop when at start, so the config
+	// isn't silently dropped during migrate.
+	dot := `digraph W {
+  Supervise [shape=Mdiamond, label="Supervisor", poll_interval="10s", max_cycles="5"];
+  Done [shape=Msquare, label="Done"];
+  Supervise -> Done;
+}`
+	w, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	n := w.Node("Supervise")
+	if n == nil || n.Kind != ir.NodeManagerLoop {
+		t.Fatalf("Supervise kind = %v, want NodeManagerLoop (partial manager_loop attrs should still resolve)", n)
+	}
+}

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2361,3 +2361,103 @@ func TestMigrateGraphAttrsToVars(t *testing.T) {
 		t.Errorf("goal should not be in Vars, but it is: %q", w.Vars["goal"])
 	}
 }
+
+func TestMigrate_ManagerLoop(t *testing.T) {
+	dot := `digraph W {
+  S [shape=Mdiamond, label="S"];
+  M [shape=house, label="Supervisor", subgraph_ref="inner", poll_interval="30s", max_cycles="12", stop_condition="stack.child.cycles = 10", steer_condition="stack.child.cycles = 5", steer_context="hint=speed_up,priority=high"];
+  E [shape=Msquare, label="E"];
+  S -> M;
+  M -> E;
+}`
+	w, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	var n *ir.Node
+	for _, node := range w.Nodes {
+		if node.ID == "M" {
+			n = node
+		}
+	}
+	if n == nil {
+		t.Fatalf("node M not found in workflow")
+	}
+	if n.Kind != ir.NodeManagerLoop {
+		t.Fatalf("Kind = %v, want NodeManagerLoop", n.Kind)
+	}
+	cfg, ok := n.Config.(ir.ManagerLoopConfig)
+	if !ok {
+		t.Fatalf("Config = %T, want ManagerLoopConfig", n.Config)
+	}
+	if cfg.SubgraphRef != "inner" {
+		t.Errorf("SubgraphRef = %q, want %q", cfg.SubgraphRef, "inner")
+	}
+	if cfg.MaxCycles != 12 {
+		t.Errorf("MaxCycles = %d, want 12", cfg.MaxCycles)
+	}
+	if cfg.PollInterval != 30*time.Second {
+		t.Errorf("PollInterval = %v, want 30s", cfg.PollInterval)
+	}
+	if cfg.StopCondition == nil || cfg.StopCondition.Raw != "stack.child.cycles = 10" {
+		t.Errorf("StopCondition = %+v", cfg.StopCondition)
+	}
+	if cfg.SteerCondition == nil || cfg.SteerCondition.Raw != "stack.child.cycles = 5" {
+		t.Errorf("SteerCondition = %+v", cfg.SteerCondition)
+	}
+	if cfg.SteerContext["hint"] != "speed_up" || cfg.SteerContext["priority"] != "high" {
+		t.Errorf("SteerContext = %v", cfg.SteerContext)
+	}
+}
+
+func TestMigrate_ManagerLoop_Minimal(t *testing.T) {
+	// A manager_loop node with only subgraph_ref set should migrate cleanly
+	// with zero-value PollInterval, MaxCycles, and nil condition pointers.
+	// Exercises the attr-presence guards in applyManagerLoopScalarMigrate
+	// and applyManagerLoopConditionMigrate.
+	dot := `digraph W {
+  S [shape=Mdiamond, label="S"];
+  M [shape=house, label="Minimal", subgraph_ref="inner"];
+  E [shape=Msquare, label="E"];
+  S -> M;
+  M -> E;
+}`
+	w, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	var n *ir.Node
+	for _, node := range w.Nodes {
+		if node.ID == "M" {
+			n = node
+		}
+	}
+	if n == nil || n.Kind != ir.NodeManagerLoop {
+		t.Fatalf("node M wrong: %+v", n)
+	}
+	cfg, ok := n.Config.(ir.ManagerLoopConfig)
+	if !ok {
+		t.Fatalf("Config = %T", n.Config)
+	}
+	if cfg.SubgraphRef != "inner" {
+		t.Errorf("SubgraphRef = %q", cfg.SubgraphRef)
+	}
+	if cfg.PollInterval != 0 {
+		t.Errorf("PollInterval = %v, want 0", cfg.PollInterval)
+	}
+	if cfg.MaxCycles != 0 {
+		t.Errorf("MaxCycles = %d, want 0", cfg.MaxCycles)
+	}
+	if cfg.StopCondition != nil {
+		t.Errorf("StopCondition = %+v, want nil", cfg.StopCondition)
+	}
+	if cfg.SteerCondition != nil {
+		t.Errorf("SteerCondition = %+v, want nil", cfg.SteerCondition)
+	}
+	if cfg.SteerContext == nil {
+		t.Errorf("SteerContext should be non-nil empty map")
+	}
+	if len(cfg.SteerContext) != 0 {
+		t.Errorf("SteerContext should be empty; got %v", cfg.SteerContext)
+	}
+}

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2451,3 +2451,28 @@ func TestMigrate_ManagerLoop_Minimal(t *testing.T) {
 		t.Errorf("SteerContext should be empty; got %v", cfg.SteerContext)
 	}
 }
+
+func TestMigrate_ManagerLoop_AsStartNode(t *testing.T) {
+	// A manager_loop node at Start gets shape=Mdiamond from export, not shape=house.
+	// migrate must still reconstruct it as NodeManagerLoop by looking at attrs.
+	dot := `digraph W {
+  Supervise [shape=Mdiamond, label="Supervisor", subgraph_ref="inner", max_cycles="5", stop_condition="stack.child.outcome = success"];
+  Done [shape=Msquare, label="Done"];
+  Supervise -> Done;
+}`
+	w, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	n := w.Node("Supervise")
+	if n == nil || n.Kind != ir.NodeManagerLoop {
+		t.Fatalf("Supervise kind = %v, want NodeManagerLoop", n)
+	}
+	cfg, ok := n.Config.(ir.ManagerLoopConfig)
+	if !ok {
+		t.Fatalf("Config = %T", n.Config)
+	}
+	if cfg.SubgraphRef != "inner" || cfg.MaxCycles != 5 {
+		t.Errorf("fields lost on migrate through Mdiamond: %+v", cfg)
+	}
+}

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2374,12 +2374,7 @@ func TestMigrate_ManagerLoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Migrate: %v", err)
 	}
-	var n *ir.Node
-	for _, node := range w.Nodes {
-		if node.ID == "M" {
-			n = node
-		}
-	}
+	n := w.Node("M")
 	if n == nil {
 		t.Fatalf("node M not found in workflow")
 	}
@@ -2426,12 +2421,7 @@ func TestMigrate_ManagerLoop_Minimal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Migrate: %v", err)
 	}
-	var n *ir.Node
-	for _, node := range w.Nodes {
-		if node.ID == "M" {
-			n = node
-		}
-	}
+	n := w.Node("M")
 	if n == nil || n.Kind != ir.NodeManagerLoop {
 		t.Fatalf("node M wrong: %+v", n)
 	}

--- a/migrate/roundtrip_test.go
+++ b/migrate/roundtrip_test.go
@@ -1,0 +1,130 @@
+package migrate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/export"
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// TestExportDOT_ManagerLoop_SteerContextReservedCharsRoundTrip verifies that
+// steer_context values with reserved delimiters (',', '=', '%') round-trip
+// losslessly through ExportDOT → parseFlattenedSteerContext.
+//
+// Note: ExportDOT and migrate.Migrate() use different DOT formats at the
+// graph-attribute level (ExportDOT emits bare "key=val;" statements while
+// the migrate DOT parser expects "graph [key=val];" blocks), so the test
+// extracts the steer_context attr value directly from the DOT string and
+// passes it through parseFlattenedSteerContext.
+func TestExportDOT_ManagerLoop_SteerContextReservedCharsRoundTrip(t *testing.T) {
+	// Values with reserved delimiters (',', '=', '%') must round-trip losslessly
+	// through flattenSteerContext → parseFlattenedSteerContext.
+	original := map[string]string{
+		"hint":     "be concise, technical",
+		"priority": "high=medium",
+		"meta":     "100%",
+	}
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "S",
+		Exit:  "E",
+		Nodes: []*ir.Node{
+			{ID: "S", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{ID: "M", Kind: ir.NodeManagerLoop, Config: ir.ManagerLoopConfig{
+				SubgraphRef:  "inner",
+				MaxCycles:    5,
+				SteerContext: original,
+			}},
+			{ID: "E", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+		},
+		Edges: []*ir.Edge{{From: "S", To: "M"}, {From: "M", To: "E"}},
+	}
+	dot := export.ExportDOT(w, export.ExportOptions{})
+
+	// Extract the steer_context attribute value from the DOT string.
+	// It appears as: steer_context="<value>"
+	attrVal := extractDOTAttr(dot, "steer_context")
+	if attrVal == "" {
+		t.Fatalf("steer_context attr not found in DOT output:\n%s", dot)
+	}
+
+	// Decode via parseFlattenedSteerContext (the migrate path).
+	got := parseFlattenedSteerContext(attrVal)
+
+	for k, want := range original {
+		if got[k] != want {
+			t.Errorf("round-trip lost %q: got %q want %q", k, got[k], want)
+		}
+	}
+}
+
+// TestExportDOT_ManagerLoop_SteerContextNoReservedCharsPassThrough verifies
+// that plain keys/values (no reserved chars) are not mangled by the encoding.
+func TestExportDOT_ManagerLoop_SteerContextNoReservedCharsPassThrough(t *testing.T) {
+	original := map[string]string{
+		"hint":     "speed_up",
+		"priority": "high",
+	}
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "S",
+		Exit:  "E",
+		Nodes: []*ir.Node{
+			{ID: "S", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{ID: "M", Kind: ir.NodeManagerLoop, Config: ir.ManagerLoopConfig{
+				SubgraphRef:  "inner",
+				MaxCycles:    3,
+				SteerContext: original,
+			}},
+			{ID: "E", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+		},
+		Edges: []*ir.Edge{{From: "S", To: "M"}, {From: "M", To: "E"}},
+	}
+	dot := export.ExportDOT(w, export.ExportOptions{})
+
+	attrVal := extractDOTAttr(dot, "steer_context")
+	if attrVal == "" {
+		t.Fatalf("steer_context attr not found in DOT output:\n%s", dot)
+	}
+
+	// Plain values must not be mangled — the encoded form should equal "k=v,k=v".
+	keys := []string{"hint", "priority"}
+	sort.Strings(keys)
+	var parts []string
+	for _, k := range keys {
+		parts = append(parts, k+"="+original[k])
+	}
+	wantFlat := strings.Join(parts, ",")
+	if attrVal != wantFlat {
+		t.Errorf("plain steer_context encoded as %q, want %q", attrVal, wantFlat)
+	}
+
+	got := parseFlattenedSteerContext(attrVal)
+	for k, want := range original {
+		if got[k] != want {
+			t.Errorf("round-trip changed %q: got %q want %q", k, got[k], want)
+		}
+	}
+}
+
+// extractDOTAttr extracts the value of a DOT attribute from a line like:
+//
+//	key="value"
+//
+// It handles the quoted format produced by ExportDOT. Returns "" if not found.
+func extractDOTAttr(dot, key string) string {
+	needle := fmt.Sprintf(`%s="`, key)
+	idx := strings.Index(dot, needle)
+	if idx == -1 {
+		return ""
+	}
+	start := idx + len(needle)
+	end := strings.Index(dot[start:], `"`)
+	if end == -1 {
+		return ""
+	}
+	return dot[start : start+end]
+}

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -14,6 +14,7 @@ var defaultNodeConfigs = map[ir.NodeKind]func() ir.NodeConfig{
 	ir.NodeTool:        func() ir.NodeConfig { return ir.ToolConfig{} },
 	ir.NodeSubgraph:    func() ir.NodeConfig { return ir.SubgraphConfig{Params: make(map[string]string)} },
 	ir.NodeConditional: func() ir.NodeConfig { return ir.ConditionalConfig{} },
+	ir.NodeManagerLoop: func() ir.NodeConfig { return ir.ManagerLoopConfig{SteerContext: make(map[string]string)} },
 }
 
 // defaultNodeConfig returns the zero config for a given node kind.
@@ -148,7 +149,7 @@ func (p *Parser) applyPrimaryConfigField(n *ir.Node, key, val string, loc ir.Sou
 	return true
 }
 
-// applySecondaryConfigField handles tool, subgraph, and conditional config fields.
+// applySecondaryConfigField handles tool, subgraph, manager_loop, and conditional config fields.
 func (p *Parser) applySecondaryConfigField(n *ir.Node, key, val string, loc ir.SourceLocation) {
 	switch cfg := n.Config.(type) {
 	case ir.ToolConfig:
@@ -156,6 +157,9 @@ func (p *Parser) applySecondaryConfigField(n *ir.Node, key, val string, loc ir.S
 		n.Config = cfg
 	case ir.SubgraphConfig:
 		p.applySubgraphField(&cfg, key, val, loc)
+		n.Config = cfg
+	case ir.ManagerLoopConfig:
+		p.applyManagerLoopField(&cfg, key, val, loc)
 		n.Config = cfg
 	case ir.ConditionalConfig:
 		p.emitUnknownFieldHint("conditional", key, loc)
@@ -422,6 +426,96 @@ func (p *Parser) applySubgraphField(cfg *ir.SubgraphConfig, key, val string, loc
 	default:
 		p.emitUnknownFieldHint("subgraph", key, loc)
 	}
+}
+
+// applyManagerLoopField applies manager_loop-specific configuration fields.
+func (p *Parser) applyManagerLoopField(cfg *ir.ManagerLoopConfig, key, val string, loc ir.SourceLocation) {
+	if p.applyManagerLoopStringField(cfg, key, val) {
+		return
+	}
+	if p.applyManagerLoopParsedField(cfg, key, val, loc) {
+		return
+	}
+	p.emitUnknownFieldHint("manager_loop", key, loc)
+}
+
+// applyManagerLoopStringField handles string/condition fields. Returns true if handled.
+func (p *Parser) applyManagerLoopStringField(cfg *ir.ManagerLoopConfig, key, val string) bool {
+	switch key {
+	case "subgraph_ref":
+		cfg.SubgraphRef = val
+	case "stop_condition":
+		cfg.StopCondition = &ir.Condition{Raw: val}
+	case "steer_condition":
+		cfg.SteerCondition = &ir.Condition{Raw: val}
+	default:
+		return false
+	}
+	return true
+}
+
+// applyManagerLoopParsedField handles duration/int/map fields. Returns true if handled.
+func (p *Parser) applyManagerLoopParsedField(cfg *ir.ManagerLoopConfig, key, val string, loc ir.SourceLocation) bool {
+	switch key {
+	case "poll_interval":
+		cfg.PollInterval = p.parseDuration(val, key, loc)
+	case "max_cycles":
+		cfg.MaxCycles = p.parseInt(val, key, loc)
+	case "steer_context":
+		cfg.SteerContext = p.parseSteerContext(val)
+	default:
+		return false
+	}
+	return true
+}
+
+// parseSteerContext accepts both inline CSV ("k=v,k=v") and block-form content
+// (one "k: v" per line, same as parseParamsBlock). The inline form splits on
+// comma without quote-awareness — values containing commas MUST use the block
+// form or they will be truncated at the first comma.
+func (p *Parser) parseSteerContext(raw string) map[string]string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return map[string]string{}
+	}
+	if strings.Contains(raw, "\n") {
+		return p.parseParamsBlock(raw)
+	}
+	return p.parseSteerContextInline(raw)
+}
+
+// parseSteerContextInline parses "k=v, k=v, k=v" into a map. Values containing
+// commas are not supported — callers must use the block form for such values.
+func (p *Parser) parseSteerContextInline(raw string) map[string]string {
+	out := make(map[string]string)
+	for _, part := range strings.Split(raw, ",") {
+		p.applySteerContextEntry(out, strings.TrimSpace(part))
+	}
+	return out
+}
+
+// applySteerContextEntry parses a single "k=v" token into out, emitting
+// a diagnostic for malformed entries or duplicate keys.
+func (p *Parser) applySteerContextEntry(out map[string]string, raw string) {
+	if raw == "" {
+		return
+	}
+	kv := strings.SplitN(raw, "=", 2)
+	if len(kv) != 2 {
+		p.diagnostics = append(p.diagnostics,
+			fmt.Sprintf("steer_context entry %q must be key=value", raw))
+		return
+	}
+	k := strings.TrimSpace(kv[0])
+	v := strings.TrimSpace(kv[1])
+	if k == "" {
+		return
+	}
+	if _, exists := out[k]; exists {
+		p.diagnostics = append(p.diagnostics,
+			fmt.Sprintf("duplicate steer_context key %q (last value wins)", k))
+	}
+	out[k] = unquoteRaw(v)
 }
 
 // parseParamsBlock parses a raw block of key: value lines into a map.

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -476,15 +476,29 @@ func (p *Parser) applyManagerLoopParsedField(cfg *ir.ManagerLoopConfig, key, val
 //
 // Disambiguates forms by looking at the first separator: ":" → block form
 // (including single-entry block which has no embedded newline), "=" → inline.
+//
+// Post-parse: keys containing ':', ',', or '=' are dropped with a diagnostic
+// because they break the block-form round-trip (splitKeyValue splits on the
+// first colon) or the DOT flat-attr delimiter convention.
 func (p *Parser) parseSteerContext(raw string) map[string]string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return map[string]string{}
 	}
+	var result map[string]string
 	if isSteerContextBlockForm(raw) {
-		return p.parseParamsBlock(raw)
+		result = p.parseParamsBlock(raw)
+	} else {
+		result = p.parseSteerContextInline(raw)
 	}
-	return p.parseSteerContextInline(raw)
+	for k := range result {
+		if strings.ContainsAny(k, ":,=") {
+			p.diagnostics = append(p.diagnostics,
+				fmt.Sprintf("steer_context key %q contains reserved character (':', ',', or '=')", k))
+			delete(result, k)
+		}
+	}
+	return result
 }
 
 // isSteerContextBlockForm returns true when raw looks like block-form content

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -473,15 +473,33 @@ func (p *Parser) applyManagerLoopParsedField(cfg *ir.ManagerLoopConfig, key, val
 // (one "k: v" per line, same as parseParamsBlock). The inline form splits on
 // comma without quote-awareness — values containing commas MUST use the block
 // form or they will be truncated at the first comma.
+//
+// Disambiguates forms by looking at the first separator: ":" → block form
+// (including single-entry block which has no embedded newline), "=" → inline.
 func (p *Parser) parseSteerContext(raw string) map[string]string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return map[string]string{}
 	}
-	if strings.Contains(raw, "\n") {
+	if isSteerContextBlockForm(raw) {
 		return p.parseParamsBlock(raw)
 	}
 	return p.parseSteerContextInline(raw)
+}
+
+// isSteerContextBlockForm returns true when raw looks like block-form content
+// (one or more "k: v" lines) rather than inline "k=v,k=v". Decides by finding
+// the first ":" or "=" — whichever comes first wins.
+func isSteerContextBlockForm(raw string) bool {
+	colon := strings.Index(raw, ":")
+	equals := strings.Index(raw, "=")
+	if colon == -1 {
+		return false // no colon → cannot be block form
+	}
+	if equals == -1 {
+		return true // has colon, no equals → block form
+	}
+	return colon < equals
 }
 
 // parseSteerContextInline parses "k=v, k=v, k=v" into a map. Values containing

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -477,9 +477,11 @@ func (p *Parser) applyManagerLoopParsedField(cfg *ir.ManagerLoopConfig, key, val
 // Disambiguates forms by looking at the first separator: ":" → block form
 // (including single-entry block which has no embedded newline), "=" → inline.
 //
-// Post-parse: keys containing ':', ',', or '=' are dropped with a diagnostic
-// because they break the block-form round-trip (splitKeyValue splits on the
-// first colon) or the DOT flat-attr delimiter convention.
+// Post-parse: keys containing ':' are dropped with a diagnostic because the
+// formatter emits block form ("key: value") and parseParamsBlock splits on the
+// first colon — a colon in the key breaks the .dip-internal round-trip.
+// ',' and '=' are percent-encoded at the DOT export/migrate boundary, so they
+// no longer need to be rejected here.
 func (p *Parser) parseSteerContext(raw string) map[string]string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -492,9 +494,9 @@ func (p *Parser) parseSteerContext(raw string) map[string]string {
 		result = p.parseSteerContextInline(raw)
 	}
 	for k := range result {
-		if strings.ContainsAny(k, ":,=") {
+		if strings.Contains(k, ":") {
 			p.diagnostics = append(p.diagnostics,
-				fmt.Sprintf("steer_context key %q contains reserved character (':', ',', or '=')", k))
+				fmt.Sprintf("steer_context key %q contains ':' which breaks block-form round-trip through the formatter", k))
 			delete(result, k)
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -77,7 +77,8 @@ func (p *Parser) parseWorkflowBody() {
 
 // workflowNodeKinds maps identifiers to their node kinds for dispatch.
 var workflowNodeKinds = map[string]bool{
-	"agent": true, "human": true, "tool": true, "subgraph": true, "conditional": true,
+	"agent": true, "human": true, "tool": true,
+	"subgraph": true, "conditional": true, "manager_loop": true,
 }
 
 // workflowSimpleBlocks maps workflow block keywords to their parser methods.

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1801,3 +1801,36 @@ func TestParseManagerLoop_SteerContextInline_CommaInValueTruncates(t *testing.T)
 		t.Errorf("expected malformed-entry diagnostic; got %v", p.diagnostics)
 	}
 }
+
+func TestParseManagerLoop_SteerContextBlock_SingleEntry(t *testing.T) {
+	// Regression: a single-entry block-form steer_context produces a raw
+	// block value with no embedded newline. The pre-fix parser routed that
+	// to the inline CSV handler and emitted a "must be key=value" diagnostic.
+	src := `workflow W
+  start: M
+  exit: M
+
+  manager_loop M
+    subgraph_ref: inner
+    steer_context:
+      hint: halfway_through
+
+  edges
+    M -> M
+`
+	p := NewParser(src, "")
+	_, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse returned error (diagnostics): %v", err)
+	}
+	if len(p.diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics on single-entry block form: %v", p.diagnostics)
+	}
+	cfg := p.workflow.Nodes[0].Config.(ir.ManagerLoopConfig)
+	if cfg.SteerContext["hint"] != "halfway_through" {
+		t.Errorf("SteerContext[hint] = %q, want %q", cfg.SteerContext["hint"], "halfway_through")
+	}
+	if len(cfg.SteerContext) != 1 {
+		t.Errorf("SteerContext size = %d, want 1: %v", len(cfg.SteerContext), cfg.SteerContext)
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1834,3 +1834,42 @@ func TestParseManagerLoop_SteerContextBlock_SingleEntry(t *testing.T) {
 		t.Errorf("SteerContext size = %d, want 1: %v", len(cfg.SteerContext), cfg.SteerContext)
 	}
 }
+
+func TestParseManagerLoop_SteerContextKeyWithColon(t *testing.T) {
+	// Keys containing ':' break the block-form round-trip (splitKeyValue splits
+	// on first colon), so the parser rejects them with a diagnostic and drops
+	// the entry. Valid keys in the same entry are still parsed.
+	//
+	// Note: isSteerContextBlockForm routes to block form when ':' comes before '='
+	// in the raw string. To get a ':'-containing key into the inline parser, '='
+	// must appear before ':' in the first token — e.g. "hint=ok, ns:weird=value".
+	src := `workflow W
+  start: M
+  exit: M
+
+  manager_loop M
+    subgraph_ref: inner
+    steer_context: hint=ok, ns:weird=value
+
+  edges
+    M -> M
+`
+	p := NewParser(src, "")
+	_, _ = p.Parse()
+	cfg := p.workflow.Nodes[0].Config.(ir.ManagerLoopConfig)
+	if _, bad := cfg.SteerContext["ns:weird"]; bad {
+		t.Errorf("key with ':' should have been dropped, got %v", cfg.SteerContext)
+	}
+	if cfg.SteerContext["hint"] != "ok" {
+		t.Errorf("hint should still parse: %v", cfg.SteerContext)
+	}
+	found := false
+	for _, d := range p.diagnostics {
+		if strings.Contains(d, `"ns:weird"`) && strings.Contains(d, "reserved") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected diagnostic about key with ':'; got %v", p.diagnostics)
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1640,3 +1640,164 @@ func TestParseDefaultsBudgetRoundTrip(t *testing.T) {
 		t.Errorf("round-trip: max_wall_time = %v, want 30m0s", d.MaxWallTime)
 	}
 }
+
+func TestParseManagerLoopNode(t *testing.T) {
+	src := `workflow W
+  start: M
+  exit: M
+
+  manager_loop M
+    label: "Quality Gate Supervisor"
+    subgraph_ref: quality_loop
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.cycles = 10
+    steer_condition: stack.child.cycles = 5
+
+  edges
+    M -> M
+`
+	p := NewParser(src, "")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if len(w.Nodes) != 1 {
+		t.Fatalf("got %d nodes, want 1", len(w.Nodes))
+	}
+	n := w.Nodes[0]
+	if n.Kind != ir.NodeManagerLoop {
+		t.Errorf("Kind = %q, want %q", n.Kind, ir.NodeManagerLoop)
+	}
+	cfg, ok := n.Config.(ir.ManagerLoopConfig)
+	if !ok {
+		t.Fatalf("Config = %T, want ManagerLoopConfig", n.Config)
+	}
+	if cfg.SubgraphRef != "quality_loop" {
+		t.Errorf("SubgraphRef = %q, want %q", cfg.SubgraphRef, "quality_loop")
+	}
+	if cfg.PollInterval != 30*time.Second {
+		t.Errorf("PollInterval = %v, want 30s", cfg.PollInterval)
+	}
+	if cfg.MaxCycles != 12 {
+		t.Errorf("MaxCycles = %d, want 12", cfg.MaxCycles)
+	}
+	if n.Label != "Quality Gate Supervisor" {
+		t.Errorf("Label = %q", n.Label)
+	}
+	if cfg.StopCondition == nil || cfg.StopCondition.Raw != "stack.child.cycles = 10" {
+		t.Errorf("StopCondition.Raw = %+v", cfg.StopCondition)
+	}
+	if cfg.SteerCondition == nil || cfg.SteerCondition.Raw != "stack.child.cycles = 5" {
+		t.Errorf("SteerCondition.Raw = %+v", cfg.SteerCondition)
+	}
+}
+
+func TestParseManagerLoop_SteerContextInline(t *testing.T) {
+	src := `workflow W
+  start: M
+  exit: M
+
+  manager_loop M
+    subgraph_ref: inner
+    steer_context: hint=speed_up, priority=high
+
+  edges
+    M -> M
+`
+	p := NewParser(src, "")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	cfg := w.Nodes[0].Config.(ir.ManagerLoopConfig)
+	if cfg.SteerContext["hint"] != "speed_up" || cfg.SteerContext["priority"] != "high" {
+		t.Errorf("SteerContext = %v", cfg.SteerContext)
+	}
+}
+
+func TestParseManagerLoop_SteerContextBlock(t *testing.T) {
+	src := `workflow W
+  start: M
+  exit: M
+
+  manager_loop M
+    subgraph_ref: inner
+    steer_context:
+      hint: speed_up
+      priority: high
+
+  edges
+    M -> M
+`
+	p := NewParser(src, "")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	cfg := w.Nodes[0].Config.(ir.ManagerLoopConfig)
+	if cfg.SteerContext["hint"] != "speed_up" || cfg.SteerContext["priority"] != "high" {
+		t.Errorf("SteerContext = %v", cfg.SteerContext)
+	}
+}
+
+func TestParseManagerLoop_UnknownFieldHint(t *testing.T) {
+	src := `workflow W
+  start: M
+  exit: M
+
+  manager_loop M
+    subgraph_ref: inner
+    bogus_field: value
+
+  edges
+    M -> M
+`
+	p := NewParser(src, "")
+	_, err := p.Parse()
+	if err == nil {
+		t.Fatalf("expected parse error containing unknown-field hint; got nil")
+	}
+	if !strings.Contains(err.Error(), "manager_loop") || !strings.Contains(err.Error(), "bogus_field") {
+		t.Errorf("expected error mentioning manager_loop and bogus_field; got %v", err)
+	}
+}
+
+func TestParseManagerLoop_SteerContextInline_CommaInValueTruncates(t *testing.T) {
+	// Documents the limitation of the inline form: a value containing a comma
+	// is split at that comma. Users needing comma-containing values must use
+	// the block form. This test exists so future refactors don't silently
+	// change the behavior without a deliberate decision.
+	src := `workflow W
+  start: M
+  exit: M
+
+  manager_loop M
+    subgraph_ref: inner
+    steer_context: hint="speed, up", priority=high
+
+  edges
+    M -> M
+`
+	p := NewParser(src, "")
+	_, _ = p.Parse() // non-nil err expected (malformed entry diagnostic)
+	cfg := p.workflow.Nodes[0].Config.(ir.ManagerLoopConfig)
+	// hint is truncated to `"speed` (the part before the comma, quote preserved).
+	if cfg.SteerContext["hint"] != `"speed` {
+		t.Errorf("hint = %q, want %q (documents inline-form truncation)", cfg.SteerContext["hint"], `"speed`)
+	}
+	// priority parses normally because it's after the second comma.
+	if cfg.SteerContext["priority"] != "high" {
+		t.Errorf("priority = %q, want %q", cfg.SteerContext["priority"], "high")
+	}
+	// A "malformed entry" diagnostic is emitted for the middle fragment.
+	gotMalformed := false
+	for _, d := range p.diagnostics {
+		if strings.Contains(d, "must be key=value") {
+			gotMalformed = true
+		}
+	}
+	if !gotMalformed {
+		t.Errorf("expected malformed-entry diagnostic; got %v", p.diagnostics)
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1865,7 +1865,7 @@ func TestParseManagerLoop_SteerContextKeyWithColon(t *testing.T) {
 	}
 	found := false
 	for _, d := range p.diagnostics {
-		if strings.Contains(d, `"ns:weird"`) && strings.Contains(d, "reserved") {
+		if strings.Contains(d, `"ns:weird"`) && strings.Contains(d, ":") {
 			found = true
 		}
 	}

--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -4,22 +4,24 @@ package scaffold
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/2389-research/dippin-lang/ir"
 )
 
 // TemplateNames returns the sorted list of available template names.
 func TemplateNames() []string {
-	return []string{"conditional", "human-gate", "minimal", "parallel", "review-loop"}
+	return []string{"conditional", "human-gate", "manager_loop", "minimal", "parallel", "review-loop"}
 }
 
 // templateBuilders maps template names to their builder functions.
 var templateBuilders = map[string]func(string) *ir.Workflow{
-	"minimal":     buildMinimal,
-	"parallel":    buildParallel,
-	"conditional": buildConditional,
-	"review-loop": buildReviewLoop,
-	"human-gate":  buildHumanGate,
+	"minimal":      buildMinimal,
+	"parallel":     buildParallel,
+	"conditional":  buildConditional,
+	"review-loop":  buildReviewLoop,
+	"human-gate":   buildHumanGate,
+	"manager_loop": buildManagerLoop,
 }
 
 // Build constructs an ir.Workflow for the named template.
@@ -188,6 +190,31 @@ func buildHumanGate(name string) *ir.Workflow {
 			{From: "Gate", To: "Rejected", Label: "reject"},
 			{From: "Approved", To: "Done"},
 			{From: "Rejected", To: "Done"},
+		},
+	}
+}
+
+func buildManagerLoop(name string) *ir.Workflow {
+	return &ir.Workflow{
+		Name:  name,
+		Goal:  "Supervise a child pipeline with periodic steering",
+		Start: "Supervise",
+		Exit:  "Done",
+		Nodes: []*ir.Node{
+			{ID: "Supervise", Kind: ir.NodeManagerLoop, Label: "Quality Gate Supervisor", Config: ir.ManagerLoopConfig{
+				SubgraphRef:    "child_pipeline.dip",
+				PollInterval:   30 * time.Second,
+				MaxCycles:      10,
+				StopCondition:  &ir.Condition{Raw: "stack.child.outcome = success"},
+				SteerCondition: &ir.Condition{Raw: "stack.child.cycles = 5"},
+				SteerContext:   map[string]string{"hint": "halfway_through"},
+			}},
+			{ID: "Done", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+				Prompt: "Summarize the supervised run outcome.",
+			}},
+		},
+		Edges: []*ir.Edge{
+			{From: "Supervise", To: "Done"},
 		},
 	}
 }

--- a/scaffold/scaffold_test.go
+++ b/scaffold/scaffold_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/2389-research/dippin-lang/formatter"
+	"github.com/2389-research/dippin-lang/ir"
 	"github.com/2389-research/dippin-lang/parser"
 	"github.com/2389-research/dippin-lang/validator"
 )
@@ -71,7 +72,46 @@ func TestBuild_UnknownTemplate(t *testing.T) {
 
 func TestTemplateNames(t *testing.T) {
 	names := TemplateNames()
-	if len(names) != 5 {
-		t.Errorf("expected 5 templates, got %d: %v", len(names), names)
+	if len(names) != 6 {
+		t.Errorf("expected 6 templates, got %d: %v", len(names), names)
 	}
+}
+
+func TestBuildManagerLoop(t *testing.T) {
+	w, err := Build("manager_loop", "Supervisor")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if w.Name != "Supervisor" {
+		t.Errorf("Name = %q, want %q", w.Name, "Supervisor")
+	}
+	hasManager := false
+	for _, n := range w.Nodes {
+		if n.Kind == ir.NodeManagerLoop {
+			hasManager = true
+			cfg, ok := n.Config.(ir.ManagerLoopConfig)
+			if !ok {
+				t.Fatalf("manager_loop node Config = %T, want ManagerLoopConfig", n.Config)
+			}
+			if cfg.SubgraphRef == "" {
+				t.Errorf("ManagerLoopConfig.SubgraphRef is empty in template output")
+			}
+			if cfg.MaxCycles == 0 && cfg.StopCondition == nil {
+				t.Errorf("template is unbounded — would trigger DIP137")
+			}
+		}
+	}
+	if !hasManager {
+		t.Errorf("no NodeManagerLoop node in template output")
+	}
+}
+
+func TestTemplateNames_IncludesManagerLoop(t *testing.T) {
+	names := TemplateNames()
+	for _, n := range names {
+		if n == "manager_loop" {
+			return
+		}
+	}
+	t.Errorf("manager_loop missing from TemplateNames: %v", names)
 }

--- a/simulate/condition.go
+++ b/simulate/condition.go
@@ -262,12 +262,18 @@ func isWordBreak(ch byte) bool {
 	return ch == ' ' || ch == '\t' || isOperatorChar(ch)
 }
 
-// EnsureConditionsParsed walks all edges in a workflow and ensures that any
-// Condition with a Raw string but nil Parsed field gets parsed. This is needed
-// because the .dip parser may not always populate the Parsed AST.
+// EnsureConditionsParsed walks all edges and manager_loop nodes in a workflow
+// and ensures that any Condition with a Raw string but nil Parsed field gets
+// parsed. This is needed because the .dip parser stores Raw text only; the
+// AST is lazily populated before lint checks run and before simulation.
 func EnsureConditionsParsed(w *ir.Workflow) error {
 	for _, e := range w.Edges {
 		if err := ensureEdgeConditionParsed(e); err != nil {
+			return err
+		}
+	}
+	for _, n := range w.Nodes {
+		if err := ensureNodeConditionsParsed(n); err != nil {
 			return err
 		}
 	}
@@ -284,5 +290,30 @@ func ensureEdgeConditionParsed(e *ir.Edge) error {
 		return fmt.Errorf("edge %s -> %s: invalid condition %q: %w", e.From, e.To, e.Condition.Raw, err)
 	}
 	e.Condition.Parsed = parsed
+	return nil
+}
+
+// ensureNodeConditionsParsed walks node-level conditions (currently manager_loop only).
+func ensureNodeConditionsParsed(n *ir.Node) error {
+	cfg, ok := n.Config.(ir.ManagerLoopConfig)
+	if !ok {
+		return nil
+	}
+	if err := ensureConditionParsed(cfg.StopCondition, n.ID, "stop_condition"); err != nil {
+		return err
+	}
+	return ensureConditionParsed(cfg.SteerCondition, n.ID, "steer_condition")
+}
+
+// ensureConditionParsed parses a single Condition if it has Raw but no Parsed.
+func ensureConditionParsed(c *ir.Condition, nodeID, field string) error {
+	if c == nil || c.Parsed != nil || c.Raw == "" {
+		return nil
+	}
+	parsed, err := ParseCondition(c.Raw)
+	if err != nil {
+		return fmt.Errorf("node %s %s: invalid condition %q: %w", nodeID, field, c.Raw, err)
+	}
+	c.Parsed = parsed
 	return nil
 }

--- a/simulate/condition_test.go
+++ b/simulate/condition_test.go
@@ -1,6 +1,7 @@
 package simulate
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/2389-research/dippin-lang/ir"
@@ -213,5 +214,55 @@ func TestEnsureConditionsParsed(t *testing.T) {
 	// Third edge should remain as-is (already parsed).
 	if w.Edges[2].Condition.Parsed == nil {
 		t.Error("edge C->D condition should still be parsed")
+	}
+}
+
+func TestEnsureConditionsParsed_ManagerLoop(t *testing.T) {
+	stop := &ir.Condition{Raw: "stack.child.cycles = 10"}
+	steer := &ir.Condition{Raw: "stack.child.cycles = 5"}
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "M",
+		Exit:  "M",
+		Nodes: []*ir.Node{
+			{ID: "M", Kind: ir.NodeManagerLoop, Config: ir.ManagerLoopConfig{
+				SubgraphRef:    "inner",
+				StopCondition:  stop,
+				SteerCondition: steer,
+			}},
+		},
+	}
+	if err := EnsureConditionsParsed(w); err != nil {
+		t.Fatalf("EnsureConditionsParsed error: %v", err)
+	}
+	if stop.Parsed == nil {
+		t.Errorf("StopCondition.Parsed still nil after EnsureConditionsParsed")
+	}
+	if steer.Parsed == nil {
+		t.Errorf("SteerCondition.Parsed still nil after EnsureConditionsParsed")
+	}
+}
+
+func TestEnsureConditionsParsed_ManagerLoop_InvalidCondition(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "M",
+		Exit:  "M",
+		Nodes: []*ir.Node{
+			{ID: "Supervisor", Kind: ir.NodeManagerLoop, Config: ir.ManagerLoopConfig{
+				SubgraphRef:   "inner",
+				StopCondition: &ir.Condition{Raw: "stack.child.cycles ="},
+			}},
+		},
+	}
+	err := EnsureConditionsParsed(w)
+	if err == nil {
+		t.Fatal("expected error for invalid condition, got nil")
+	}
+	if !strings.Contains(err.Error(), "node Supervisor stop_condition") {
+		t.Errorf("error %q does not contain %q", err.Error(), "node Supervisor stop_condition")
+	}
+	if !strings.Contains(err.Error(), `"stack.child.cycles ="`) {
+		t.Errorf("error %q does not include the offending raw condition", err.Error())
 	}
 }

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,15 +4,31 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.21.0] — 2026-04-20
+
+### Added
+- **`HumanConfig.Timeout` / `TimeoutAction`** on human nodes (tracker#112). Pairs with edge labels like `when: timeout` for auto-advance semantics. Round-trips through parser, formatter, DOT export, and migrate. ([#22](https://github.com/2389-research/dippin-lang/pull/22))
+- **`WorkflowDefaults` budget fields** (tracker#67): `max_total_tokens`, `max_cost_cents`, `max_wall_time`. Allow workflows to declare global budget caps consumed by the runtime. ([#22](https://github.com/2389-research/dippin-lang/pull/22))
+- **Scoped context reads** — `ctx.node.<id>.*` now validates as a legitimate read pattern in DIP121/DIP122, eliminating lint false-positives for cross-node state access (tracker#75). ([#23](https://github.com/2389-research/dippin-lang/pull/23))
+- **Agent-readiness discovery endpoints** on the docs site: `.well-known/agent-skills/index.json`, `.well-known/mcp/server-card.json`, `.well-known/api-catalog`, `robots.txt`, and hosted `skill.md`. Lets coding agents auto-discover dippin-lang tooling. ([#24](https://github.com/2389-research/dippin-lang/pull/24))
+- **`reasoning_effort` expansion** — DIP119 now accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max` to cover Opus 4.7 and GPT-5.4.
+- **Model catalog update** (verified 2026-04-17): `claude-opus-4-7` (Anthropic, $5/$25), `mistral-small-2603` (Mistral Small 4), `command-a-03-2025` (Cohere flagship, $2.50/$10).
+
+### Fixed
+- **Syntax grammars** (VS Code TextMate, language-configuration, site highlight.js) updated to cover the `conditional` node kind and `vars` section introduced in v0.20.0.
+- **`claude-haiku-3-5` deprecation comment** corrected — retired 2026-02-19, not 2026-04-19.
+
 ## [v0.20.0] — 2026-04-17
 
 ### Added
 - **`vars` block** at the workflow level for declaring user-defined variables. Vars export as DOT graph-level attributes and round-trip through parse → format → export → migrate.
-- **DIP134 lint rule**: warns on `max_retries` vs `max_restarts` confusion.
+- **DIP134 lint rule**: warns when `max_retries` is set in defaults with `restart: true` edges but no `max_restarts` — catches the common confusion between per-node LLM retries and loop restart budget.
+- **Release invariant checks** (`releasecheck/`) — validates the embedded spec is tracked, current, and buildable from a source tree without `.git`.
 
 ### Fixed
-- **DIP125 false positives on shell variable assignments** (tracker#87). Shell AST parsing via `mvdan.cc/sh/v3` replaces regex-based extraction.
-- **`go install ...@latest` broken** — embedded spec now checked in.
+- **DIP125 false positives on shell variable assignments** (tracker#87). Replaced regex-based binary extraction with proper shell AST parsing via `mvdan.cc/sh/v3`. Variable assignments, command substitutions, and `command -v` checks are now correctly identified. Preamble commands (`mkdir`) are skipped to find the real tool binary.
+- **`go install ...@latest` broken** — `cmd/dippin/generated-spec.md` is now checked into the repo so the `go:embed` directive resolves from module proxy downloads.
+- **Pre-commit hook and `just check` now mirror CI exactly** — spec freshness, release checks, complexity exclusions all aligned.
 
 ## [v0.19.1] — 2026-04-16
 

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -87,7 +87,7 @@ Vars are exported as graph-level DOT attributes so they round-trip through `dipp
 
 ## Node Kinds
 
-There are 7 node kinds, each with its own syntax and configuration:
+There are 8 node kinds, each with its own syntax and configuration:
 
 <div class="flow-diagram">
   <div class="pipeline-box lavender">agent<br>LLM interaction</div>
@@ -97,6 +97,7 @@ There are 7 node kinds, each with its own syntax and configuration:
   <div class="pipeline-box green">fan_in<br>Join</div>
   <div class="pipeline-box yellow">subgraph<br>Sub-pipeline</div>
   <div class="pipeline-box cream">conditional<br>Pure routing</div>
+  <div class="pipeline-box lavender">manager_loop<br>Child supervisor</div>
 </div>
 
 ### agent
@@ -189,6 +190,38 @@ Subgraph nodes embed another workflow as a single step. Parameters are passed vi
       strict: true
       model: gpt-5.4
 ```
+
+### manager_loop
+
+Manager loop nodes supervise a child sub-pipeline: they spawn it, poll it on a configurable cadence, and can steer it by injecting additional context during execution. They map to Tracker's `stack.manager_loop` construct and export as DOT shape `house`.
+
+```
+  manager_loop QualityGate
+    label: "Quality Gate Supervisor"
+    subgraph_ref: quality_loop.dip
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.outcome = success
+    steer_condition: stack.child.cycles = 5
+    steer_context:
+      hint: halfway_through
+      priority: high
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subgraph_ref` | String | **Required.** Path to the child `.dip` file (DIP135 if missing or not found) |
+| `poll_interval` | Duration | How often to poll the child (e.g. `30s`, `5m`). `0` means event-driven |
+| `max_cycles` | Integer | Maximum poll cycles before the node exits. `0` = unbounded — triggers DIP137 |
+| `stop_condition` | Condition | Expression over `stack.child.*` evaluated each cycle; when true the loop exits |
+| `steer_condition` | Condition | When true, inject `steer_context` into the running child |
+| `steer_context` | map[string]string | Key-value pairs injected on steer. Inline `k=v, k=v` or indented block form. Inline values may not contain commas |
+
+**Runtime state** exposed as context variables: `stack.child.cycles`, `stack.child.outcome`, `stack.child.status`.
+
+**Lint codes:** DIP135 (subgraph_ref missing or file not found), DIP136 (invalid control field value), DIP137 (unbounded loop — max_cycles: 0).
+
+See [docs/nodes.md](https://github.com/2389-research/dippin-lang/blob/main/docs/nodes.md) for the complete field reference.
 
 ### Conditional Nodes
 

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -195,7 +195,7 @@ Subgraph nodes embed another workflow as a single step. Parameters are passed vi
 
 Manager loop nodes supervise a child sub-pipeline: they spawn it, poll it on a configurable cadence, and can steer it by injecting additional context during execution. They map to Tracker's `stack.manager_loop` construct and export as DOT shape `house`.
 
-```
+```dippin
   manager_loop QualityGate
     label: "Quality Gate Supervisor"
     subgraph_ref: quality_loop.dip

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -155,7 +155,7 @@ Inline syntax only. Every `parallel` must have a matching `fan_in` with identica
 
 Spawns a child `.dip` pipeline, polls it on a cadence, and can steer it by injecting context. Maps to `stack.manager_loop` in Tracker; DOT shape `house`. Full reference: [docs/nodes.md](https://github.com/2389-research/dippin-lang/blob/main/docs/nodes.md).
 
-```
+```dip
   manager_loop QualityGate
     label: "Quality Gate Supervisor"
     subgraph_ref: quality_loop.dip
@@ -282,7 +282,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP009) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001-DIP133) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001-DIP137) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -151,6 +151,34 @@ Inline syntax only. Every `parallel` must have a matching `fan_in` with identica
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
+### manager_loop — supervised child pipeline
+
+Spawns a child `.dip` pipeline, polls it on a cadence, and can steer it by injecting context. Maps to `stack.manager_loop` in Tracker; DOT shape `house`. Full reference: [docs/nodes.md](https://github.com/2389-research/dippin-lang/blob/main/docs/nodes.md).
+
+```
+  manager_loop QualityGate
+    label: "Quality Gate Supervisor"
+    subgraph_ref: quality_loop.dip
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.outcome = success
+    steer_condition: stack.child.cycles = 5
+    steer_context:
+      hint: halfway_through
+      priority: high
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `subgraph_ref` | string | **Required.** Path to child .dip file (DIP135 if missing/not found) |
+| `poll_interval` | duration | Poll cadence (e.g. `30s`). `0` = event-driven |
+| `max_cycles` | int | Max poll cycles. `0` = unbounded → DIP137 |
+| `stop_condition` | condition | Over `stack.child.*`; when true the loop exits |
+| `steer_condition` | condition | When true, inject `steer_context` into child |
+| `steer_context` | map[string]string | Inline `k=v, k=v` or block form. No commas in inline values |
+
+Runtime state: `stack.child.cycles`, `stack.child.outcome`, `stack.child.status`. Lint: DIP135 (bad ref), DIP136 (invalid field), DIP137 (unbounded).
+
 ## Common Fields (all block nodes)
 
 | Field | Notes |

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -369,5 +369,26 @@ func nodeValidationExplanations() map[string]Explanation {
 			Fix:     "If you want to control loop iterations, set max_restarts instead of (or in addition to) max_retries.",
 			Example: "defaults\n  max_retries: 5  // but no max_restarts!\n\nedges\n  Review -> Implement  restart: true",
 		},
+		DIP135: {
+			Code:    DIP135,
+			Summary: "manager_loop subgraph_ref missing or file does not exist",
+			Trigger: "A manager_loop node either has no subgraph_ref field set, or the referenced file cannot be found on disk.",
+			Fix:     "Set subgraph_ref to the path of an existing .dip file that defines the child pipeline.",
+			Example: "manager_loop Supervise\n  subgraph_ref: quality_loop.dip  // file must exist relative to this workflow",
+		},
+		DIP136: {
+			Code:    DIP136,
+			Summary: "manager_loop control field has invalid value",
+			Trigger: "A manager_loop field failed validation: poll_interval is negative, max_cycles is negative, or steer_context entries are not valid key=value pairs.",
+			Fix:     "Use a non-negative duration for poll_interval (e.g., 30s), a positive integer for max_cycles, and comma-separated key=value pairs (or a block) for steer_context.",
+			Example: "manager_loop Supervise\n  subgraph_ref: inner\n  poll_interval: 30s\n  max_cycles: 12\n  steer_context: hint=speed_up, priority=high",
+		},
+		DIP137: {
+			Code:    DIP137,
+			Summary: "unbounded manager_loop: no stop_condition and no max_cycles",
+			Trigger: "A manager_loop node has neither a stop_condition nor a max_cycles cap, so supervision can run forever.",
+			Fix:     "Set stop_condition (e.g., stack.child.outcome = success) or max_cycles to bound supervision.",
+			Example: "manager_loop Supervise\n  subgraph_ref: inner\n  stop_condition: stack.child.outcome = success  // or: max_cycles: 20",
+		},
 	}
 }

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -378,10 +378,10 @@ func nodeValidationExplanations() map[string]Explanation {
 		},
 		DIP136: {
 			Code:    DIP136,
-			Summary: "manager_loop control field has invalid value (poll_interval or max_cycles)",
-			Trigger: "A manager_loop control field failed validation: poll_interval is negative, or max_cycles is negative.",
-			Fix:     "Use a non-negative duration for poll_interval (e.g., 30s; 0 means event-driven) and a non-negative integer for max_cycles (0 means unbounded).",
-			Example: "manager_loop Supervise\n  subgraph_ref: inner\n  poll_interval: 30s\n  max_cycles: 12",
+			Summary: "manager_loop control field has invalid value (poll_interval, max_cycles, or steer_context delimiter)",
+			Trigger: "A manager_loop control field failed validation: poll_interval is negative, max_cycles is negative, or steer_context contains a key/value with reserved delimiters ',' or '='.",
+			Fix:     "Use non-negative values for poll_interval and max_cycles. For steer_context, ensure no key or value contains ',' or '=' — those are delimiters in the DOT flat-attr form.",
+			Example: "manager_loop Supervise\n  subgraph_ref: inner\n  poll_interval: -30s    // DIP136: negative\n  max_cycles: -1          // DIP136: negative",
 		},
 		DIP137: {
 			Code:    DIP137,

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -378,9 +378,9 @@ func nodeValidationExplanations() map[string]Explanation {
 		},
 		DIP136: {
 			Code:    DIP136,
-			Summary: "manager_loop control field has invalid value (poll_interval, max_cycles, or steer_context delimiter)",
-			Trigger: "A manager_loop control field failed validation: poll_interval is negative, max_cycles is negative, or steer_context contains a key/value with reserved delimiters ',' or '='.",
-			Fix:     "Use non-negative values for poll_interval and max_cycles. For steer_context, ensure no key or value contains ',' or '=' — those are delimiters in the DOT flat-attr form.",
+			Summary: "manager_loop control field has invalid value (poll_interval or max_cycles)",
+			Trigger: "poll_interval or max_cycles is negative.",
+			Fix:     "Use non-negative values for poll_interval and max_cycles.",
 			Example: "manager_loop Supervise\n  subgraph_ref: inner\n  poll_interval: -30s    // DIP136: negative\n  max_cycles: -1          // DIP136: negative",
 		},
 		DIP137: {

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -378,10 +378,10 @@ func nodeValidationExplanations() map[string]Explanation {
 		},
 		DIP136: {
 			Code:    DIP136,
-			Summary: "manager_loop control field has invalid value",
-			Trigger: "A manager_loop field failed validation: poll_interval is negative, max_cycles is negative, or steer_context entries are not valid key=value pairs.",
-			Fix:     "Use a non-negative duration for poll_interval (e.g., 30s), a positive integer for max_cycles, and comma-separated key=value pairs (or a block) for steer_context.",
-			Example: "manager_loop Supervise\n  subgraph_ref: inner\n  poll_interval: 30s\n  max_cycles: 12\n  steer_context: hint=speed_up, priority=high",
+			Summary: "manager_loop control field has invalid value (poll_interval or max_cycles)",
+			Trigger: "A manager_loop control field failed validation: poll_interval is negative, or max_cycles is negative.",
+			Fix:     "Use a non-negative duration for poll_interval (e.g., 30s; 0 means event-driven) and a non-negative integer for max_cycles (0 means unbounded).",
+			Example: "manager_loop Supervise\n  subgraph_ref: inner\n  poll_interval: 30s\n  max_cycles: 12",
 		},
 		DIP137: {
 			Code:    DIP137,

--- a/validator/explanations_test.go
+++ b/validator/explanations_test.go
@@ -30,3 +30,14 @@ func assertFieldNonEmpty(t *testing.T, code, field, value string) {
 		t.Errorf("%s: %s is empty", code, field)
 	}
 }
+
+func TestManagerLoopCodesRegistered(t *testing.T) {
+	for _, code := range []string{DIP135, DIP136, DIP137} {
+		if _, ok := CodeDescription[code]; !ok {
+			t.Errorf("%s missing from CodeDescription", code)
+		}
+		if _, ok := Explanations[code]; !ok {
+			t.Errorf("%s missing from Explanations", code)
+		}
+	}
+}

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -62,7 +62,8 @@ func Lint(w *ir.Workflow) Result {
 
 // knownNamespaces lists the valid namespace prefixes for variable references.
 // Per §8.2 of the Dippin spec: ctx. (runtime context), graph. (workflow-level
-// attributes), params. (module parameters for composition).
+// attributes), params. (module parameters for composition), stack. (supervisor
+// state exposed by manager_loop, e.g., stack.child.cycles).
 // node.* is intentionally excluded: it requires structural validation
 // (node ID must exist, ref must have exactly 3 parts) handled in isVarRefValid.
 // Used by lint_context.go (DIP106) and lint_conditions.go (DIP120).
@@ -70,6 +71,7 @@ var knownNamespaces = map[string]bool{
 	"ctx":    true,
 	"graph":  true,
 	"params": true,
+	"stack":  true,
 }
 
 // buildForwardAdjacency builds a forward adjacency map for non-restart edges,

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -48,6 +48,7 @@ func Lint(w *ir.Workflow) Result {
 	diags = append(diags, lintToolCtxVars(w)...)
 	diags = append(diags, lintToolBinary(w)...)
 	diags = append(diags, lintSubgraphRef(w)...)
+	diags = append(diags, lintManagerLoop(w)...)
 	diags = append(diags, lintHumanMode(w)...)
 	diags = append(diags, lintInterviewDefault(w)...)
 	diags = append(diags, lintInterviewLabeledEdges(w)...)

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -36,6 +36,9 @@ const (
 	DIP132 = "DIP132" // response_schema is not valid JSON
 	DIP133 = "DIP133" // agent params key shadows a first-class field
 	DIP134 = "DIP134" // max_retries set with restart edges but no max_restarts
+	DIP135 = "DIP135" // manager_loop subgraph_ref missing or file does not exist
+	DIP136 = "DIP136" // manager_loop control field has invalid value (poll_interval/max_cycles/steer_context)
+	DIP137 = "DIP137" // unbounded manager_loop: no stop_condition and no max_cycles
 )
 
 func init() {
@@ -74,4 +77,7 @@ func init() {
 	CodeDescription[DIP132] = "response_schema is not valid JSON"
 	CodeDescription[DIP133] = "agent params key shadows a first-class field"
 	CodeDescription[DIP134] = "max_retries set in defaults with restart edges but no max_restarts — did you mean max_restarts?"
+	CodeDescription[DIP135] = "manager_loop subgraph_ref missing or file does not exist"
+	CodeDescription[DIP136] = "manager_loop control field has invalid value"
+	CodeDescription[DIP137] = "unbounded manager_loop: no stop_condition and no max_cycles"
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP134).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP137).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -37,7 +37,7 @@ const (
 	DIP133 = "DIP133" // agent params key shadows a first-class field
 	DIP134 = "DIP134" // max_retries set with restart edges but no max_restarts
 	DIP135 = "DIP135" // manager_loop subgraph_ref missing or file does not exist
-	DIP136 = "DIP136" // manager_loop control field has invalid value (poll_interval or max_cycles)
+	DIP136 = "DIP136" // manager_loop control field has invalid value (poll_interval, max_cycles, or steer_context delimiter)
 	DIP137 = "DIP137" // unbounded manager_loop: no stop_condition and no max_cycles
 )
 
@@ -78,6 +78,6 @@ func init() {
 	CodeDescription[DIP133] = "agent params key shadows a first-class field"
 	CodeDescription[DIP134] = "max_retries set in defaults with restart edges but no max_restarts — did you mean max_restarts?"
 	CodeDescription[DIP135] = "manager_loop subgraph_ref missing or file does not exist"
-	CodeDescription[DIP136] = "manager_loop control field has invalid value (poll_interval or max_cycles)"
+	CodeDescription[DIP136] = "manager_loop control field has invalid value (poll_interval, max_cycles, or steer_context delimiter)"
 	CodeDescription[DIP137] = "unbounded manager_loop: no stop_condition and no max_cycles"
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -37,7 +37,7 @@ const (
 	DIP133 = "DIP133" // agent params key shadows a first-class field
 	DIP134 = "DIP134" // max_retries set with restart edges but no max_restarts
 	DIP135 = "DIP135" // manager_loop subgraph_ref missing or file does not exist
-	DIP136 = "DIP136" // manager_loop control field has invalid value (poll_interval/max_cycles/steer_context)
+	DIP136 = "DIP136" // manager_loop control field has invalid value (poll_interval or max_cycles)
 	DIP137 = "DIP137" // unbounded manager_loop: no stop_condition and no max_cycles
 )
 
@@ -78,6 +78,6 @@ func init() {
 	CodeDescription[DIP133] = "agent params key shadows a first-class field"
 	CodeDescription[DIP134] = "max_retries set in defaults with restart edges but no max_restarts — did you mean max_restarts?"
 	CodeDescription[DIP135] = "manager_loop subgraph_ref missing or file does not exist"
-	CodeDescription[DIP136] = "manager_loop control field has invalid value"
+	CodeDescription[DIP136] = "manager_loop control field has invalid value (poll_interval or max_cycles)"
 	CodeDescription[DIP137] = "unbounded manager_loop: no stop_condition and no max_cycles"
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -37,7 +37,7 @@ const (
 	DIP133 = "DIP133" // agent params key shadows a first-class field
 	DIP134 = "DIP134" // max_retries set with restart edges but no max_restarts
 	DIP135 = "DIP135" // manager_loop subgraph_ref missing or file does not exist
-	DIP136 = "DIP136" // manager_loop control field has invalid value (poll_interval, max_cycles, or steer_context delimiter)
+	DIP136 = "DIP136" // manager_loop control field has invalid value (poll_interval or max_cycles)
 	DIP137 = "DIP137" // unbounded manager_loop: no stop_condition and no max_cycles
 )
 
@@ -78,6 +78,6 @@ func init() {
 	CodeDescription[DIP133] = "agent params key shadows a first-class field"
 	CodeDescription[DIP134] = "max_retries set in defaults with restart edges but no max_restarts — did you mean max_restarts?"
 	CodeDescription[DIP135] = "manager_loop subgraph_ref missing or file does not exist"
-	CodeDescription[DIP136] = "manager_loop control field has invalid value (poll_interval, max_cycles, or steer_context delimiter)"
+	CodeDescription[DIP136] = "manager_loop control field has invalid value (poll_interval or max_cycles)"
 	CodeDescription[DIP137] = "unbounded manager_loop: no stop_condition and no max_cycles"
 }

--- a/validator/lint_manager_loop.go
+++ b/validator/lint_manager_loop.go
@@ -3,17 +3,19 @@
 package validator
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
 )
 
 // lintManagerLoop emits DIP135 (ref missing or file does not exist), DIP136
-// (invalid control field — negative poll_interval or max_cycles), and DIP137
-// (unbounded supervision — neither stop_condition nor max_cycles set).
+// (invalid control field — negative poll_interval, max_cycles, or reserved
+// steer_context delimiter), and DIP137 (unbounded supervision — neither
+// stop_condition nor max_cycles set).
 func lintManagerLoop(w *ir.Workflow) []Diagnostic {
 	var diags []Diagnostic
 	for _, n := range w.Nodes {
@@ -22,18 +24,9 @@ func lintManagerLoop(w *ir.Workflow) []Diagnostic {
 			continue
 		}
 		diags = appendManagerLoopDiags(diags, n, cfg)
-	}
-	return diags
-}
-
-// appendManagerLoopDiags emits all DIP135/136/137 diagnostics for a node.
-func appendManagerLoopDiags(diags []Diagnostic, n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
-	if d := checkManagerLoopRef(n, cfg); d != nil {
-		diags = append(diags, *d)
-	}
-	diags = append(diags, checkManagerLoopControl(n, cfg)...)
-	if d := checkManagerLoopUnbounded(n, cfg); d != nil {
-		diags = append(diags, *d)
+		if d := checkManagerLoopRefExists(n, cfg); d != nil {
+			diags = append(diags, *d)
+		}
 	}
 	return diags
 }
@@ -51,23 +44,22 @@ func resolveManagerLoopRef(n *ir.Node, cfg ir.ManagerLoopConfig) string {
 	return resolveRefPath(cfg.SubgraphRef, n.Source.File)
 }
 
-// checkManagerLoopRef emits DIP135 if subgraph_ref is empty or points to a
-// nonexistent file (when the file path can be resolved).
-func checkManagerLoopRef(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
+// checkManagerLoopRefExists emits DIP135 when subgraph_ref points to a path
+// that can be resolved but the file does not exist. Permission errors and other
+// transient IO errors are silently ignored to avoid misreporting.
+func checkManagerLoopRefExists(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
 	if cfg.SubgraphRef == "" {
-		return &Diagnostic{
-			Code:     DIP135,
-			Severity: SeverityWarning,
-			Message:  fmt.Sprintf("manager_loop %q has no subgraph_ref", n.ID),
-			Location: n.Source,
-			Help:     "set subgraph_ref to the path of a .dip file defining the child pipeline",
-		}
+		return nil
 	}
 	resolved := resolveManagerLoopRef(n, cfg)
 	if resolved == "" {
 		return nil
 	}
 	if _, err := os.Stat(resolved); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			// Permission error or transient IO — don't mis-report as missing.
+			return nil
+		}
 		return &Diagnostic{
 			Code:     DIP135,
 			Severity: SeverityWarning,
@@ -77,67 +69,4 @@ func checkManagerLoopRef(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
 		}
 	}
 	return nil
-}
-
-// checkManagerLoopControl emits DIP136 for each invalid control field.
-func checkManagerLoopControl(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
-	var out []Diagnostic
-	if cfg.PollInterval < 0 {
-		out = append(out, Diagnostic{
-			Code:     DIP136,
-			Severity: SeverityWarning,
-			Message:  fmt.Sprintf("manager_loop %q poll_interval is negative (%s)", n.ID, cfg.PollInterval),
-			Location: n.Source,
-			Help:     "use a non-negative duration such as 30s; 0 means event-driven",
-		})
-	}
-	if cfg.MaxCycles < 0 {
-		out = append(out, Diagnostic{
-			Code:     DIP136,
-			Severity: SeverityWarning,
-			Message:  fmt.Sprintf("manager_loop %q max_cycles is negative (%d)", n.ID, cfg.MaxCycles),
-			Location: n.Source,
-			Help:     "use a positive integer; 0 means unbounded",
-		})
-	}
-	out = append(out, checkManagerLoopSteerContextDelimiters(n, cfg)...)
-	return out
-}
-
-// checkManagerLoopSteerContextDelimiters emits DIP136 when a steer_context key
-// or value contains ',' or '=' — those characters are delimiters in the DOT
-// flat-attr form and would corrupt round-trips through DOT export/migrate.
-func checkManagerLoopSteerContextDelimiters(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
-	var out []Diagnostic
-	for k, v := range cfg.SteerContext {
-		if strings.ContainsAny(k, ",=") || strings.ContainsAny(v, ",=") {
-			out = append(out, Diagnostic{
-				Code:     DIP136,
-				Severity: SeverityWarning,
-				Message:  fmt.Sprintf("manager_loop %q steer_context key/value contains reserved delimiter (',' or '='): %s=%s", n.ID, k, v),
-				Location: n.Source,
-				Help:     "steer_context keys and values must not contain ',' or '=' — those characters are used as delimiters in the DOT flat-attr form",
-			})
-		}
-	}
-	return out
-}
-
-// checkManagerLoopUnbounded emits DIP137 when both stop_condition and
-// max_cycles are unset — supervision can run forever.
-func checkManagerLoopUnbounded(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
-	hasStop := cfg.StopCondition != nil && cfg.StopCondition.Raw != ""
-	// Any non-zero MaxCycles (including invalid negative) indicates the user
-	// expressed bounding intent; DIP136 owns the invalid-value diagnosis.
-	hasMax := cfg.MaxCycles != 0
-	if hasStop || hasMax {
-		return nil
-	}
-	return &Diagnostic{
-		Code:     DIP137,
-		Severity: SeverityWarning,
-		Message:  fmt.Sprintf("manager_loop %q is unbounded: no stop_condition and no max_cycles", n.ID),
-		Location: n.Source,
-		Help:     "set stop_condition (e.g., stack.child.outcome = success) or max_cycles to bound supervision",
-	}
 }

--- a/validator/lint_manager_loop.go
+++ b/validator/lint_manager_loop.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
 )
@@ -98,6 +99,26 @@ func checkManagerLoopControl(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic 
 			Location: n.Source,
 			Help:     "use a positive integer; 0 means unbounded",
 		})
+	}
+	out = append(out, checkManagerLoopSteerContextDelimiters(n, cfg)...)
+	return out
+}
+
+// checkManagerLoopSteerContextDelimiters emits DIP136 when a steer_context key
+// or value contains ',' or '=' — those characters are delimiters in the DOT
+// flat-attr form and would corrupt round-trips through DOT export/migrate.
+func checkManagerLoopSteerContextDelimiters(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
+	var out []Diagnostic
+	for k, v := range cfg.SteerContext {
+		if strings.ContainsAny(k, ",=") || strings.ContainsAny(v, ",=") {
+			out = append(out, Diagnostic{
+				Code:     DIP136,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("manager_loop %q steer_context key/value contains reserved delimiter (',' or '='): %s=%s", n.ID, k, v),
+				Location: n.Source,
+				Help:     "steer_context keys and values must not contain ',' or '=' — those characters are used as delimiters in the DOT flat-attr form",
+			})
+		}
 	}
 	return out
 }

--- a/validator/lint_manager_loop.go
+++ b/validator/lint_manager_loop.go
@@ -1,0 +1,122 @@
+//go:build !wasm
+
+package validator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// lintManagerLoop emits DIP135 (ref missing or file does not exist), DIP136
+// (invalid control field — negative poll_interval or max_cycles), and DIP137
+// (unbounded supervision — neither stop_condition nor max_cycles set).
+func lintManagerLoop(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, n := range w.Nodes {
+		cfg, ok := n.Config.(ir.ManagerLoopConfig)
+		if !ok {
+			continue
+		}
+		diags = appendManagerLoopDiags(diags, n, cfg)
+	}
+	return diags
+}
+
+// appendManagerLoopDiags emits all DIP135/136/137 diagnostics for a node.
+func appendManagerLoopDiags(diags []Diagnostic, n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
+	if d := checkManagerLoopRef(n, cfg); d != nil {
+		diags = append(diags, *d)
+	}
+	diags = append(diags, checkManagerLoopControl(n, cfg)...)
+	if d := checkManagerLoopUnbounded(n, cfg); d != nil {
+		diags = append(diags, *d)
+	}
+	return diags
+}
+
+// resolveManagerLoopRef returns the resolved file path for cfg.SubgraphRef,
+// or "" when resolution isn't possible (empty ref, or relative ref with no
+// source file for context). Delegates actual path resolution to resolveRefPath.
+func resolveManagerLoopRef(n *ir.Node, cfg ir.ManagerLoopConfig) string {
+	if cfg.SubgraphRef == "" {
+		return ""
+	}
+	if !filepath.IsAbs(cfg.SubgraphRef) && n.Source.File == "" {
+		return ""
+	}
+	return resolveRefPath(cfg.SubgraphRef, n.Source.File)
+}
+
+// checkManagerLoopRef emits DIP135 if subgraph_ref is empty or points to a
+// nonexistent file (when the file path can be resolved).
+func checkManagerLoopRef(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
+	if cfg.SubgraphRef == "" {
+		return &Diagnostic{
+			Code:     DIP135,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("manager_loop %q has no subgraph_ref", n.ID),
+			Location: n.Source,
+			Help:     "set subgraph_ref to the path of a .dip file defining the child pipeline",
+		}
+	}
+	resolved := resolveManagerLoopRef(n, cfg)
+	if resolved == "" {
+		return nil
+	}
+	if _, err := os.Stat(resolved); err != nil {
+		return &Diagnostic{
+			Code:     DIP135,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("manager_loop %q references %q which does not exist", n.ID, cfg.SubgraphRef),
+			Location: n.Source,
+			Help:     fmt.Sprintf("resolved path: %s", resolved),
+		}
+	}
+	return nil
+}
+
+// checkManagerLoopControl emits DIP136 for each invalid control field.
+func checkManagerLoopControl(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
+	var out []Diagnostic
+	if cfg.PollInterval < 0 {
+		out = append(out, Diagnostic{
+			Code:     DIP136,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("manager_loop %q poll_interval is negative (%s)", n.ID, cfg.PollInterval),
+			Location: n.Source,
+			Help:     "use a non-negative duration such as 30s; 0 means event-driven",
+		})
+	}
+	if cfg.MaxCycles < 0 {
+		out = append(out, Diagnostic{
+			Code:     DIP136,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("manager_loop %q max_cycles is negative (%d)", n.ID, cfg.MaxCycles),
+			Location: n.Source,
+			Help:     "use a positive integer; 0 means unbounded",
+		})
+	}
+	return out
+}
+
+// checkManagerLoopUnbounded emits DIP137 when both stop_condition and
+// max_cycles are unset — supervision can run forever.
+func checkManagerLoopUnbounded(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
+	hasStop := cfg.StopCondition != nil && cfg.StopCondition.Raw != ""
+	// Any non-zero MaxCycles (including invalid negative) indicates the user
+	// expressed bounding intent; DIP136 owns the invalid-value diagnosis.
+	hasMax := cfg.MaxCycles != 0
+	if hasStop || hasMax {
+		return nil
+	}
+	return &Diagnostic{
+		Code:     DIP137,
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("manager_loop %q is unbounded: no stop_condition and no max_cycles", n.ID),
+		Location: n.Source,
+		Help:     "set stop_condition (e.g., stack.child.outcome = success) or max_cycles to bound supervision",
+	}
+}

--- a/validator/lint_manager_loop_common.go
+++ b/validator/lint_manager_loop_common.go
@@ -5,7 +5,6 @@ package validator
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
 )
@@ -59,26 +58,6 @@ func checkManagerLoopControl(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic 
 			Location: n.Source,
 			Help:     "use a positive integer; 0 means unbounded",
 		})
-	}
-	out = append(out, checkManagerLoopSteerContextDelimiters(n, cfg)...)
-	return out
-}
-
-// checkManagerLoopSteerContextDelimiters emits DIP136 when a steer_context key
-// or value contains ',' or '=' — those characters are delimiters in the DOT
-// flat-attr form and would corrupt round-trips through DOT export/migrate.
-func checkManagerLoopSteerContextDelimiters(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
-	var out []Diagnostic
-	for k, v := range cfg.SteerContext {
-		if strings.ContainsAny(k, ",=") || strings.ContainsAny(v, ",=") {
-			out = append(out, Diagnostic{
-				Code:     DIP136,
-				Severity: SeverityWarning,
-				Message:  fmt.Sprintf("manager_loop %q steer_context key/value contains reserved delimiter (',' or '='): %s=%s", n.ID, k, v),
-				Location: n.Source,
-				Help:     "steer_context keys and values must not contain ',' or '=' — those characters are used as delimiters in the DOT flat-attr form",
-			})
-		}
 	}
 	return out
 }

--- a/validator/lint_manager_loop_common.go
+++ b/validator/lint_manager_loop_common.go
@@ -1,0 +1,103 @@
+// lint_manager_loop_common.go contains pure-logic manager_loop lint checks that
+// do not require filesystem access. These compile for both wasm and non-wasm.
+
+package validator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// appendManagerLoopDiags emits all DIP135/136/137 diagnostics for one node.
+// The file-existence check (checkManagerLoopRefExists) is NOT called here;
+// callers that have filesystem access (non-wasm) add it separately.
+func appendManagerLoopDiags(diags []Diagnostic, n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
+	if d := checkManagerLoopMissingRef(n, cfg); d != nil {
+		diags = append(diags, *d)
+	}
+	diags = append(diags, checkManagerLoopControl(n, cfg)...)
+	if d := checkManagerLoopUnbounded(n, cfg); d != nil {
+		diags = append(diags, *d)
+	}
+	return diags
+}
+
+// checkManagerLoopMissingRef emits DIP135 when subgraph_ref is empty.
+// This is a pure-logic check — no filesystem access required.
+func checkManagerLoopMissingRef(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
+	if cfg.SubgraphRef != "" {
+		return nil
+	}
+	return &Diagnostic{
+		Code:     DIP135,
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("manager_loop %q has no subgraph_ref", n.ID),
+		Location: n.Source,
+		Help:     "set subgraph_ref to the path of a .dip file defining the child pipeline",
+	}
+}
+
+// checkManagerLoopControl emits DIP136 for each invalid control field.
+func checkManagerLoopControl(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
+	var out []Diagnostic
+	if cfg.PollInterval < 0 {
+		out = append(out, Diagnostic{
+			Code:     DIP136,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("manager_loop %q poll_interval is negative (%s)", n.ID, cfg.PollInterval),
+			Location: n.Source,
+			Help:     "use a non-negative duration such as 30s; 0 means event-driven",
+		})
+	}
+	if cfg.MaxCycles < 0 {
+		out = append(out, Diagnostic{
+			Code:     DIP136,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("manager_loop %q max_cycles is negative (%d)", n.ID, cfg.MaxCycles),
+			Location: n.Source,
+			Help:     "use a positive integer; 0 means unbounded",
+		})
+	}
+	out = append(out, checkManagerLoopSteerContextDelimiters(n, cfg)...)
+	return out
+}
+
+// checkManagerLoopSteerContextDelimiters emits DIP136 when a steer_context key
+// or value contains ',' or '=' — those characters are delimiters in the DOT
+// flat-attr form and would corrupt round-trips through DOT export/migrate.
+func checkManagerLoopSteerContextDelimiters(n *ir.Node, cfg ir.ManagerLoopConfig) []Diagnostic {
+	var out []Diagnostic
+	for k, v := range cfg.SteerContext {
+		if strings.ContainsAny(k, ",=") || strings.ContainsAny(v, ",=") {
+			out = append(out, Diagnostic{
+				Code:     DIP136,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("manager_loop %q steer_context key/value contains reserved delimiter (',' or '='): %s=%s", n.ID, k, v),
+				Location: n.Source,
+				Help:     "steer_context keys and values must not contain ',' or '=' — those characters are used as delimiters in the DOT flat-attr form",
+			})
+		}
+	}
+	return out
+}
+
+// checkManagerLoopUnbounded emits DIP137 when both stop_condition and
+// max_cycles are unset — supervision can run forever.
+func checkManagerLoopUnbounded(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
+	hasStop := cfg.StopCondition != nil && cfg.StopCondition.Raw != ""
+	// Any non-zero MaxCycles (including invalid negative) indicates the user
+	// expressed bounding intent; DIP136 owns the invalid-value diagnosis.
+	hasMax := cfg.MaxCycles != 0
+	if hasStop || hasMax {
+		return nil
+	}
+	return &Diagnostic{
+		Code:     DIP137,
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("manager_loop %q is unbounded: no stop_condition and no max_cycles", n.ID),
+		Location: n.Source,
+		Help:     "set stop_condition (e.g., stack.child.outcome = success) or max_cycles to bound supervision",
+	}
+}

--- a/validator/lint_manager_loop_common.go
+++ b/validator/lint_manager_loop_common.go
@@ -86,11 +86,10 @@ func checkManagerLoopSteerContextDelimiters(n *ir.Node, cfg ir.ManagerLoopConfig
 // checkManagerLoopUnbounded emits DIP137 when both stop_condition and
 // max_cycles are unset — supervision can run forever.
 func checkManagerLoopUnbounded(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic {
-	hasStop := cfg.StopCondition != nil && cfg.StopCondition.Raw != ""
 	// Any non-zero MaxCycles (including invalid negative) indicates the user
 	// expressed bounding intent; DIP136 owns the invalid-value diagnosis.
 	hasMax := cfg.MaxCycles != 0
-	if hasStop || hasMax {
+	if conditionPresent(cfg.StopCondition) || hasMax {
 		return nil
 	}
 	return &Diagnostic{
@@ -100,4 +99,14 @@ func checkManagerLoopUnbounded(n *ir.Node, cfg ir.ManagerLoopConfig) *Diagnostic
 		Location: n.Source,
 		Help:     "set stop_condition (e.g., stack.child.outcome = success) or max_cycles to bound supervision",
 	}
+}
+
+// conditionPresent reports whether c carries a usable condition expression.
+// Either a populated Raw text (typical for parser-produced workflows) or a
+// non-nil Parsed AST (programmatic construction) counts as "present".
+func conditionPresent(c *ir.Condition) bool {
+	if c == nil {
+		return false
+	}
+	return c.Raw != "" || c.Parsed != nil
 }

--- a/validator/lint_manager_loop_test.go
+++ b/validator/lint_manager_loop_test.go
@@ -176,22 +176,6 @@ func TestLintConditions_StackChildNamespace(t *testing.T) {
 	}
 }
 
-func TestLintManagerLoop_DIP136_SteerContextReservedChar(t *testing.T) {
-	// A steer_context key containing '=' or value containing ',' should fire DIP136.
-	w := managerLoopWorkflow(ir.ManagerLoopConfig{
-		SubgraphRef: "inner.dip",
-		MaxCycles:   5,
-		SteerContext: map[string]string{
-			"bad=key": "value",
-			"good":    "val,ue",
-		},
-	})
-	diags := lintManagerLoop(w)
-	if !diagHasCode(diags, DIP136) {
-		t.Errorf("expected DIP136 for steer_context with reserved delimiters, got %v", diags)
-	}
-}
-
 func TestLintManagerLoop_DIP137_NotFiredWhenStopConditionOnlyInParsed(t *testing.T) {
 	// Mirrors the formatter/exporter Parsed-fallback: a stop_condition with
 	// only Parsed populated (Raw empty) still counts as a bounding signal.

--- a/validator/lint_manager_loop_test.go
+++ b/validator/lint_manager_loop_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/2389-research/dippin-lang/ir"
 )
@@ -72,7 +73,7 @@ func TestLintManagerLoop_DIP135_RefExists(t *testing.T) {
 func TestLintManagerLoop_DIP136_NegativePollInterval(t *testing.T) {
 	w := managerLoopWorkflow(ir.ManagerLoopConfig{
 		SubgraphRef:  "inner.dip",
-		PollInterval: -5,
+		PollInterval: -5 * time.Second,
 		MaxCycles:    5,
 	})
 	// Avoid DIP135 for nonexistent file by not setting Source.

--- a/validator/lint_manager_loop_test.go
+++ b/validator/lint_manager_loop_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/simulate"
 )
 
 func managerLoopWorkflow(cfg ir.ManagerLoopConfig) *ir.Workflow {
@@ -188,5 +189,22 @@ func TestLintManagerLoop_DIP136_SteerContextReservedChar(t *testing.T) {
 	diags := lintManagerLoop(w)
 	if !diagHasCode(diags, DIP136) {
 		t.Errorf("expected DIP136 for steer_context with reserved delimiters, got %v", diags)
+	}
+}
+
+func TestLintManagerLoop_DIP137_NotFiredWhenStopConditionOnlyInParsed(t *testing.T) {
+	// Mirrors the formatter/exporter Parsed-fallback: a stop_condition with
+	// only Parsed populated (Raw empty) still counts as a bounding signal.
+	parsed, err := simulate.ParseCondition("stack.child.outcome = success")
+	if err != nil {
+		t.Fatalf("ParseCondition: %v", err)
+	}
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{
+		SubgraphRef:   "inner.dip",
+		StopCondition: &ir.Condition{Parsed: parsed}, // Raw intentionally empty
+	})
+	diags := lintManagerLoop(w)
+	if diagHasCode(diags, DIP137) {
+		t.Errorf("DIP137 should NOT fire when StopCondition.Parsed is set: %v", diags)
 	}
 }

--- a/validator/lint_manager_loop_test.go
+++ b/validator/lint_manager_loop_test.go
@@ -173,3 +173,19 @@ func TestLintConditions_StackChildNamespace(t *testing.T) {
 		}
 	}
 }
+
+func TestLintManagerLoop_DIP136_SteerContextReservedChar(t *testing.T) {
+	// A steer_context key containing '=' or value containing ',' should fire DIP136.
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{
+		SubgraphRef: "inner.dip",
+		MaxCycles:   5,
+		SteerContext: map[string]string{
+			"bad=key": "value",
+			"good":    "val,ue",
+		},
+	})
+	diags := lintManagerLoop(w)
+	if !diagHasCode(diags, DIP136) {
+		t.Errorf("expected DIP136 for steer_context with reserved delimiters, got %v", diags)
+	}
+}

--- a/validator/lint_manager_loop_test.go
+++ b/validator/lint_manager_loop_test.go
@@ -145,3 +145,31 @@ func TestLintManagerLoop_NonManagerNodeIgnored(t *testing.T) {
 		t.Errorf("expected 0 diagnostics on non-manager workflow, got %v", diags)
 	}
 }
+
+// TestLintConditions_StackChildNamespace is a pinning test: a manager_loop
+// stop_condition that references stack.child.* must never fire DIP120
+// (variable missing namespace prefix). The stack.* namespace is valid for
+// supervisor-exposed runtime variables such as stack.child.cycles and
+// stack.child.outcome. This test exercises the full Lint() path so it will
+// catch regressions if DIP120 is later extended to walk node-level conditions.
+func TestLintConditions_StackChildNamespace(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "M",
+		Exit:  "M",
+		Nodes: []*ir.Node{
+			{ID: "M", Kind: ir.NodeManagerLoop, Config: ir.ManagerLoopConfig{
+				SubgraphRef:   "inner.dip",
+				MaxCycles:     5,
+				StopCondition: &ir.Condition{Raw: "stack.child.cycles = 10"},
+			}},
+		},
+		Edges: []*ir.Edge{{From: "M", To: "M"}},
+	}
+	res := Lint(w)
+	for _, d := range res.Diagnostics {
+		if d.Code == DIP120 {
+			t.Errorf("stack.child.* should be a recognized namespace, got DIP120: %s", d.Message)
+		}
+	}
+}

--- a/validator/lint_manager_loop_test.go
+++ b/validator/lint_manager_loop_test.go
@@ -1,0 +1,147 @@
+//go:build !wasm
+
+package validator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+func managerLoopWorkflow(cfg ir.ManagerLoopConfig) *ir.Workflow {
+	return &ir.Workflow{
+		Name:  "W",
+		Start: "M",
+		Exit:  "M",
+		Nodes: []*ir.Node{{ID: "M", Kind: ir.NodeManagerLoop, Config: cfg}},
+		Edges: []*ir.Edge{{From: "M", To: "M"}},
+	}
+}
+
+// diagHasCode reports whether diags contains a diagnostic with the given code.
+func diagHasCode(diags []Diagnostic, code string) bool {
+	for _, d := range diags {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLintManagerLoop_DIP135_MissingRef(t *testing.T) {
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{MaxCycles: 5})
+	diags := lintManagerLoop(w)
+	if !diagHasCode(diags, DIP135) {
+		t.Errorf("expected DIP135 for missing subgraph_ref, got %v", diags)
+	}
+}
+
+func TestLintManagerLoop_DIP135_RefFileDoesNotExist(t *testing.T) {
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{
+		SubgraphRef: "does_not_exist.dip",
+		MaxCycles:   5,
+	})
+	w.Nodes[0].Source = ir.SourceLocation{File: "/tmp/fakeworkflow.dip"}
+	diags := lintManagerLoop(w)
+	if !diagHasCode(diags, DIP135) {
+		t.Errorf("expected DIP135 for nonexistent ref, got %v", diags)
+	}
+}
+
+func TestLintManagerLoop_DIP135_RefExists(t *testing.T) {
+	// Create a temp file and a workflow that references it relatively.
+	dir := t.TempDir()
+	refFile := filepath.Join(dir, "child.dip")
+	if err := os.WriteFile(refFile, []byte("workflow C\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	srcFile := filepath.Join(dir, "parent.dip")
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{
+		SubgraphRef: "child.dip",
+		MaxCycles:   5,
+	})
+	w.Nodes[0].Source = ir.SourceLocation{File: srcFile}
+	diags := lintManagerLoop(w)
+	if diagHasCode(diags, DIP135) {
+		t.Errorf("unexpected DIP135 for existing ref: %v", diags)
+	}
+}
+
+func TestLintManagerLoop_DIP136_NegativePollInterval(t *testing.T) {
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{
+		SubgraphRef:  "inner.dip",
+		PollInterval: -5,
+		MaxCycles:    5,
+	})
+	// Avoid DIP135 for nonexistent file by not setting Source.
+	diags := lintManagerLoop(w)
+	if !diagHasCode(diags, DIP136) {
+		t.Errorf("expected DIP136 for negative poll_interval, got %v", diags)
+	}
+}
+
+func TestLintManagerLoop_DIP136_NegativeMaxCycles(t *testing.T) {
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{
+		SubgraphRef: "inner.dip",
+		MaxCycles:   -1,
+		// Also needs some bound signal to avoid DIP137; but the test
+		// is checking DIP136 specifically.
+	})
+	diags := lintManagerLoop(w)
+	if !diagHasCode(diags, DIP136) {
+		t.Errorf("expected DIP136 for negative max_cycles, got %v", diags)
+	}
+}
+
+func TestLintManagerLoop_DIP137_Unbounded(t *testing.T) {
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{SubgraphRef: "inner.dip"})
+	diags := lintManagerLoop(w)
+	if !diagHasCode(diags, DIP137) {
+		t.Errorf("expected DIP137 for unbounded manager_loop, got %v", diags)
+	}
+}
+
+func TestLintManagerLoop_Clean(t *testing.T) {
+	// Fully bounded manager_loop, no Source.File so DIP135 cannot resolve
+	// and silently skips. Expect zero diagnostics.
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{
+		SubgraphRef:   "inner.dip",
+		MaxCycles:     5,
+		StopCondition: &ir.Condition{Raw: "stack.child.cycles = 10"},
+	})
+	diags := lintManagerLoop(w)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics on clean manager_loop, got %d: %v", len(diags), diags)
+	}
+}
+
+func TestLintManagerLoop_NegativeMaxCyclesDoesNotAlsoFireDIP137(t *testing.T) {
+	// Verifies Fix 3: a negative max_cycles fires DIP136 but NOT DIP137,
+	// because the user expressed bounding intent.
+	w := managerLoopWorkflow(ir.ManagerLoopConfig{
+		SubgraphRef: "inner.dip",
+		MaxCycles:   -1,
+	})
+	diags := lintManagerLoop(w)
+	if !diagHasCode(diags, DIP136) {
+		t.Errorf("expected DIP136, got %v", diags)
+	}
+	if diagHasCode(diags, DIP137) {
+		t.Errorf("unexpected DIP137 — negative max_cycles should suppress unbounded warning: %v", diags)
+	}
+}
+
+func TestLintManagerLoop_NonManagerNodeIgnored(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "W",
+		Start: "A",
+		Exit:  "A",
+		Nodes: []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "hi"}}},
+	}
+	diags := lintManagerLoop(w)
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics on non-manager workflow, got %v", diags)
+	}
+}

--- a/validator/lint_manager_loop_wasm.go
+++ b/validator/lint_manager_loop_wasm.go
@@ -1,0 +1,10 @@
+//go:build wasm
+
+package validator
+
+import "github.com/2389-research/dippin-lang/ir"
+
+// lintManagerLoop is a no-op on WASM — os.Stat is not available.
+// Non-file-related checks (DIP136, DIP137) could run in theory, but we
+// mirror the lint_subgraph_wasm pattern and skip entirely for simplicity.
+func lintManagerLoop(_ *ir.Workflow) []Diagnostic { return nil }

--- a/validator/lint_manager_loop_wasm.go
+++ b/validator/lint_manager_loop_wasm.go
@@ -4,7 +4,18 @@ package validator
 
 import "github.com/2389-research/dippin-lang/ir"
 
-// lintManagerLoop is a no-op on WASM — os.Stat is not available.
-// Non-file-related checks (DIP136, DIP137) could run in theory, but we
-// mirror the lint_subgraph_wasm pattern and skip entirely for simplicity.
-func lintManagerLoop(_ *ir.Workflow) []Diagnostic { return nil }
+// lintManagerLoop runs all pure-logic manager_loop checks on WASM.
+// The file-existence check (DIP135 for nonexistent path) is skipped because
+// os.Stat is not available in the WASM sandbox; all other checks (DIP135
+// missing ref, DIP136 invalid control field, DIP137 unbounded) run normally.
+func lintManagerLoop(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, n := range w.Nodes {
+		cfg, ok := n.Config.(ir.ManagerLoopConfig)
+		if !ok {
+			continue
+		}
+		diags = appendManagerLoopDiags(diags, n, cfg)
+	}
+	return diags
+}


### PR DESCRIPTION
## Summary

Adds a new `manager_loop` node kind to the dippin-lang IR so `.dip` files can natively express Tracker's `stack.manager_loop` supervisors — a node that runs a child sub-pipeline, polls on an interval, and can steer the running child via context injection. Closes #26.

Without this change, pipelines using manager_loop must be authored in DOT end-to-end.

## What's in this PR

- **IR**: `NodeManagerLoop` kind + `ManagerLoopConfig` struct (SubgraphRef, PollInterval, MaxCycles, StopCondition, SteerCondition, SteerContext).
- **Parser**: `manager_loop` keyword dispatch; `steer_context` parses both inline CSV (`k=v,k=v`) and block form. Includes a follow-up fix for single-entry block-form parsing (separator-position heuristic instead of embedded-newline).
- **Conditions**: `stop_condition`/`steer_condition` reuse `ir.Condition{Raw, Parsed}`. `simulate.EnsureConditionsParsed` extended to walk manager_loop nodes so lint rules get the AST.
- **Formatter**: canonical output with idempotent round-trip (verified by test).
- **DOT export**: `shape=house` plus lossless flat-attr round-trip (`steer_context` flattens to sorted `k=v,k=v`).
- **DOT migrate**: reverse mapping `shape=house` → `NodeManagerLoop`.
- **Linter**: DIP135 (missing/nonexistent `subgraph_ref`), DIP136 (invalid control field), DIP137 (unbounded supervisor — DIP104 analog). `stack.*` added to DIP120 `knownNamespaces`.
- **Scaffold**: `dippin scaffold manager_loop` template.
- **LSP**: symbol outline entry.
- **Tree-sitter**: `manager_loop_node` grammar rule, highlights coverage, corpus test, committed generated parser, `just tree-sitter-generate` / `just tree-sitter-test` recipes, and a CI drift-check job.
- **VS Code**: grammar updated for `manager_loop` keyword, new field names, and `stack.*` namespace. Also fixes a pre-existing bug: the node-declaration regex was missing `parallel`/`fan_in`.
- **Docs**: `docs/nodes.md` full section (also adds the missing `conditional` entry), EBNF grammar rule, README node-type entry, published site language ref, hosted `skill.md`.
- **Example**: `examples/manager_loop_demo.dip` (+ `child_pipeline.dip` for the ref target).
- **CHANGELOG**: Unreleased section with Added + Fixed bullets.

## Cross-repo coordination

**Tracker side: 2389-research/tracker#162** — the Tracker adapter (`pipeline/dippin_adapter.go`) needs a parallel update to map `ir.NodeManagerLoop` → `shape=house` with the same flat attrs this repo's exporter emits. **Until that lands, pin Tracker to `dippin-lang@v0.21.0`.** Bumping to v0.22.0 before the adapter exists will silently drop manager_loop config on the Tracker side.

## Post-merge TODO

- Bump `editors/zed-dippin/extension.toml` `commit = "..."` SHA to the merge commit so Zed picks up the new grammar.

## Test plan

- [x] `just check` passes (build, vet, fmt, test-race, releasecheck, complexity ≤5/≤7, validate-examples)
- [x] `just tree-sitter-test` — all 5 corpus cases PASS including new "Manager loop node"
- [x] `dippin fmt` is idempotent on `examples/manager_loop_demo.dip`
- [x] `dippin validate` clean, `dippin lint` clean on the new example
- [x] `dippin scaffold manager_loop` produces a validatable, lint-clean workflow
- [x] Full DOT → IR migration test (hand-written DOT with `shape=house`) round-trips all 6 config fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manager_loop node to supervise child pipelines with polling, cycle limits, stop/steer conditions and steer_context; scaffold/template and examples included.

* **Documentation**
  * Full docs, site, changelog, README, and generated language spec updates; new diagnostics DIP135–DIP137 and editor highlighting/syntax support.

* **Tests**
  * Extensive unit/integration tests across parser, formatter, migrate, export, scaffold, simulate, and lint.

* **Chores**
  * CI now regenerates and tests the Tree-sitter parser before deploy; added ignore for Tree-sitter build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->