### PR TITLE
fix(site): bump dark-block default text contrast (closes #29)

### DIFF
--- a/site/static/style.css
+++ b/site/static/style.css
@@ -179,7 +179,7 @@ section { padding: 4.5rem 0; }
 .compare-label { font-family: var(--mono); font-size: 0.68rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; padding: 0.5rem 1rem; border-radius: 8px 8px 0 0; display: inline-block; }
 .compare-label.bad { color: #b84040; background: #fde8e8; }
 .compare-label.good { color: var(--green-deep); background: var(--green-light); }
-.compare-code { background: #2A2A30; border-radius: 0 10px 10px 10px; padding: 1.25rem; font-family: var(--mono); font-size: 0.72rem; line-height: 1.75; overflow-x: auto; border: 2px solid rgba(0,0,0,0.1); color: #bbb; }
+.compare-code { background: #2A2A30; border-radius: 0 10px 10px 10px; padding: 1.25rem; font-family: var(--mono); font-size: 0.72rem; line-height: 1.75; overflow-x: auto; border: 2px solid rgba(0,0,0,0.1); color: #cccccc; }
 .compare-code pre { min-width: 0; }
 .compare-code .kw { color: #B8A9E8; }
 .compare-code .str { color: #8FD5A6; }
@@ -247,7 +247,7 @@ section { padding: 4.5rem 0; }
 .terminal-dot:nth-child(2) { background: #febc2e; }
 .terminal-dot:nth-child(3) { background: #28c840; }
 .terminal-title { font-family: var(--mono); font-size: 0.68rem; color: #888; margin-left: auto; }
-.terminal pre { padding: 1.1rem; font-family: var(--mono); font-size: 0.76rem; line-height: 1.8; color: #bbb; overflow-x: auto; }
+.terminal pre { padding: 1.1rem; font-family: var(--mono); font-size: 0.76rem; line-height: 1.8; color: #cccccc; overflow-x: auto; }
 .terminal .prompt { color: var(--green); }
 .terminal .pass { color: #8FD5A6; }
 .terminal .warn { color: #F5D56A; }
@@ -279,7 +279,7 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
 .doc-body h2 { font-family: var(--serif); font-size: 1.6rem; font-weight: 700; margin: 3rem 0 1rem; padding-top: 1.5rem; border-top: 1.5px solid var(--border); }
 .doc-body h3 { font-size: 1.1rem; font-weight: 700; margin: 2rem 0 0.5rem; }
 .doc-body p { color: var(--text-mid); margin-bottom: 1rem; max-width: 720px; }
-.doc-body pre { background: #2A2A30; color: #bbb; padding: 1.2rem; border-radius: 10px; font-family: var(--mono); font-size: 0.8rem; line-height: 1.7; overflow-x: auto; margin-bottom: 1.5rem; border: 2px solid rgba(0,0,0,0.08); }
+.doc-body pre { background: #2A2A30; color: #cccccc; padding: 1.2rem; border-radius: 10px; font-family: var(--mono); font-size: 0.8rem; line-height: 1.7; overflow-x: auto; margin-bottom: 1.5rem; border: 2px solid rgba(0,0,0,0.08); }
 .doc-body table { border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.9rem; width: 100%; }
 .doc-body th { text-align: left; font-weight: 700; padding: 0.6rem 1rem; border-bottom: 2px solid var(--border); }
 .doc-body td { padding: 0.5rem 1rem; border-bottom: 1px solid var(--border); color: var(--text-mid); }


### PR DESCRIPTION
Closes #29. Follows up on PR #31 by handling the last acceptance item.

## What was left

PR #31 fixed syntax-highlighting gaps (`manager_loop` / `parallel` / `fan_in` / `subgraph` detection + wider dippin identifier pattern) and raised `.hl-dim` / `.terminal .dim` to meet WCAG AA. The remaining item was the gate.dip example on `/testing/` where `claude-sonnet-4-6` reads as "barely readable."

## Root cause

My original issue text blamed missing `.compare-code .node` / `.op` rules, but those already exist. The actual cause is that value tokens (plain text not wrapped in any `kw` / `str` / `node` / `op` span) fall back to the block's default text color — `#bbb` — which is ~6.9:1 on the `#2A2A30` block background.

That's WCAG AAA legal, but in a palette where every *classed* span is saturated (lavender kw, yellow node, green str, light-gray op), plain text at `#bbb` reads as the darkest and drabbest element — flattened rather than unreadable.

## Change

Bumped the three dark-block default text colors from `#bbb` to `#cccccc`:

- `.compare-code` (used by the hand-authored gate.dip / compare blocks on `/testing/`, landing page)
- `.terminal pre` (used by the cost / coverage / doctor terminal blocks on `/analysis/`)
- `.doc-body pre` (used by auto-highlighted `.dip` code fences in blog posts + docs)

Contrast rises to ~9.0:1 on `#2A2A30`, putting plain text flush with `.op` (`#ddd`) and close to the saturated colors' luminance range. Hierarchy is preserved because the saturated span colors keep their differentiation — it's the gray-to-white baseline that changes, not the colored spans.

## Why one color bump instead of wrapping values in a `.val` span

Wrapping each value token would require a content sweep across every hand-authored `.compare-code` block (`site/content/testing.md`, `site/layouts/index.html`, etc.) *and* an extension to `highlight.js` to color unquoted values after `:`. The CSS bump is one line, uniform, and solves the visible symptom in every affected context.

## Test plan

- [ ] After deploy, visual check on `/testing/` — `claude-sonnet-4-6` in the gate.dip block reads cleanly alongside the colored keywords.
- [ ] Visual check on `/analysis/` — cost/coverage terminal blocks have legible bodies without looking washed out.
- [ ] Visual check on `/blog/whats-new-v021-v022/` — auto-highlighted `.dip` code blocks still have clear keyword / string / node differentiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text coloring in code display areas including code comparisons, terminal output, and documentation code blocks for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->