### PR TITLE
fix(site): highlight manager_loop + parallel/fan_in block form; raise .dim contrast (#29)

### DIFF
--- a/site/static/highlight.js
+++ b/site/static/highlight.js
@@ -32,14 +32,10 @@
     h = h.replace(/("(?:[^"\\]|\\.)*")/g, function (_, v) { return s("str", v); });
     // ${ctx.*} variables.
     h = h.replace(/(\$\{[^}]+\})/g, function (_, v) { return s("shvar", v); });
-    // Node declarations.
-    h = h.replace(/\b(workflow|agent|human|tool|subgraph|conditional)\s+([A-Z]\w*)/g,
+    // Node declarations — all kinds, with identifier starting uppercase OR lowercase.
+    h = h.replace(/\b(workflow|agent|human|tool|subgraph|conditional|manager_loop|parallel|fan_in)\s+(\w+)/g,
       function (_, kw, n) { return s("kw", kw) + " " + s("node", n); });
-    // Parallel/fan_in.
-    h = h.replace(/\b(parallel)\s+(\w+)\s*(-&gt;)/g,
-      function (_, kw, n, a) { return s("kw", kw) + " " + s("node", n) + " " + s("op", a); });
-    h = h.replace(/\b(fan_in)\s+(\w+)\s*(&lt;-)/g,
-      function (_, kw, n, a) { return s("kw", kw) + " " + s("node", n) + " " + s("op", a); });
+    // Inline edge forms follow via the arrow regex below; no special case needed.
     // Section keywords.
     h = h.replace(/\b(edges|defaults|vars|stylesheet)\b/g, function (_, k) { return s("kw", k); });
     // Condition keywords.

--- a/site/static/highlight.js
+++ b/site/static/highlight.js
@@ -32,8 +32,10 @@
     h = h.replace(/("(?:[^"\\]|\\.)*")/g, function (_, v) { return s("str", v); });
     // ${ctx.*} variables.
     h = h.replace(/(\$\{[^}]+\})/g, function (_, v) { return s("shvar", v); });
-    // Node declarations — all kinds, with identifier starting uppercase OR lowercase.
-    h = h.replace(/\b(workflow|agent|human|tool|subgraph|conditional|manager_loop|parallel|fan_in)\s+(\w+)/g,
+    // Node declarations — all kinds. Identifier pattern matches dippin's lexer
+    // (alphanumeric start, then alphanumeric + underscore/dash/dot/slash) so
+    // IDs like `code-review` or `phases/code_review` color correctly.
+    h = h.replace(/\b(workflow|agent|human|tool|subgraph|conditional|manager_loop|parallel|fan_in)\s+([A-Za-z0-9][A-Za-z0-9_./-]*)/g,
       function (_, kw, n) { return s("kw", kw) + " " + s("node", n); });
     // Inline edge forms follow via the arrow regex below; no special case needed.
     // Section keywords.
@@ -114,7 +116,9 @@
   }
 
   // ── Detection ───────────────────────────────────────────
