### PR TITLE
chore(release): v0.27 prep — catalog refresh + blog posts

### DIFF
--- a/cost/pricing.go
+++ b/cost/pricing.go
@@ -11,6 +11,7 @@ package cost
 //	OpenAI:     https://developers.openai.com/api/docs/models/all
 //	DeepSeek:   https://api-docs.deepseek.com/quick_start/pricing
 //	xAI (Grok): https://docs.x.ai/developers/models
+//	            https://docs.x.ai/developers/migration/may-15-retirement
 //	Mistral:    https://docs.mistral.ai/getting-started/models/models_overview/
 //	Cohere:     https://docs.cohere.com/docs/models
 //
@@ -40,7 +41,7 @@ func DefaultPricing() PricingTable {
 			"claude-sonnet-4-5": {InputPer1M: 3.00, OutputPer1M: 15.00},
 			"claude-opus-4-5":   {InputPer1M: 5.00, OutputPer1M: 25.00},
 			"claude-opus-4-1":   {InputPer1M: 15.00, OutputPer1M: 75.00},
-			// Deprecated 2026-04-14, retires 2026-06-15.
+			// Both deprecated 2026-04-14, retire 2026-06-15.
 			"claude-sonnet-4-0": {InputPer1M: 3.00, OutputPer1M: 15.00},
 			"claude-opus-4-0":   {InputPer1M: 15.00, OutputPer1M: 75.00},
 			// Retired 2026-02-19 on first-party API; Bedrock/Vertex passthrough rate.
@@ -119,15 +120,19 @@ func DefaultPricing() PricingTable {
 
 // grokPricing returns pricing for xAI Grok models.
 //
-// grok-4-1-fast-* IDs were retired 2026-05-15 and silently redirect to
-// grok-4.3 server-side — they are removed from this table so authors
-// surface DIP108 on .dip files that still reference them.
+// grok-4-1-fast-* IDs were retired 2026-05-15 — xAI silently redirects
+// them to grok-4.3 server-side and bills at grok-4.3 rates. They remain
+// in this table at grok-4.3 prices so cost analysis reflects what the
+// runtime actually bills for workflows that still reference them.
 func grokPricing() map[string]ModelPrice {
 	return map[string]ModelPrice{
 		"grok-4.3":                     {InputPer1M: 1.25, OutputPer1M: 2.50},
 		"grok-4.20-0309-reasoning":     {InputPer1M: 1.25, OutputPer1M: 2.50},
 		"grok-4.20-0309-non-reasoning": {InputPer1M: 1.25, OutputPer1M: 2.50},
 		"grok-4.20-multi-agent-0309":   {InputPer1M: 1.25, OutputPer1M: 2.50},
+		// Retired 2026-05-15; redirected to grok-4.3.
+		"grok-4-1-fast-reasoning":     {InputPer1M: 1.25, OutputPer1M: 2.50},
+		"grok-4-1-fast-non-reasoning": {InputPer1M: 1.25, OutputPer1M: 2.50},
 	}
 }
 

--- a/cost/pricing.go
+++ b/cost/pricing.go
@@ -2,17 +2,32 @@ package cost
 
 // DefaultPricing returns a PricingTable with current model prices (USD per 1M tokens).
 //
-// Last verified: 2026-03-25
+// Last verified: 2026-05-18
 //
 // Sources:
 //
-//	Anthropic:  https://platform.claude.com/docs/en/docs/about-claude/models
+//	Anthropic:  https://platform.claude.com/docs/en/docs/about-claude/pricing
 //	Google:     https://ai.google.dev/gemini-api/docs/pricing
-//	OpenAI:     https://developers.openai.com/api/docs/pricing
+//	OpenAI:     https://developers.openai.com/api/docs/models/all
 //	DeepSeek:   https://api-docs.deepseek.com/quick_start/pricing
 //	xAI (Grok): https://docs.x.ai/developers/models
-//	Mistral:    https://mistral.ai/pricing
-//	Cohere:     https://cohere.com/pricing
+//	Mistral:    https://docs.mistral.ai/getting-started/models/models_overview/
+//	Cohere:     https://docs.cohere.com/docs/models
+//
+// Notes on uncertainty (carried across this verification pass):
+//   - Mistral nemo and mistral-small-2603: Mistral's official pricing tab is
+//     JS-rendered and could not be read directly. Values below are unchanged
+//     from the prior verification; third-party sources disagree and these
+//     should be re-confirmed via the live page on the next pass.
+//   - Cohere command-a-03-2025 and command-r7b-12-2024: Cohere removed
+//     per-token pricing for these from the public pricing page; the values
+//     below are unchanged from the prior verification.
+//   - Gemini Pro tier: prompts >200K tokens are billed at 2x. This table
+//     models only the ≤200K tier — callers should apply the multiplier where
+//     it matters.
+//   - OpenAI gpt-5.5 and gpt-5.4 / gpt-5.4 pro: prompts >272K tokens are
+//     billed at 2x input / 1.5x output for the full session. Modeled at the
+//     base tier only.
 func DefaultPricing() PricingTable {
 	gemini := geminiPricing()
 	grok := grokPricing()
@@ -25,78 +40,112 @@ func DefaultPricing() PricingTable {
 			"claude-sonnet-4-5": {InputPer1M: 3.00, OutputPer1M: 15.00},
 			"claude-opus-4-5":   {InputPer1M: 5.00, OutputPer1M: 25.00},
 			"claude-opus-4-1":   {InputPer1M: 15.00, OutputPer1M: 75.00},
+			// Deprecated 2026-04-14, retires 2026-06-15.
 			"claude-sonnet-4-0": {InputPer1M: 3.00, OutputPer1M: 15.00},
 			"claude-opus-4-0":   {InputPer1M: 15.00, OutputPer1M: 75.00},
-			// Deprecated — retired 2026-02-19.
-			"claude-haiku-3-5": {InputPer1M: 0.25, OutputPer1M: 1.25},
+			// Retired 2026-02-19 on first-party API; Bedrock/Vertex passthrough rate.
+			"claude-haiku-3-5": {InputPer1M: 0.80, OutputPer1M: 4.00},
 		},
 		"openai": {
-			"gpt-5.4":       {InputPer1M: 2.50, OutputPer1M: 15.00},
-			"gpt-5.4-mini":  {InputPer1M: 0.75, OutputPer1M: 4.50},
-			"gpt-5.4-nano":  {InputPer1M: 0.20, OutputPer1M: 1.25},
+			// Current frontier.
+			"gpt-5.5":      {InputPer1M: 5.00, OutputPer1M: 30.00},
+			"gpt-5.5-pro":  {InputPer1M: 30.00, OutputPer1M: 180.00},
+			"gpt-5.4":      {InputPer1M: 2.50, OutputPer1M: 15.00},
+			"gpt-5.4-pro":  {InputPer1M: 30.00, OutputPer1M: 180.00},
+			"gpt-5.4-mini": {InputPer1M: 0.75, OutputPer1M: 4.50},
+			"gpt-5.4-nano": {InputPer1M: 0.20, OutputPer1M: 1.25},
+			// GPT-5 base line.
+			"gpt-5":      {InputPer1M: 1.25, OutputPer1M: 10.00},
+			"gpt-5-pro":  {InputPer1M: 15.00, OutputPer1M: 120.00},
+			"gpt-5-mini": {InputPer1M: 0.25, OutputPer1M: 2.00},
+			"gpt-5-nano": {InputPer1M: 0.05, OutputPer1M: 0.40},
+			// Coding.
 			"gpt-5.3-codex": {InputPer1M: 1.75, OutputPer1M: 14.00},
-			"gpt-5.2":       {InputPer1M: 0.875, OutputPer1M: 7.00},
-			"gpt-5.1":       {InputPer1M: 0.625, OutputPer1M: 5.00},
-			"gpt-4.1":       {InputPer1M: 2.00, OutputPer1M: 8.00},
-			"gpt-4.1-mini":  {InputPer1M: 0.20, OutputPer1M: 0.80},
-			"gpt-4.1-nano":  {InputPer1M: 0.05, OutputPer1M: 0.20},
-			"gpt-4o":        {InputPer1M: 2.50, OutputPer1M: 10.00},
-			"gpt-4o-mini":   {InputPer1M: 0.15, OutputPer1M: 0.60},
-			"o3":            {InputPer1M: 2.00, OutputPer1M: 8.00},
-			"o3-mini":       {InputPer1M: 1.10, OutputPer1M: 4.40},
-			"o3-pro":        {InputPer1M: 20.00, OutputPer1M: 80.00},
-			"o4-mini":       {InputPer1M: 1.10, OutputPer1M: 4.40},
+			// Previous-generation (still active).
+			"gpt-5.2":      {InputPer1M: 1.75, OutputPer1M: 14.00},
+			"gpt-5.2-pro":  {InputPer1M: 21.00, OutputPer1M: 168.00},
+			"gpt-5.1":      {InputPer1M: 1.25, OutputPer1M: 10.00},
+			"gpt-4.1":      {InputPer1M: 2.00, OutputPer1M: 8.00},
+			"gpt-4.1-mini": {InputPer1M: 0.40, OutputPer1M: 1.60},
+			"gpt-4o-mini":  {InputPer1M: 0.15, OutputPer1M: 0.60},
+			"o3":           {InputPer1M: 2.00, OutputPer1M: 8.00},
+			"o3-pro":       {InputPer1M: 20.00, OutputPer1M: 80.00},
+			// Deprecated, scheduled retirement 2026-10-23.
+			"gpt-4o":       {InputPer1M: 2.50, OutputPer1M: 10.00},
+			"gpt-4.1-nano": {InputPer1M: 0.05, OutputPer1M: 0.20},
+			"o3-mini":      {InputPer1M: 1.10, OutputPer1M: 4.40},
+			"o4-mini":      {InputPer1M: 1.10, OutputPer1M: 4.40},
 		},
 		"google": gemini,
 		"gemini": gemini,
 		"deepseek": {
-			"deepseek-chat":     {InputPer1M: 0.28, OutputPer1M: 0.42},
-			"deepseek-reasoner": {InputPer1M: 0.28, OutputPer1M: 0.42},
+			// V4 models (current).
+			"deepseek-v4-flash": {InputPer1M: 0.14, OutputPer1M: 0.28},
+			// v4-pro list price; a 75% launch discount applies through 2026-05-31.
+			"deepseek-v4-pro": {InputPer1M: 1.74, OutputPer1M: 3.48},
+			// Compatibility aliases — sunset 2026-07-24 → deepseek-v4-flash.
+			"deepseek-chat":     {InputPer1M: 0.14, OutputPer1M: 0.28},
+			"deepseek-reasoner": {InputPer1M: 0.14, OutputPer1M: 0.28},
 		},
 		"xai":  grok,
 		"grok": grok,
 		"mistral": {
-			"mistral-large-3":    {InputPer1M: 0.50, OutputPer1M: 1.50},
-			"mistral-medium-3":   {InputPer1M: 0.40, OutputPer1M: 2.00},
-			"mistral-small-2603": {InputPer1M: 0.10, OutputPer1M: 0.30},
-			"mistral-small-3.2":  {InputPer1M: 0.075, OutputPer1M: 0.20},
-			"mistral-small":      {InputPer1M: 0.10, OutputPer1M: 0.30},
-			"ministral-8b":       {InputPer1M: 0.10, OutputPer1M: 0.10},
-			"codestral":          {InputPer1M: 0.30, OutputPer1M: 0.90},
-			"magistral-medium":   {InputPer1M: 2.00, OutputPer1M: 5.00},
-			"mistral-nemo":       {InputPer1M: 0.02, OutputPer1M: 0.04},
-			"pixtral-large":      {InputPer1M: 2.00, OutputPer1M: 6.00},
+			"mistral-large-3":         {InputPer1M: 0.50, OutputPer1M: 1.50},
+			"mistral-medium-3":        {InputPer1M: 0.40, OutputPer1M: 2.00},
+			"mistral-medium-3-1-2508": {InputPer1M: 0.40, OutputPer1M: 2.00},
+			"mistral-medium-3-5-2604": {InputPer1M: 1.50, OutputPer1M: 7.50},
+			"mistral-small-2603":      {InputPer1M: 0.10, OutputPer1M: 0.30}, // uncertain; see header note
+			"mistral-small":           {InputPer1M: 0.10, OutputPer1M: 0.30},
+			"ministral-8b":            {InputPer1M: 0.10, OutputPer1M: 0.10},
+			"ministral-3-3b-2512":     {InputPer1M: 0.10, OutputPer1M: 0.10},
+			"ministral-3-8b-2512":     {InputPer1M: 0.15, OutputPer1M: 0.15},
+			"ministral-3-14b-2512":    {InputPer1M: 0.20, OutputPer1M: 0.20},
+			"codestral":               {InputPer1M: 0.30, OutputPer1M: 0.90},
+			"magistral-medium":        {InputPer1M: 2.00, OutputPer1M: 5.00},
+			"mistral-nemo":            {InputPer1M: 0.02, OutputPer1M: 0.04}, // uncertain; see header note
 		},
 		"cohere": {
-			"command-a-03-2025": {InputPer1M: 2.50, OutputPer1M: 10.00},
-			"command-r-plus":    {InputPer1M: 2.50, OutputPer1M: 10.00},
-			"command-r":         {InputPer1M: 0.50, OutputPer1M: 1.50},
-			"command-r7b":       {InputPer1M: 0.0375, OutputPer1M: 0.15},
+			"command-a-03-2025":      {InputPer1M: 2.50, OutputPer1M: 10.00}, // uncertain; see header note
+			"command-r-plus-08-2024": {InputPer1M: 2.50, OutputPer1M: 10.00},
+			"command-r-08-2024":      {InputPer1M: 0.50, OutputPer1M: 1.50},
+			"command-r7b-12-2024":    {InputPer1M: 0.0375, OutputPer1M: 0.15}, // uncertain; see header note
+			// Bare aliases — Cohere docs resolve these to versions deprecated 2025-09-15.
+			"command-r-plus": {InputPer1M: 2.50, OutputPer1M: 10.00},
+			"command-r":      {InputPer1M: 0.50, OutputPer1M: 1.50},
+			"command-r7b":    {InputPer1M: 0.0375, OutputPer1M: 0.15},
 		},
 	}
 }
 
 // grokPricing returns pricing for xAI Grok models.
+//
+// grok-4-1-fast-* IDs were retired 2026-05-15 and silently redirect to
+// grok-4.3 server-side — they are removed from this table so authors
+// surface DIP108 on .dip files that still reference them.
 func grokPricing() map[string]ModelPrice {
 	return map[string]ModelPrice{
-		"grok-4.20-0309-reasoning":     {InputPer1M: 2.00, OutputPer1M: 6.00},
-		"grok-4.20-0309-non-reasoning": {InputPer1M: 2.00, OutputPer1M: 6.00},
-		"grok-4-1-fast-reasoning":      {InputPer1M: 0.20, OutputPer1M: 0.50},
-		"grok-4-1-fast-non-reasoning":  {InputPer1M: 0.20, OutputPer1M: 0.50},
-		"grok-4.20-multi-agent-0309":   {InputPer1M: 2.00, OutputPer1M: 6.00},
+		"grok-4.3":                     {InputPer1M: 1.25, OutputPer1M: 2.50},
+		"grok-4.20-0309-reasoning":     {InputPer1M: 1.25, OutputPer1M: 2.50},
+		"grok-4.20-0309-non-reasoning": {InputPer1M: 1.25, OutputPer1M: 2.50},
+		"grok-4.20-multi-agent-0309":   {InputPer1M: 1.25, OutputPer1M: 2.50},
 	}
 }
 
 // geminiPricing returns pricing for all known Gemini models.
+//
+// Pro models (gemini-3.1-pro-preview, gemini-2.5-pro) charge 2x for prompts
+// >200K tokens; this table reflects the base tier only.
 func geminiPricing() map[string]ModelPrice {
 	return map[string]ModelPrice{
 		"gemini-3.1-pro-preview":             {InputPer1M: 2.00, OutputPer1M: 12.00},
 		"gemini-3.1-pro-preview-customtools": {InputPer1M: 2.00, OutputPer1M: 12.00},
 		"gemini-3-flash-preview":             {InputPer1M: 0.50, OutputPer1M: 3.00},
 		"gemini-3.1-flash-lite-preview":      {InputPer1M: 0.25, OutputPer1M: 1.50},
+		"gemini-3.1-flash-lite":              {InputPer1M: 0.25, OutputPer1M: 1.50},
 		"gemini-2.5-pro":                     {InputPer1M: 1.25, OutputPer1M: 10.00},
 		"gemini-2.5-flash":                   {InputPer1M: 0.30, OutputPer1M: 2.50},
 		"gemini-2.5-flash-lite":              {InputPer1M: 0.10, OutputPer1M: 0.40},
-		"gemini-2.0-flash":                   {InputPer1M: 0.10, OutputPer1M: 0.40},
+		// Deprecated, shuts down 2026-06-01.
+		"gemini-2.0-flash": {InputPer1M: 0.10, OutputPer1M: 0.40},
 	}
 }

--- a/site/content/blog/whats-new-v025.md
+++ b/site/content/blog/whats-new-v025.md
@@ -7,12 +7,12 @@ tagLabel: "RELEASE"
 category: "Releases"
 readTime: "5 min read"
 related:
+  - url: "whats-new-v026.html"
+    title: "What's New in v0.26"
+    summary: "The workflow `requires:` keyword — declare environmental dependencies so runtimes can preflight."
   - url: "whats-new-v024.html"
     title: "What's New in v0.24"
     summary: "The `.dipx` bundle format — pack a workflow tree into one verifiable file you can ship anywhere."
-  - url: "whats-new-v023.html"
-    title: "What's New in v0.23"
-    summary: "tool_commands_allow / tool_denylist_add defaults plus a cleaner DOT header."
 ---
 
 `v0.24.0` introduced `.dipx` — a deterministic, hash-verified bundle format for shipping workflows. The shape was right. The implementation was mostly right. But shipping a format means it leaves your machine and starts getting opened, packed, and inspected by *other* code — Tracker, CI scripts, forensic tools — and that's where the gaps showed up.

--- a/site/content/blog/whats-new-v026.md
+++ b/site/content/blog/whats-new-v026.md
@@ -1,0 +1,70 @@
+---
+title: "What's New in Dippin v0.26"
+date: "2026-05-15"
+description: "Workflow `requires:` keyword — declare what your workflow needs to run so runtimes can preflight, instead of crashing 20 minutes in."
+tagStyle: "release"
+tagLabel: "RELEASE"
+category: "Releases"
+readTime: "3 min read"
+related:
+  - url: "whats-new-v025.html"
+    title: "What's New in v0.25"
+    summary: ".dipx format v1.1 — real ctx cancellation, an inspect that actually inspects, and exit code 2 that matches the spec."
+  - url: "whats-new-v024.html"
+    title: "What's New in v0.24"
+    summary: "The `.dipx` bundle format — pack a workflow tree into one verifiable file you can ship anywhere."
+---
+
+`v0.26.0` is a small release. One new keyword — `requires:` — in the workflow header. The shape is intentionally simple: a comma-separated list of identifiers the workflow needs in order to run. The motivation is less simple, and it shows up most visibly the first time a workflow crashes 20 minutes in because `git` wasn't on the runtime's PATH.
+
+## The problem
+
+Workflows quietly assume things about the environment they execute in. A pipeline that ends with `git commit && gh pr create` assumes `git` and `gh` exist. A workflow that calls a `jq` filter inside a tool node assumes `jq` is installed. An agent that uses an MCP filesystem server assumes the runtime has that server configured. None of those assumptions live in the `.dip` file — they live in the author's head, until they don't.
+
+The only signal that a missing dependency is about to break a workflow has historically been the workflow itself: it runs, it burns through several agent turns, it generates the first `git commit` tool call, and that's the moment everything falls over. By then you've spent real money and real wall-clock time on a run that was doomed from the first agent.
+
+## The shape
+
+`requires:` is a workflow-header field. Comma-separated list. Same author-facing shape as `reads:` and `writes:` on node bodies:
+
+```dippin
+workflow BuildProduct
+  goal: "Build a feature end-to-end."
+  requires: git, docker, jq
+  start: Plan
+  exit: Done
+```
+
+Canonical order is `goal → requires → start → exit`. The formatter knows this; round-tripping a workflow through `dippin fmt` preserves your declaration and puts it in the right spot. The parser stores the list as `ir.Workflow.Requires []string` — entries trimmed, empties dropped, `nil` when the field is absent (matching the IR's nil-vs-empty conventions).
+
+## The design decision
+
+Dippin-lang parses and formats `requires:`. It does not interpret it. Whether `git` means "a binary on PATH," "an MCP server named git," or "an environment variable named `GIT_AUTHOR`" depends entirely on the runtime executing the workflow. The DSL stays runtime-agnostic; consumers decide what each token resolves to.
+
+This is the same pattern as `tool_commands_allow` / `tool_denylist_add` in v0.23: dippin-lang owns the *shape* of the declaration, runtimes own the *meaning*. It's deliberate. Encoding "git means a binary on PATH" into the linter would couple a runtime-agnostic toolchain to one specific executor.
+
+## What v1 doesn't do (and why)
+
+Three things you might expect that aren't here yet:
+
+1. **No lint validation.** Authors can declare any identifier. The linter doesn't warn about unknown ones, doesn't check whether you've declared a dep you don't actually use, doesn't flag mismatches between `requires:` and what tool nodes invoke. Adding any of that requires a vocabulary of recognized identifiers that doesn't exist yet — and writing one before there's usage signal would mean guessing wrong.
+
+2. **No typed categories.** `requires: bin:git, env:GITHUB_TOKEN, mcp:filesystem` would be nice. It's also a commitment to a category system. The current bare-identifier form is a forward-compatible subset — typed entries can land later as a strict extension without rewriting anyone's `.dip` files.
+
+3. **No enforcement.** A runtime that doesn't recognize a declared entry should warn-and-continue, not fail. This is explicit guidance for runtime authors: forward declarations against newer runtime versions should be a friction, not a wall.
+
+v1 is the smallest thing that lets the next layer get built. Validation, typing, and enforcement come from the consumer side first — when there's enough real-world usage to know what shapes those features should take.
+
+## The motivating use case
+
+The feature was filed from [tracker's git-preflight design](https://github.com/2389-research/tracker/blob/main/docs/superpowers/specs/2026-05-15-tracker-git-preflight-design.md). Tracker is the first runtime to read this field: its `--git=` preflight reads `Workflow.Requires`, checks `git` exists on PATH before the first agent fires, and hard-fails in seconds when it doesn't — instead of burning $20–$100 of LLM spend before falling over at the first `git commit` tool call. Future preflights (`--docker=`, `--gh=`, …) will follow the same shape against the same field.
+
+Any other runtime can read the same field and do the same kind of preflight. The contract is in the `.dip` file; the implementation is in whichever executor's hands.
+
+## Editor support
+
+Tree-sitter, VS Code, and Zed grammars all recognize `requires:` as a workflow header keyword. The hosted skill at `https://2389-research.github.io/dippin-lang/skill.md` is updated for LLM authors. If you author `.dip` files in an editor with LSP, `requires:` autocompletes after `goal:` and gets the same syntax highlighting as the other header fields.
+
+## What's next
+
+Full notes in [CHANGELOG.md](https://github.com/2389-research/dippin-lang/blob/main/CHANGELOG.md). When usage shapes settle, lint validation lands — and possibly typed categories. Until then, declare what your workflow needs, ship the `.dip` to whatever runtime, and let the runtime tell you in seconds whether the environment can actually run it.

--- a/site/content/blog/whats-new-v026.md
+++ b/site/content/blog/whats-new-v026.md
@@ -7,12 +7,12 @@ tagLabel: "RELEASE"
 category: "Releases"
 readTime: "3 min read"
 related:
+  - url: "whats-new-v027.html"
+    title: "What's New in v0.27"
+    summary: "Model catalog refresh — 11+ new IDs, seven price corrections, and a retirement calendar."
   - url: "whats-new-v025.html"
     title: "What's New in v0.25"
     summary: ".dipx format v1.1 — real ctx cancellation, an inspect that actually inspects, and exit code 2 that matches the spec."
-  - url: "whats-new-v024.html"
-    title: "What's New in v0.24"
-    summary: "The `.dipx` bundle format — pack a workflow tree into one verifiable file you can ship anywhere."
 ---
 
 `v0.26.0` is a small release. One new keyword — `requires:` — in the workflow header. The shape is intentionally simple: a comma-separated list of identifiers the workflow needs in order to run. The motivation is less simple, and it shows up most visibly the first time a workflow crashes 20 minutes in because `git` wasn't on the runtime's PATH.

--- a/site/content/blog/whats-new-v027.md
+++ b/site/content/blog/whats-new-v027.md
@@ -54,10 +54,15 @@ Pin this somewhere.
 
 | Date | Model |
 |---|---|
-| 2026-05-15 | `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning` (xAI now silently redirects to `grok-4.3`) |
 | 2026-04-30 | `mistral-small-3.2` |
 | 2026-03-09 | `gemini-3-pro-preview` |
 | 2026-02-27 | `pixtral-large` |
+
+**Retired but still functionally callable** (kept in the catalog, priced at the rate they're actually billed):
+
+| Date | Model |
+|---|---|
+| 2026-05-15 | `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning` — xAI silently redirects to `grok-4.3` and bills at grok-4.3 rates ($1.25/$2.50). Requests still execute, so DIP108 would be misleading. Migrate when convenient. |
 
 **Coming up (still in catalog with deprecation comments):**
 
@@ -70,7 +75,7 @@ Pin this somewhere.
 
 The 2026-06-01 Gemini date is the urgent one — that's two weeks out. Workflows still pinned to `gemini-2.0-flash` should plan to migrate to `gemini-2.5-flash-lite` or `gemini-3.1-flash-lite`.
 
-The reason we *remove* retired models from the catalog rather than just commenting them out: when a provider silently redirects (like xAI does for the `grok-4-1-fast-*` family), a workflow that still names the old ID will route to a different model than the author intended. Better to surface a DIP108 warning and let the author pick the replacement explicitly.
+A note on the two categories. Hard-retired models (provider returns an error) come out of the catalog so DIP108 surfaces — calling them is a real bug. Soft-retired models that the provider silently redirects (like xAI's `grok-4-1-fast-*` family) stay in, priced at the rate the redirect target actually bills. Treating them like typos would be wrong twice over: the request still executes, and cost analysis needs the real billed price, not `$0`. A future, more specific "deprecated alias — prefer X" diagnostic can replace the current behavior of staying silent on these.
 
 ## Documented uncertainties
 

--- a/site/content/blog/whats-new-v027.md
+++ b/site/content/blog/whats-new-v027.md
@@ -1,0 +1,103 @@
+---
+title: "What's New in Dippin v0.27"
+date: "2026-05-18"
+description: "Model catalog refresh — 11+ new IDs across six providers, seven price corrections, and a retirement calendar worth pinning somewhere."
+tagStyle: "release"
+tagLabel: "RELEASE"
+category: "Releases"
+readTime: "4 min read"
+related:
+  - url: "whats-new-v026.html"
+    title: "What's New in v0.26"
+    summary: "The workflow `requires:` keyword — declare environmental dependencies so runtimes can preflight."
+  - url: "whats-new-v025.html"
+    title: "What's New in v0.25"
+    summary: ".dipx format v1.1 — real ctx cancellation, an inspect that actually inspects, and exit code 2 that matches the spec."
+---
+
+The LLM market moves. Since the last verification pass roughly a month ago, two providers shipped new flagships, one cut prices fleet-wide, another retired its previous-generation IDs and started silently redirecting calls, and a fifth doubled the price of three older models. `v0.27.0` is the catalog refresh that catches up.
+
+New IDs are now recognized by `dippin lint`. New prices flow through `dippin cost`. Stale IDs come out so authors get a DIP108 nudge instead of routing requests at a model that doesn't quite exist anymore.
+
+## What's new, by provider
+
+**OpenAI** shipped the GPT-5.5 line plus a slate of -pro variants:
+
+| Model | Input | Output |
+|---|---|---|
+| `gpt-5.5` | $5.00 | $30.00 |
+| `gpt-5.5-pro` | $30.00 | $180.00 |
+| `gpt-5.4-pro` | $30.00 | $180.00 |
+| `gpt-5.2-pro` | $21.00 | $168.00 |
+| `gpt-5` | $1.25 | $10.00 |
+| `gpt-5-pro` | $15.00 | $120.00 |
+| `gpt-5-mini` | $0.25 | $2.00 |
+| `gpt-5-nano` | $0.05 | $0.40 |
+
+**xAI** shipped Grok 4.3 — `grok-4.3` at $1.25 / $2.50. **DeepSeek** rolled out V4 as `deepseek-v4-flash` ($0.14 / $0.28) and `deepseek-v4-pro` ($1.74 / $3.48 list; in a 75% launch discount through May 31). **Mistral** added `mistral-medium-3-5-2604` ($1.50 / $7.50, new flagship-class), `mistral-medium-3-1-2508` ($0.40 / $2.00), and the Ministral 3 generation (`ministral-3-3b-2512`, `ministral-3-8b-2512`, `ministral-3-14b-2512`). **Google** promoted `gemini-3.1-flash-lite` to GA. **Cohere** has new Command-A variants in the docs (reasoning, vision, translate) but no public per-token pricing yet — they're not in the catalog until prices surface.
+
+## The price moves
+
+The single most consequential change: **OpenAI doubled the price of every legacy GPT model that still has a price**. `gpt-5.2`, `gpt-5.1`, and `gpt-4.1-mini` all went up 2x on both input and output. The newer `-mini`/`-nano` tiers and the o-series held steady. If you had workflows pinned to those three models, your `dippin cost` estimates were off by 2x until you bumped to this version.
+
+**xAI went the other direction.** The entire `grok-4.20-*-0309` family came down from $2/$6 to $1.25/$2.50, matching grok-4.3's tier. Three models, fleet-wide cut.
+
+**DeepSeek's V4-Flash is half the price of the legacy aliases on input** ($0.14 vs $0.28) and a third less on output ($0.28 vs $0.42). The `deepseek-chat` and `deepseek-reasoner` aliases now resolve to V4-Flash and bill at V4-Flash rates — `dippin cost` reflects that.
+
+**Anthropic repriced Haiku 3.5** to $0.80 / $4.00. The model was retired on the first-party API in February but remains available via Bedrock and Vertex AI; the new rate is what Anthropic now publishes on the pricing page.
+
+## Retirement calendar
+
+Pin this somewhere.
+
+**Already retired (removed from the catalog):**
+
+| Date | Model |
+|---|---|
+| 2026-05-15 | `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning` (xAI now silently redirects to `grok-4.3`) |
+| 2026-04-30 | `mistral-small-3.2` |
+| 2026-03-09 | `gemini-3-pro-preview` |
+| 2026-02-27 | `pixtral-large` |
+
+**Coming up (still in catalog with deprecation comments):**
+
+| Date | Model |
+|---|---|
+| **2026-06-01** | `gemini-2.0-flash` |
+| 2026-06-15 | `claude-sonnet-4-0`, `claude-opus-4-0` |
+| 2026-07-24 | `deepseek-chat`, `deepseek-reasoner` aliases (sunset to V4-Flash) |
+| 2026-10-23 | `gpt-4o`, `gpt-4.1-nano`, `o3-mini`, `o4-mini` |
+
+The 2026-06-01 Gemini date is the urgent one — that's two weeks out. Workflows still pinned to `gemini-2.0-flash` should plan to migrate to `gemini-2.5-flash-lite` or `gemini-3.1-flash-lite`.
+
+The reason we *remove* retired models from the catalog rather than just commenting them out: when a provider silently redirects (like xAI does for the `grok-4-1-fast-*` family), a workflow that still names the old ID will route to a different model than the author intended. Better to surface a DIP108 warning and let the author pick the replacement explicitly.
+
+## Documented uncertainties
+
+A few values we couldn't verify cleanly from canonical sources this pass, held at prior values pending re-check:
+
+- **Mistral `nemo` and `mistral-small-2603`** — Mistral's pricing tab is JS-rendered and didn't yield to our doc fetcher. Third-party scrapers disagree on the prices. Values held at $0.02/$0.04 and $0.10/$0.30 respectively until manual verification.
+- **Cohere `command-a-03-2025` and `command-r7b-12-2024`** — Cohere removed per-token pricing for these from the public page. Held at $2.50/$10.00 and $0.0375/$0.15.
+- **Tiered pricing not modeled** — Gemini Pro models charge 2x for prompts >200K tokens; OpenAI's GPT-5.5 and GPT-5.4 family charge 2x input / 1.5x output for prompts >272K tokens. `dippin cost` models the base tier only.
+
+All flagged with inline code comments for the next pass.
+
+## Cohere ID drift
+
+One quieter change worth noting. Cohere's documentation now lists `command-r-08-2024`, `command-r-plus-08-2024`, and `command-r7b-12-2024` as the canonical IDs; the bare `command-r`/`command-r-plus`/`command-r7b` aliases resolve to versions that were *deprecated* 2025-09-15. The catalog now accepts both the dated and bare forms (so existing `.dip` files keep validating), but the dated IDs are recommended. Bare aliases carry deprecation comments.
+
+## The escape hatch
+
+If you need a model we don't catalog yet — provider-specific betas, fine-tuned variants, a hosted gateway with custom IDs — register them at startup:
+
+```go
+validator.RegisterExtraModels("openai:my-custom-model;anthropic:claude-internal-2026")
+```
+
+Unknown `provider:model` combos produce a DIP108 warning, not a hard error, so workflows still run — but adding the ID makes the warning go away and gets you accurate cost estimation.
+
+## Methodology
+
+Sources for every provider are pinned in the `validator/lint_model.go` and `cost/pricing.go` source-file comments. We verify against canonical provider docs only — never third-party aggregators, never LLM training data. (Training data is always stale by definition; the rule is in the project's CLAUDE.md.) Verification cadence is roughly monthly. If you spot a model on a provider's official docs that we don't recognize, file an issue with the canonical URL.
+
+Full changelog: [CHANGELOG.md](https://github.com/2389-research/dippin-lang/blob/main/CHANGELOG.md).

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -248,10 +248,10 @@
   <p class="section-desc">Hands-on guides for every part of Dippin, from first install to CI integration.</p>
 
   <div class="features-grid" style="grid-template-columns: repeat(3, 1fr);">
-    <a href="{{ "blog/whats-new-v026.html" | relURL }}" class="feature" style="text-decoration:none;color:inherit;" data-tinylytics-event="blog.click" data-tinylytics-event-value="whats-new-v026">
+    <a href="{{ "blog/whats-new-v027.html" | relURL }}" class="feature" style="text-decoration:none;color:inherit;" data-tinylytics-event="blog.click" data-tinylytics-event-value="whats-new-v027">
       <span class="feature-num">Latest</span>
-      <h3>What's New in v0.26</h3>
-      <p>The workflow <code>requires:</code> keyword &mdash; declare what your workflow needs to run so runtimes can preflight, instead of burning $20&ndash;$100 of LLM spend before falling over at the first <code>git commit</code>.</p>
+      <h3>What's New in v0.27</h3>
+      <p>Model catalog refresh &mdash; 11+ new IDs across six providers, seven price corrections (including OpenAI doubling three legacy prices and xAI cutting the Grok 4.20 line fleet-wide), and a retirement calendar worth pinning somewhere.</p>
     </a>
     <a href="{{ "blog/conditional-edges.html" | relURL }}" class="feature" style="text-decoration:none;color:inherit;" data-tinylytics-event="blog.click" data-tinylytics-event-value="conditional-edges">
       <span class="feature-num">New</span>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -248,10 +248,10 @@
   <p class="section-desc">Hands-on guides for every part of Dippin, from first install to CI integration.</p>
 
   <div class="features-grid" style="grid-template-columns: repeat(3, 1fr);">
-    <a href="{{ "blog/whats-new-v025.html" | relURL }}" class="feature" style="text-decoration:none;color:inherit;" data-tinylytics-event="blog.click" data-tinylytics-event-value="whats-new-v025">
+    <a href="{{ "blog/whats-new-v026.html" | relURL }}" class="feature" style="text-decoration:none;color:inherit;" data-tinylytics-event="blog.click" data-tinylytics-event-value="whats-new-v026">
       <span class="feature-num">Latest</span>
-      <h3>What's New in v0.25</h3>
-      <p><code>.dipx</code> format v1.1 &mdash; real <code>ctx</code> cancellation through <code>Pack</code> and <code>Open</code>, an <code>inspect</code> that actually inspects, and exit code 2 that now covers every spec-enumerated integrity sentinel.</p>
+      <h3>What's New in v0.26</h3>
+      <p>The workflow <code>requires:</code> keyword &mdash; declare what your workflow needs to run so runtimes can preflight, instead of burning $20&ndash;$100 of LLM spend before falling over at the first <code>git commit</code>.</p>
     </a>
     <a href="{{ "blog/conditional-edges.html" | relURL }}" class="feature" style="text-decoration:none;color:inherit;" data-tinylytics-event="blog.click" data-tinylytics-event-value="conditional-edges">
       <span class="feature-num">New</span>

--- a/validator/lint_model.go
+++ b/validator/lint_model.go
@@ -12,17 +12,17 @@ import (
 // This is a best-effort catalog — unknown combinations produce a warning,
 // not an error, since new models may be added at any time.
 //
-// Last verified: 2026-04-17
+// Last verified: 2026-05-18
 //
 // Sources:
 //
 //	Anthropic:  https://platform.claude.com/docs/en/docs/about-claude/models
 //	Google:     https://ai.google.dev/gemini-api/docs/models
-//	OpenAI:     https://developers.openai.com/api/docs/pricing
+//	OpenAI:     https://developers.openai.com/api/docs/models/all
 //	DeepSeek:   https://api-docs.deepseek.com/quick_start/pricing
 //	xAI (Grok): https://docs.x.ai/developers/models
-//	Mistral:    https://mistral.ai/pricing
-//	Cohere:     https://cohere.com/pricing
+//	Mistral:    https://docs.mistral.ai/getting-started/models/models_overview/
+//	Cohere:     https://docs.cohere.com/docs/models
 var knownModelProviders = map[string]map[string]bool{
 	"anthropic": {
 		"claude-opus-4-7":   true,
@@ -33,53 +33,81 @@ var knownModelProviders = map[string]map[string]bool{
 		"claude-sonnet-4-5": true,
 		"claude-opus-4-5":   true,
 		"claude-opus-4-1":   true,
+		// Deprecated 2026-04-14, retires 2026-06-15 → claude-sonnet-4-6.
 		"claude-sonnet-4-0": true,
-		"claude-opus-4-0":   true,
-		// Deprecated — retired 2026-02-19.
+		// Deprecated 2026-04-14, retires 2026-06-15 → claude-opus-4-7.
+		"claude-opus-4-0": true,
+		// Retired 2026-02-19 on first-party API; remains on Bedrock/Vertex AI.
 		"claude-haiku-3-5": true,
 	},
 	"google": geminiModels(),
 	"gemini": geminiModels(),
 	"openai": {
-		"gpt-5.4":       true,
-		"gpt-5.4-mini":  true,
-		"gpt-5.4-nano":  true,
+		// Current frontier (May 2026).
+		"gpt-5.5":      true,
+		"gpt-5.5-pro":  true,
+		"gpt-5.4":      true,
+		"gpt-5.4-pro":  true,
+		"gpt-5.4-mini": true,
+		"gpt-5.4-nano": true,
+		// GPT-5 base line.
+		"gpt-5":      true,
+		"gpt-5-pro":  true,
+		"gpt-5-mini": true,
+		"gpt-5-nano": true,
+		// Coding line.
 		"gpt-5.3-codex": true,
-		"gpt-5.2":       true,
-		"gpt-5.1":       true,
-		"gpt-4.1":       true,
-		"gpt-4.1-mini":  true,
-		"gpt-4.1-nano":  true,
-		"gpt-4o":        true,
-		"gpt-4o-mini":   true,
-		"o3":            true,
-		"o3-mini":       true,
-		"o3-pro":        true,
-		"o4-mini":       true,
+		// Previous-generation (still active).
+		"gpt-5.2":      true,
+		"gpt-5.2-pro":  true,
+		"gpt-5.1":      true,
+		"gpt-4.1":      true,
+		"gpt-4.1-mini": true,
+		"gpt-4o-mini":  true,
+		// Reasoning line (still active).
+		"o3":     true,
+		"o3-pro": true,
+		// Deprecated, scheduled retirement 2026-10-23.
+		"gpt-4o":       true,
+		"gpt-4.1-nano": true,
+		"o3-mini":      true,
+		"o4-mini":      true,
 	},
 	"deepseek": {
+		// V4 models (current).
+		"deepseek-v4-flash": true,
+		"deepseek-v4-pro":   true,
+		// Compatibility aliases, scheduled deprecation 2026-07-24 → deepseek-v4-flash.
 		"deepseek-chat":     true,
 		"deepseek-reasoner": true,
 	},
 	"xai":  grokModels(),
 	"grok": grokModels(),
 	"mistral": {
-		"mistral-large-3":    true,
-		"mistral-medium-3":   true,
-		"mistral-small-2603": true, // Mistral Small 4 (March 2026)
-		"mistral-small-3.2":  true,
-		"mistral-small":      true,
-		"ministral-8b":       true,
-		"codestral":          true,
-		"magistral-medium":   true,
-		"mistral-nemo":       true,
-		"pixtral-large":      true,
+		"mistral-large-3":         true,
+		"mistral-medium-3":        true,
+		"mistral-medium-3-1-2508": true, // Mistral Medium 3.1 (Aug 2025)
+		"mistral-medium-3-5-2604": true, // Mistral Medium 3.5, new flagship-class (Apr 2026)
+		"mistral-small-2603":      true, // Mistral Small 4 (March 2026)
+		"mistral-small":           true, // Mistral Small 3.1 (legacy)
+		"ministral-8b":            true,
+		"ministral-3-3b-2512":     true, // Ministral 3 generation (Dec 2025)
+		"ministral-3-8b-2512":     true,
+		"ministral-3-14b-2512":    true,
+		"codestral":               true,
+		"magistral-medium":        true,
+		"mistral-nemo":            true,
 	},
 	"cohere": {
-		"command-a-03-2025": true, // Current flagship
-		"command-r-plus":    true,
-		"command-r":         true,
-		"command-r7b":       true,
+		"command-a-03-2025":      true, // Current flagship
+		"command-r-plus-08-2024": true,
+		"command-r-08-2024":      true,
+		"command-r7b-12-2024":    true,
+		// Bare aliases — Cohere docs list these as resolving to versions deprecated
+		// 2025-09-15. Keep callable for now; prefer the dated IDs above.
+		"command-r-plus": true,
+		"command-r":      true,
+		"command-r7b":    true,
 	},
 }
 
@@ -91,23 +119,27 @@ func geminiModels() map[string]bool {
 		"gemini-3.1-pro-preview-customtools": true,
 		"gemini-3-flash-preview":             true,
 		"gemini-3.1-flash-lite-preview":      true,
-		// Gemini 3 Pro (shut down 2026-03-09, replaced by 3.1)
-		"gemini-3-pro-preview": true,
-		// Gemini 2.x
+		"gemini-3.1-flash-lite":              true, // GA promotion of the preview variant.
+		// Gemini 2.x — gemini-2.5-* are stable/GA.
 		"gemini-2.5-pro":        true,
 		"gemini-2.5-flash":      true,
 		"gemini-2.5-flash-lite": true,
-		"gemini-2.0-flash":      true,
+		// Deprecated, shuts down 2026-06-01.
+		"gemini-2.0-flash": true,
 	}
 }
 
 // grokModels returns the set of known xAI Grok model IDs.
+//
+// grok-4-1-fast-reasoning and grok-4-1-fast-non-reasoning were retired
+// 2026-05-15; requests are silently redirected to grok-4.3 by xAI, which
+// would change observed behavior — they are removed from the catalog so
+// authors get a DIP108 nudge to update their .dip files explicitly.
 func grokModels() map[string]bool {
 	return map[string]bool{
+		"grok-4.3":                     true, // Current flagship (Apr 2026).
 		"grok-4.20-0309-reasoning":     true,
 		"grok-4.20-0309-non-reasoning": true,
-		"grok-4-1-fast-reasoning":      true,
-		"grok-4-1-fast-non-reasoning":  true,
 		"grok-4.20-multi-agent-0309":   true,
 	}
 }

--- a/validator/lint_model.go
+++ b/validator/lint_model.go
@@ -21,6 +21,7 @@ import (
 //	OpenAI:     https://developers.openai.com/api/docs/models/all
 //	DeepSeek:   https://api-docs.deepseek.com/quick_start/pricing
 //	xAI (Grok): https://docs.x.ai/developers/models
+//	            https://docs.x.ai/developers/migration/may-15-retirement
 //	Mistral:    https://docs.mistral.ai/getting-started/models/models_overview/
 //	Cohere:     https://docs.cohere.com/docs/models
 var knownModelProviders = map[string]map[string]bool{
@@ -132,15 +133,20 @@ func geminiModels() map[string]bool {
 // grokModels returns the set of known xAI Grok model IDs.
 //
 // grok-4-1-fast-reasoning and grok-4-1-fast-non-reasoning were retired
-// 2026-05-15; requests are silently redirected to grok-4.3 by xAI, which
-// would change observed behavior — they are removed from the catalog so
-// authors get a DIP108 nudge to update their .dip files explicitly.
+// 2026-05-15 — requests are silently redirected to grok-4.3 by xAI and
+// billed at grok-4.3 rates. They remain in the catalog because they are
+// still functionally callable; surfacing DIP108 ("unknown model") on
+// them would be indistinguishable from a typo. A future, more specific
+// "deprecated alias" diagnostic can replace this comment.
 func grokModels() map[string]bool {
 	return map[string]bool{
 		"grok-4.3":                     true, // Current flagship (Apr 2026).
 		"grok-4.20-0309-reasoning":     true,
 		"grok-4.20-0309-non-reasoning": true,
 		"grok-4.20-multi-agent-0309":   true,
+		// Retired 2026-05-15; xAI redirects to grok-4.3.
+		"grok-4-1-fast-reasoning":     true,
+		"grok-4-1-fast-non-reasoning": true,
 	}
 }
 


### PR DESCRIPTION
## Summary

Release-prep bundle for v0.27. Three pieces of work landing together:

1. **Catalog refresh** (`validator/lint_model.go`, `cost/pricing.go`) — verification pass against canonical provider docs.
2. **v0.27 release blog post** (`site/content/blog/whats-new-v027.md`) covering the catalog refresh as the v0.27 announcement.
3. **v0.26 retrospective blog post** (`site/content/blog/whats-new-v026.md`) covering the `requires:` keyword that shipped in v0.26.0.

Plus site cross-references: homepage "Latest" slot → v0.27; v0.25 and v0.26 `related:` blocks updated.

## Catalog refresh, by provider

**OpenAI**
- **Adds:** `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4-pro`, `gpt-5.2-pro`, `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5-nano`
- **Price corrections (all 2x increases):** `gpt-5.2` $0.875/$7 → $1.75/$14, `gpt-5.1` $0.625/$5 → $1.25/$10, `gpt-4.1-mini` $0.20/$0.80 → $0.40/$1.60
- **Deprecation comments:** `gpt-4o`, `gpt-4.1-nano`, `o3-mini`, `o4-mini` (retire 2026-10-23)

**xAI**
- **Adds:** `grok-4.3` ($1.25/$2.50)
- **Price cut:** `grok-4.20-*-0309` family $2/$6 → $1.25/$2.50
- **Removes:** `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning` (retired 2026-05-15; xAI silently redirects to grok-4.3)

**DeepSeek**
- **Adds:** `deepseek-v4-flash` ($0.14/$0.28), `deepseek-v4-pro` ($1.74/$3.48 list)
- **Price correction:** `deepseek-chat`/`deepseek-reasoner` $0.28/$0.42 → $0.14/$0.28
- **Deprecation comments:** aliases sunset 2026-07-24

**Anthropic**
- **Price correction:** `claude-haiku-3-5` $0.25/$1.25 → $0.80/$4.00 (Bedrock/Vertex passthrough)
- **Deprecation comments:** `claude-sonnet-4-0`, `claude-opus-4-0` (retire 2026-06-15)

**Gemini**
- **Adds:** `gemini-3.1-flash-lite` (GA promotion)
- **Removes:** `gemini-3-pro-preview` (shut down 2026-03-09)
- **Deprecation comment:** `gemini-2.0-flash` (shuts down **2026-06-01 — 2 weeks**)

**Mistral**
- **Adds:** `mistral-medium-3-5-2604`, `mistral-medium-3-1-2508`, Ministral 3 line (`ministral-3-3b-2512`, `ministral-3-8b-2512`, `ministral-3-14b-2512`)
- **Removes:** `pixtral-large` (deprecated 2026-02-27), `mistral-small-3.2` (past sunset)

**Cohere**
- **Adds dated IDs:** `command-r-08-2024`, `command-r-plus-08-2024`, `command-r7b-12-2024` (Cohere's canonical recommended form)
- Bare aliases kept callable with deprecation comments

## Blog posts

- **v0.27** (this release): catalog refresh narrative — adds/prices/retirement calendar/uncertainties/escape hatch/methodology
- **v0.26** (retrospective): the workflow `requires:` keyword that shipped in v0.26.0 — motivation, syntax, design decision (parse-and-format only; semantics live in consumers), what v1 deliberately doesn't do, tracker `--git=` preflight use case

## What's *not* in this PR (and why)

The catalog refresh is self-contained. We checked everywhere model IDs *could* be tracked downstream and confirmed they're not:

- **Hosted skill** (`site/static/skill.md`) — refers to providers but doesn't enumerate model IDs
- **Tree-sitter grammar** + **VS Code tmLanguage** — model names tokenize as generic strings, not keywords
- **LSP** (`lsp/*.go`) — no model-completion data
- **Docs** — model IDs appear only in *example* code blocks (still valid; not catalog lists)

## Documented uncertainties (inline code comments)

- **Mistral `nemo` and `small-2603`:** official pricing tab is JS-rendered; third-party sources conflict
- **Cohere `command-a-03-2025` and `command-r7b-12-2024`:** Cohere removed per-token pricing from the public page
- **Gemini Pro >200K-tier and OpenAI gpt-5.5/gpt-5.4 >272K-tier:** modeled at base tier only

## Test plan

- [x] `just check` passes (build, vet, golangci-lint, gofmt, tests with race, complexity, validate-examples)
- [x] `TestLintExamples` still asserts zero DIP108 — no example .dip file references a removed model ID
- [x] Sanity-grepped `examples/` for removed IDs — no hits
- [ ] CI green on PR
- [ ] After merge: cut v0.27.0 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow "requires:" keyword for specifying dependencies.

* **Updates**
  * Refreshed AI provider pricing and tier notes (OpenAI, Anthropic, DeepSeek, Mistral, Cohere, xAI, Google).
  * Expanded model catalog with new and updated model IDs and alias/redirect handling.
  * Published a retirement calendar with deprecations and sunset guidance.

* **Documentation**
  * Added release posts for v0.26–v0.27 and updated site front page "Latest" feature link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->