### PR TITLE
chore(site): boost a14y agent-readability score

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ site/*.tmp
 # cmd/dippin/ copy is checked in (required for go install @latest).
 docs/generated-spec.md
 
+# AGENTS.md is authored at repo root; netlify.toml copies it into site/static/
+# during the build so the canonical source stays one file.
+site/static/AGENTS.md
+
 # Hugo build output
 site/public/
 site/resources/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# AGENTS.md — dippin-lang
+
+dippin-lang is a domain-specific language and toolchain for authoring AI pipeline workflows. It replaces Graphviz DOT as the authoring format for the Tracker runtime.
+
+This file describes how AI coding agents (Claude Code, Cursor, Aider, etc.) can install, configure, and use the toolchain. For human-targeted docs see [`README.md`](README.md) and [`https://dippin.org`](https://dippin.org).
+
+## Installation
+
+```sh
+go install github.com/2389-research/dippin-lang/cmd/dippin@latest
+```
+
+Or via Homebrew:
+
+```sh
+brew install 2389-research/tap/dippin
+```
+
+Verify:
+
+```sh
+dippin version
+```
+
+The CLI is a single static Go binary. No runtime dependencies beyond Go itself for `go install`.
+
+## Configuration
+
+Workflows live in `.dip` files. The toolchain has no global configuration file — every setting is per-workflow via the `defaults` block:
+
+```dippin
+workflow Example
+  goal: "Demonstrate defaults"
+  start: First
+  exit: Done
+
+  defaults
+    model: claude-sonnet-4-6
+    provider: anthropic
+    fidelity: high
+    retry: 2
+
+  agent First
+    prompt: Greet the user.
+
+  agent Done
+    prompt: Wrap up.
+
+  edges
+    First -> Done
+```
+
+Editor / agent integrations:
+
+- **LSP**: `dippin lsp` starts the language server. Configure your editor to launch it for `*.dip` files.
+- **Claude Code skill**: add `@https://dippin.org/skill.md` to a project's `CLAUDE.md` to teach Claude Code the syntax and DIP diagnostic codes.
+- **VS Code / Zed extensions**: see [`editors/`](editors/) in this repo.
+
+## Usage
+
+```sh
+dippin parse pipeline.dip          # JSON IR
+dippin validate pipeline.dip       # structural errors (DIP001-DIP009)
+dippin lint pipeline.dip           # semantic warnings (DIP101-DIP133)
+dippin format pipeline.dip         # canonical formatting
+dippin doctor pipeline.dip         # A-F health report
+dippin cost pipeline.dip           # per-run cost estimate
+dippin test pipeline.dip           # scenario tests from .test.json files
+dippin simulate pipeline.dip       # walk every reachable path
+dippin pack pipeline.dip           # produce a .dipx bundle
+dippin unpack pipeline.dipx        # expand a bundle
+```
+
+Run `dippin --help` for the full command list (28+ commands).
+
+## Building this site
+
+The `https://dippin.org` Hugo site lives under [`site/`](site/). Build:
+
+```sh
+cd site && hugo --minify
+```
+
+The Netlify build (see [`netlify.toml`](netlify.toml)) additionally compiles the WASM playground and generates the changelog + LLM spec.
+
+## a14y configuration
+
+- Target URL: https://dippin.org/
+- Scorecard: 0.2.0
+- Mode: site
+- Last runs:
+  - 2026-05-19 — 72 (scorecard 0.2.0)

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,7 @@
     ./scripts/gen-changelog.sh && \
     ./scripts/gen-spec.sh && \
     cp docs/generated-spec.md site/static/llms-full.txt && \
+    cp AGENTS.md site/static/AGENTS.md && \
     cd site && hugo --minify
   """
   publish = "site/public"
@@ -26,6 +27,7 @@
     ./scripts/gen-changelog.sh && \
     ./scripts/gen-spec.sh && \
     cp docs/generated-spec.md site/static/llms-full.txt && \
+    cp AGENTS.md site/static/AGENTS.md && \
     cd site && hugo --minify --baseURL $URL
   """
 
@@ -37,6 +39,7 @@
     ./scripts/gen-changelog.sh && \
     ./scripts/gen-spec.sh && \
     cp docs/generated-spec.md site/static/llms-full.txt && \
+    cp AGENTS.md site/static/AGENTS.md && \
     cd site && hugo --minify --baseURL $DEPLOY_PRIME_URL
   """
 
@@ -51,7 +54,12 @@
 [[headers]]
   for = "/"
   [headers.values]
-    Link = '</.well-known/api-catalog>; rel="api-catalog", </.well-known/agent-skills/index.json>; rel="describedby", </llms.txt>; rel="describedby"; type="text/plain", </skill.md>; rel="describedby"; type="text/plain"'
+    Link = '</.well-known/api-catalog>; rel="api-catalog", </.well-known/agent-skills/index.json>; rel="describedby", </llms.txt>; rel="describedby"; type="text/plain", </skill.md>; rel="describedby"; type="text/plain", </AGENTS.md>; rel="describedby"; type="text/markdown"'
+
+[[headers]]
+  for = "/AGENTS.md"
+  [headers.values]
+    Content-Type = "text/markdown; charset=utf-8"
 
 [[headers]]
   for = "/dippin.wasm"

--- a/site/content/blog/_index.md
+++ b/site/content/blog/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Blog"
 description: "Tutorials, guides, and deep dives into Dippin workflow authoring."
+url: /blog.html
 ---

--- a/site/content/glossary.md
+++ b/site/content/glossary.md
@@ -1,0 +1,94 @@
+---
+title: "Glossary"
+description: "Definitions for Dippin terms: workflow, node, edge, condition, defaults, subgraph, fan_in, parallel, .dipx, DIP codes, and more."
+section_label: "Reference"
+subtitle: "Terms you'll encounter authoring .dip files and using the dippin toolchain."
+---
+
+## Core concepts
+
+**Workflow** — A directed graph of nodes and edges defined in a single `.dip` file. Has a name, goal, start node, and exit node. One workflow per file.
+
+**Node** — A step in the pipeline. Every node has an ID and a kind. Kinds include `agent`, `human`, `tool`, `conditional`, `parallel`, `fan_in`, `subgraph`, and `manager_loop`.
+
+**Edge** — A connection between two nodes, written `A -> B` in the `edges` block. May carry a `when` condition, a label, a weight, and a `restart:` flag.
+
+**Condition** — A predicate attached to an edge using the `when` keyword. Syntax: `ctx.<field> <op> <value>` with operators `=`, `!=`, `contains`, and `not contains`. Complementary pairs (success/fail, contains/not-contains) are detected as exhaustive automatically.
+
+**Defaults** — A workflow-wide block setting values inherited by all nodes unless overridden. Common keys: `model`, `provider`, `fidelity`, `retry`, `tool_commands_allow`, `tool_denylist_add`.
+
+**Goal** — A short string at the top of a workflow stating the pipeline's purpose. Surfaces in `dippin doctor` reports and is shown to operators.
+
+**Start node** — The single node executed first when the workflow runs. Declared via `start:` in the workflow header.
+
+**Exit node** — The single node that terminates the workflow. Declared via `exit:` in the workflow header. All paths must reach it (lint warns otherwise).
+
+## Node kinds
+
+**agent** — An LLM call. Has a `prompt:` (single line or multiline indented block), optional `model:`, `provider:`, `temperature:`, `tools:`, and `outputs:`.
+
+**human** — A gate that requires user input. Has a `mode:` (`freeform`, `choice`, `confirm`) and an optional `timeout:`.
+
+**tool** — A shell command. Has a `command:` and optional `timeout:`. Constrained by `tool_commands_allow` / `tool_denylist_add` defaults.
+
+**conditional** — A branching node with multiple outbound edges. Routes based on context fields without an LLM call.
+
+**parallel** — Fans out execution to N children that run concurrently. Pairs with `fan_in`.
+
+**fan_in** — Joins parallel branches. Has a `strategy:` (`all`, `any`, `quorum`) and an optional `quorum:` count.
+
+**subgraph** — Embeds another `.dip` file by reference. Uses `ref:` to point to the target file. The `flatten` package resolves these into a single flat workflow for export.
+
+**manager_loop** — A supervisory loop node that runs a child workflow repeatedly under a budget, surfaced in v0.21–v0.22.
+
+## File and bundle formats
+
+**.dip** — The source file extension. Plain text, indentation-based, parsed by the `dippin` CLI.
+
+**.dipx** — A bundle format introduced in v0.24 that packs a workflow tree (root .dip + referenced subgraphs) into a single verifiable file. Created with `dippin pack`, expanded with `dippin unpack`.
+
+**.test.json** — A scenario test file. Injects context values, asserts on execution paths, and reports edge coverage. Run with `dippin test`.
+
+## Diagnostics
+
+**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP009 are structural errors (parse / shape failures). DIP101–DIP133 are semantic warnings (style, correctness hints, model catalog issues).
+
+**Exhaustive conditions** — A pair of edge conditions detected as covering all outcomes (e.g., `when ctx.status = success` + `when ctx.status = fail`). Suppresses DIP101 / DIP102 warnings.
+
+**Lint** — `dippin lint` runs semantic checks and emits DIP1xx codes. Does not exit non-zero by default; CI typically pipes through `--fail-on warning`.
+
+**Validate** — `dippin validate` runs structural checks and emits DIP0xx codes. Exits non-zero on any error.
+
+## Commands
+
+**parse** — Parse a `.dip` file into the JSON IR for downstream tooling.
+
+**format** — Rewrite a `.dip` file in canonical form (2-space indent, sorted keys where order is insignificant).
+
+**doctor** — Grade a workflow A–F. Combines lint, coverage, unused detection, and cost into a health report.
+
+**cost** — Estimate per-run cost based on the model catalog and prompt sizes. Pricing is verified against provider docs and dated in source.
+
+**optimize** — Suggest cheaper model alternatives that preserve the workflow's structural shape.
+
+**simulate** — Walk every reachable path of a workflow without making real LLM calls. Used by `test` under the hood.
+
+**migrate** — Convert Graphviz DOT pipeline files to Dippin. Pairs with `validate-migration` to verify structural parity.
+
+**pack / unpack / inspect** — Produce, expand, and introspect `.dipx` bundles.
+
+## Toolchain
+
+**IR** — The intermediate representation. A set of Go structs in the `ir` package that all downstream consumers program against.
+
+**LSP** — The Dippin Language Server Protocol implementation under `lsp/`. Provides hover docs, go-to-definition, completions, and live diagnostics in any LSP-aware editor.
+
+**WASM playground** — The browser-side parse / lint / format experience at `/playground.html`. The `dippin` core compiled to WebAssembly under `cmd/wasm/`.
+
+**Tracker** — The runtime that executes Dippin workflows. Consumes the JSON IR and installs `dippin` via `go install ...@latest`.
+
+## Related
+
+- [Language Reference]({{< relref "language" >}}) — full syntax for every construct above.
+- [CLI Reference]({{< relref "cli" >}}) — every command.
+- [Validation & Linting]({{< relref "validation" >}}) — full list of DIP codes.

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -2,6 +2,7 @@ baseURL = "https://dippin.org/"
 languageCode = "en-us"
 title = "Dippin"
 uglyURLs = true
+enableGitInfo = true
 disableHugoGeneratorInject = true
 disableKinds = ["taxonomy", "term"]
 
@@ -10,7 +11,12 @@ disableKinds = ["taxonomy", "term"]
     [markup.goldmark.renderer]
       unsafe = true
   [markup.highlight]
-    codeFences = false
+    # codeFences must be true for the render-codeblock hook to fire.
+    # Hugo's own Chroma highlighter is bypassed by the custom hook in
+    # layouts/_default/_markup/render-codeblock.html — runtime highlighting
+    # is still handled client-side by static/highlight.js.
+    codeFences = true
+    noClasses = false
 
 [mediaTypes."text/plain"]
   suffixes = ["txt"]
@@ -21,8 +27,17 @@ disableKinds = ["taxonomy", "term"]
   isPlainText = true
   notAlternative = true
 
+[mediaTypes."text/markdown"]
+  suffixes = ["md"]
+
+[outputFormats.sitemapmd]
+  mediaType = "text/markdown"
+  baseName = "sitemap"
+  isPlainText = true
+  notAlternative = true
+
 [outputs]
-  home = ["HTML", "llmstxt"]
+  home = ["HTML", "llmstxt", "sitemapmd"]
 
 [params]
   description = "A language for AI pipeline workflows"
@@ -42,7 +57,9 @@ disableKinds = ["taxonomy", "term"]
 
 [[menus.main]]
   name = "Blog"
-  pageRef = "/blog"
+  # Hardcoded URL (not pageRef) because Hugo resolves section pageRefs to
+  # /blog/index.html under uglyURLs, but the rendered file is /blog.html.
+  url = "/blog.html"
   weight = 3
 
 [[menus.main]]

--- a/site/layouts/_default/_markup/render-codeblock.html
+++ b/site/layouts/_default/_markup/render-codeblock.html
@@ -1,1 +1,2 @@
-<pre><code>{{ .Inner }}</code></pre>
+{{- $lang := .Type | default "dippin" -}}
+<pre><code class="language-{{ $lang }}">{{ .Inner }}</code></pre>

--- a/site/layouts/_default/playground.html
+++ b/site/layouts/_default/playground.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
 <style>
 .playground { padding-top: 8.5rem; min-height: 100vh; }
+.playground h1.section-title, .playground h2.pane-label { margin-top: 0; }
 .playground-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1.5rem; }
 .pane { display: flex; flex-direction: column; }
 .pane-label { font-family: var(--mono); font-size: 0.72rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 0.5rem; color: var(--text-soft); }
@@ -26,9 +27,10 @@
 <section class="playground">
 <div class="container">
   <div class="section-label">Interactive</div>
-  <div class="section-title">Playground</div>
+  <h1 class="section-title">Playground</h1>
   <p class="section-desc">Write Dippin workflows in the browser. Parse, lint, and format — all running locally via WebAssembly.</p>
 
+  <h2 class="pane-label" style="margin-top:1.5rem;">Tools</h2>
   <div class="toolbar">
     <button id="btn-lint" class="active" onclick="runLint()">Lint</button>
     <button id="btn-parse" onclick="runParse()">Parse</button>
@@ -37,7 +39,7 @@
 
   <div class="playground-grid">
     <div class="pane">
-      <div class="pane-label">Source (.dip)</div>
+      <h2 class="pane-label">Source (.dip)</h2>
       <div class="editor-wrap">
         <pre id="editor-highlight" aria-hidden="true"></pre>
         <textarea id="editor" spellcheck="false" oninput="syncHighlight()" onscroll="syncScroll()">workflow Hello
@@ -60,7 +62,7 @@
       </div>
     </div>
     <div class="pane">
-      <div class="pane-label">Output</div>
+      <h2 class="pane-label">Output</h2>
       <div id="output">Loading WASM...</div>
     </div>
   </div>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -265,7 +265,7 @@
     </a>
   </div>
 
-  <p style="margin-top: 1.5rem;"><a href="{{ "blog/index.html" | relURL }}" style="font-family:var(--mono);font-size:0.85rem;" data-tinylytics-event="blog.all_posts">All posts &rarr;</a></p>
+  <p style="margin-top: 1.5rem;"><a href="{{ "blog.html" | relURL }}" style="font-family:var(--mono);font-size:0.85rem;" data-tinylytics-event="blog.all_posts">All posts &rarr;</a></p>
 </div>
 </section>
 {{ end }}

--- a/site/layouts/index.sitemapmd.md
+++ b/site/layouts/index.sitemapmd.md
@@ -1,0 +1,18 @@
+# Dippin sitemap
+
+A flat index of every page on this site, grouped for agent consumption. The canonical machine-readable sitemap is [sitemap.xml]({{ "sitemap.xml" | absURL }}); this `.md` mirror exists for LLM clients that prefer Markdown.
+
+## Documentation
+{{ range where .Site.RegularPages "Section" "" }}{{ if ne .File.LogicalName "_index.md" }}
+- [{{ .Title }}]({{ .Permalink }}) — {{ .Description }}{{ end }}{{ end }}
+
+## Blog
+{{ range where .Site.RegularPages "Section" "blog" }}
+- [{{ .Title }}]({{ .Permalink }}) — {{ .Description }}{{ end }}
+
+## Agent skills
+
+- [Claude Code skill]({{ "skill.md" | absURL }}) — instructions for Claude Code agents working with `.dip` files.
+- [AGENTS.md]({{ "AGENTS.md" | absURL }}) — install / configure / use the toolchain.
+- [llms.txt]({{ "llms.txt" | absURL }}) — short LLM-oriented index.
+- [llms-full.txt]({{ "llms-full.txt" | absURL }}) — full spec for deeper context.

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -5,6 +5,7 @@
     <div class="footer-links">
       <a href="https://github.com/2389-research/dippin-lang" data-tinylytics-event="footer.github">GitHub</a>
       <a href="https://github.com/2389-research/dippin-lang/tree/main/docs" data-tinylytics-event="footer.docs">Docs</a>
+      <a href="{{ "glossary.html" | relURL }}" data-tinylytics-event="footer.glossary">Glossary</a>
       <a href="{{ "changelog.html" | relURL }}" data-tinylytics-event="footer.changelog">Changelog</a>
     </div>
   </div>

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -21,6 +21,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,500;0,9..144,700;1,9..144,400&family=IBM+Plex+Mono:wght@400;500;600&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="{{ "style.css" | relURL }}">
 {{- if .IsHome }}
+{{- $siteLastmod := .Site.Lastmod.Format "2006-01-02" -}}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -31,6 +32,7 @@
       "name": "Dippin",
       "url": "{{ .Site.BaseURL }}",
       "description": "{{ .Site.Params.description }}",
+      "dateModified": "{{ $siteLastmod }}",
       "publisher": { "@id": "{{ .Site.BaseURL }}#organization" }
     },
     {
@@ -45,11 +47,18 @@
       "description": "A domain-specific language and toolchain for authoring AI pipeline workflows. Replaces Graphviz DOT with first-class syntax for prompts, tools, conditions, and parallel execution.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
+      "dateModified": "{{ $siteLastmod }}",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "license": "https://opensource.org/licenses/MIT",
       "codeRepository": "https://github.com/2389-research/dippin-lang",
       "programmingLanguage": "Go",
       "author": { "@id": "{{ .Site.BaseURL }}#organization" }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "{{ .Site.BaseURL }}" }
+      ]
     }
   ]
 }
@@ -66,6 +75,18 @@
   "author": { "@id": "{{ .Site.BaseURL }}#organization" },
   "publisher": { "@id": "{{ .Site.BaseURL }}#organization" },
   "mainEntityOfPage": "{{ .Permalink }}"
+}
+</script>
+{{- else }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "{{ .Title }}",
+  "description": "{{ $desc }}",
+  "url": "{{ .Permalink }}",
+  "dateModified": "{{ .Lastmod.Format "2006-01-02" }}",
+  "publisher": { "@id": "{{ .Site.BaseURL }}#organization" }
 }
 </script>
 {{- end }}


### PR DESCRIPTION
## Summary

Improvements to make dippin.org more readable to AI coding agents, based on the [a14y v0.2.0 scorecard](https://a14y.dev/) audit run today.

- Fix broken `/blog/index.html` link on home page (resolves 8 derivative checks)
- Add `language-*` class to fenced code blocks via render-codeblock hook
- Promote playground titles to `h1`/`h2` for proper heading hierarchy
- Add `WebPage` / `SoftwareApplication` / `BreadcrumbList` JSON-LD with `dateModified`
- Add Glossary page + footer link (resolves 53 page failures)
- Publish `AGENTS.md` at repo root, mirror to `site/static/` via Netlify build
- Enable `enableGitInfo` for sitemap `lastmod` (9 entries gained timestamps)
- Add `sitemap.md` output format for LLM clients preferring Markdown
- Pin blog section URL to `/blog.html` (frontmatter `url:`) to survive Hugo version drift between local 0.161.1 and Netlify 0.147.5

## Skipped intentionally

- Markdown content negotiation (`Accept: text/markdown` → `.md` mirror) — blocked by Netlify edge constraints
- `lang=` attributes on every inline `<code>` — would inflate doc churn for no agent-readability gain
- Restructuring primary nav — current nav is fine

## Test plan
- [x] Local Hugo build clean (31 pages, no warnings)
- [x] `/blog.html` generated and reachable
- [x] Fenced code blocks emit `<code class="language-dippin">`
- [x] Home page JSON-LD validates (WebSite + Organization + SoftwareApplication + BreadcrumbList all with `dateModified`)
- [x] Doc pages emit `WebPage` JSON-LD with `dateModified` + `BreadcrumbList`
- [x] Glossary footer link renders
- [x] `sitemap.xml` `lastmod` populated for 24/26 URLs
- [x] `sitemap.md` lists Documentation / Blog / Agent skills
- [x] AGENTS.md served at `/AGENTS.md` with `Content-Type: text/markdown`
- [x] Pre-commit hooks pass (no Go code touched)
- [ ] Netlify deploy preview clean
- [ ] Re-run a14y on Netlify deploy preview → target score improves from 72 baseline

## Pre-merge

Once the Netlify deploy preview is up, I'll re-run `a14y check` against it and post the delta in a comment before merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Glossary documentation covering workflows, CLI commands, and toolchain components.
  * Published AGENTS.md guide for toolchain installation and editor/agent integration options.
  * Added machine-readable markdown sitemap for AI agents and LLM consumption.
  * Improved playground interface with clearer pane labels for better usability.

* **Improvements**
  * Enhanced code block rendering with syntax highlighting support.
  * Added Glossary link to site footer for easier navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->