-  function isDippin(t) { return /\b(workflow|agent |human |tool |conditional |edges\b|defaults\b|vars\b)/.test(t); }
+  function isDippin(t) {
+    return /\b(workflow|agent|human|tool|subgraph|conditional|manager_loop|parallel|fan_in|edges|defaults|vars|stylesheet)\b/.test(t);
+  }
   function isShell(t) { return /^(\s*#!\/bin\/|set -e)/.test(t.trim()); }
   function isTerminal(t) { return /^\$\s/.test(t.trim()); }
   function isDiagnostic(t) { return /\b(error|warning|hint)\[DIP\d+\]/.test(t); }

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -203,7 +203,7 @@ section { padding: 4.5rem 0; }
 .hl-pass { color: #8FD5A6; }
 .hl-warn { color: #F5D56A; }
 .hl-fail { color: #E88; }
-.hl-dim { color: #777; }
+.hl-dim { color: #9a9a9a; }
 .hl-shcmd { color: #ddd; }
 .hl-shvar { color: #F5D56A; }
 .hl-shkw { color: #B8A9E8; }
@@ -252,7 +252,7 @@ section { padding: 4.5rem 0; }
 .terminal .pass { color: #8FD5A6; }
 .terminal .warn { color: #F5D56A; }
 .terminal .fail { color: #E88; }
-.terminal .dim { color: #777; }
+.terminal .dim { color: #9a9a9a; }
 
 /* ── Install ── */
 .install-box { background: white; border: 1.5px solid var(--border); border-radius: 14px; padding: 2.5rem; max-width: 800px; }


### PR DESCRIPTION
Closes part of #29. Two of the five acceptance items land here; the rest (see below) are either already OK or out of scope for this PR.

## Changes

### `site/static/highlight.js`

The node-declaration regex only covered `workflow / agent / human / tool / subgraph / conditional`, so `manager_loop` got no keyword coloring anywhere. `parallel` and `fan_in` had their own regexes but required a same-line arrow (`->` / `<-`), so block/definition form (keyword on one line, config indented beneath) stayed uncolored everywhere it was used.

Consolidated into a single regex covering every node kind and dropped the edge-form special cases — the arrow regex further down already colors arrows independently, so the inline edge form still renders correctly:

```js
h = h.replace(/\b(workflow|agent|human|tool|subgraph|conditional|manager_loop|parallel|fan_in)\s+(\w+)/g,
  function (_, kw, n) { return s("kw", kw) + " " + s("node", n); });
```

Also relaxed the trailing identifier pattern from `[A-Z]\w*` to `\w+` so lowercase node IDs get node-color too — safe because this regex only fires after a known keyword, so false-positive drift on prose-like input isn't a concern inside a dippin code block.

### `site/static/style.css`

`.hl-dim` and `.terminal .dim` were `#777`, which is ~3.24:1 contrast on the `#2A2A30` code-block background — below WCAG AA's 4.5:1 minimum for normal text. Bumped both to `#9a9a9a` (~4.7:1). Affects `missing:` hints, section rules, and `(max)` annotations on `/analysis/`.

## Issue acceptance items

- [x] `manager_loop` highlights on `/language/#manager_loop`
- [x] `parallel` and `fan_in` highlight in both edge-form and block/definition-form
- [x] `subgraph` confirmed highlighting (was already in the consolidated regex after the fix; was always in the original too — the issue's third bullet was speculative and turned out not to reproduce)
- [ ] `.dim` text on `/analysis/` meets WCAG AA contrast on the `#2A2A30` block background — **done here**
- [ ] gate.dip example on `/testing/` has distinct colors for keywords, node IDs, strings, and operators (no mass of `#bbb` text) — **not fixed here; see below**

### Why the gate.dip "barely readable" item isn't in this PR

When I filed #29 I claimed `.compare-code .node` and `.compare-code .op` rules were missing. They aren't — they already exist at `style.css:186–187`. What's actually happening is that value tokens like `claude-sonnet-4-6` in the gate.dip block are not wrapped in any span, so they fall back to `.compare-code`'s default color `#bbb`. That's ~6.9:1 contrast on `#2A2A30` — passing WCAG AAA — but the visual read is "drab" because keyword/node/string text uses saturated lavender/yellow/green and the value text sits flat.

The proper fix is a content change: introduce a `.val` class (or reuse an existing `.str`-like style) and wrap value tokens in the hand-authored `.compare-code` block in `site/content/testing.md`. That's a cross-page audit, not a one-line CSS tweak, so I'd rather do it as a follow-up — happy to open one if desired.

## Test plan

- [ ] Visual check on deployed site once CI rebuilds:
  - `/language/` — `manager_loop QualityGate`, `parallel FanOut`, `fan_in Join`, `subgraph ReviewProcess` all have the purple keyword + yellow node name.
  - `/analysis/` — `missing: …` hints and `(max)` annotations are legibly dimmer than main text but not murky.
- [x] No Go/test changes; `just check` isn't involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax highlighting: node declarations and related keywords are recognized more broadly, and inline arrow edges highlight consistently.

* **Style**
  * Updated dim text color in code blocks and terminal output for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->