### PR TITLE
feat(tool): add marker_grep / route_required / output_limit to tool nodes (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Tool-node routing fields land in the parser and IR. Authors following tracker's 
 
 - `tool.marker_grep` — regex matched line-by-line against captured stdout; populates `ctx.tool_marker` at runtime.
 - `tool.route_required` — boolean; when true, the node fails with `EventToolRouteMissing` if the command emits no `_TRACKER_ROUTE=<value>` sentinel line.
-- `tool.output_limit` — positive integer (bytes) overriding the engine default stdout tail-window for this node.
+- `tool.output_limit` — non-negative integer (bytes); 0 uses the engine default stdout tail-window. `dippin fmt` omits the field when the value is zero.
 - Reserved context variables: `ctx.tool_marker`, `ctx.tool_route`.
 
 ### Changed
@@ -23,7 +23,7 @@ These fields pass through DOT export to tracker. Routing semantics require track
 
 ### Docs
 
-- New blog post: ["What's New in Dippin v0.28"](blog/whats-new-v028.md).
+- New blog post: [`site/content/blog/whats-new-v028.md`](site/content/blog/whats-new-v028.md).
 - `docs/nodes.md` gains a "Best" subsection in Markers and Verbose Output demonstrating `marker_grep`.
 - Hosted skill (`site/static/skill.md`) updated with new context variables and best-practice bullet.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.28.0] — 2026-05-19
+
+Tool-node routing fields land in the parser and IR. Authors following tracker's `TRK101` recommendation can now declare `marker_grep`, `route_required`, and `output_limit` directly in `.dip` source. Closes [#39](https://github.com/2389-research/dippin-lang/issues/39).
+
+### Added
+
+- `tool.marker_grep` — regex matched line-by-line against captured stdout; populates `ctx.tool_marker` at runtime.
+- `tool.route_required` — boolean; when true, the node fails with `EventToolRouteMissing` if the command emits no `_TRACKER_ROUTE=<value>` sentinel line.
+- `tool.output_limit` — positive integer (bytes) overriding the engine default stdout tail-window for this node.
+- Reserved context variables: `ctx.tool_marker`, `ctx.tool_route`.
+
+### Changed
+
+- `migrate/parity.go compareToolConfigs` now compares all `ToolConfig` fields. Pre-existing `Timeout` / `Outputs` parity gaps backfilled.
+
+### Runtime requirement
+
+These fields pass through DOT export to tracker. Routing semantics require tracker to ship the matching `extractToolAttrs` change; see issue [#39](https://github.com/2389-research/dippin-lang/issues/39) for details.
+
+### Docs
+
+- New blog post: ["What's New in Dippin v0.28"](blog/whats-new-v028.md).
+- `docs/nodes.md` gains a "Best" subsection in Markers and Verbose Output demonstrating `marker_grep`.
+- Hosted skill (`site/static/skill.md`) updated with new context variables and best-practice bullet.
+
 ## [v0.27.0] — 2026-05-18
 
 Model catalog and pricing verification pass against canonical provider docs. `Last verified: 2026-05-18` in `validator/lint_model.go` and `cost/pricing.go`. No breaking changes to public APIs — but the cost table values move and the catalog accepts new IDs, so downstream tooling that snapshots dippin's data should re-snapshot.

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -292,6 +292,9 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `command` | multiline | Shell command. Supports pipes, here-docs, case/esac. |
 | `timeout` | duration | **Required** (DIP111). e.g. `30s`, `5m` |
 | `outputs` | CSV | Possible stdout values for condition checks |
+| `marker_grep` | string | Regex matched against stdout; sets `ctx.tool_marker`. Tracker validates at runtime. |
+| `route_required` | bool | When true, fails the node if no `_TRACKER_ROUTE=<value>` sentinel line is emitted. |
+| `output_limit` | int | Per-node stdout byte cap (positive integer); omit to use engine default. |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -584,6 +587,7 @@ The primary loop for authoring .dip files:
 ## Best Practices
 
 - **Always set `timeout`** on tool nodes — no timeout means infinite hang
+- **Prefer `marker_grep:`** over regexing `ctx.tool_stdout` in edges when the runtime supports it. Typed routing leaves stdout free for diagnostic output and avoids truncation foot-guns.
 - **Use `auto_status: true`** on agent nodes that drive conditional routing via `ctx.outcome`
 - **Use `success`/`fail`** as condition values — the linter recognizes these as exhaustive
 - **Mark back-edges `restart: true`** — loops without it trigger DIP005
@@ -637,6 +641,8 @@ The primary loop for authoring .dip files:
 | `ctx.outcome` | `auto_status: true` on agent, or tool exit status |
 | `ctx.human_response` | Freeform human input |
 | `ctx.tool_stdout` | Tool command stdout |
+| `ctx.tool_marker` | Tool stdout regex match (when `marker_grep` declared) |
+| `ctx.tool_route` | `_TRACKER_ROUTE=<value>` sentinel (when `route_required: true`) |
 | `ctx.preferred_label` | Human choice selection (maps to edge label) |
 | `ctx.interview_answers` | Interview mode answers (via `answers_key`) |
 | `params.<key>` | Parent subgraph params |

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -294,7 +294,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `outputs` | CSV | Possible stdout values for condition checks |
 | `marker_grep` | string | Regex matched against stdout; sets `ctx.tool_marker`. Tracker validates at runtime. |
 | `route_required` | bool | When true, fails the node if no `_TRACKER_ROUTE=<value>` sentinel line is emitted. |
-| `output_limit` | int | Per-node stdout byte cap (positive integer); omit to use engine default. |
+| `output_limit` | int | Per-node stdout byte cap (non-negative integer); 0 (or omitted) uses the engine default. |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -49,7 +49,7 @@ workflow <Name>
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
 | `human` | `mode` (freeform\|choice\|interview) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
-| `tool` | `command` | `timeout` (e.g. 30s, 5m) |
+| `tool` | `command` | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
 | `subgraph` | `ref` | `params` |
@@ -85,6 +85,7 @@ when not <expr>
 | 6 | Missing tool timeout | Add `timeout: 60s` (or appropriate duration) to every `tool` node. |
 | 7 | Exhaustive conditions flagged | `ctx.outcome = success` + `ctx.outcome = fail` is exhaustive — DIP101/DIP102 are auto-suppressed. No need to add a fallback edge. |
 | 8 | Verbose output sharing stdout with routing marker | When a tool's stdout drives routing, redirect verbose output to a sibling file and `printf` only the marker. Otherwise large output (test logs, stack traces) can crowd out the marker under runtime stdout caps. See `nodes.md` → Tool Nodes → Markers and Verbose Output. |
+| 9 | Hand-parsing tool stdout for routing | Use `marker_grep: "<regex>"` (and optionally `route_required: true`) instead of regexing `ctx.tool_stdout` in edge conditions. Mirrors tracker's TRK101 recommendation; populates `ctx.tool_marker` directly. |
 
 ---
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -195,7 +195,7 @@ The validator treats variables differently based on what it can verify at parse 
 
 | Tier | Variables | Validation |
 |------|-----------|------------|
-| **Always known** | `ctx.outcome`, `ctx.last_response`, `ctx.human_response`, `ctx.tool_stdout`, `ctx.tool_stderr`, `graph.goal` | Error if misspelled |
+| **Always known** | `ctx.outcome`, `ctx.last_response`, `ctx.human_response`, `ctx.tool_stdout`, `ctx.tool_stderr`, `ctx.tool_marker`, `ctx.tool_route`, `graph.goal` | Error if misspelled (`ctx.tool_marker` / `ctx.tool_route` only populated at runtime when `marker_grep` / `route_required: true` are declared on the source tool) |
 | **Declared outputs** | Keys from upstream `writes` declarations | Warning if referenced but not declared (DIP112) |
 | **Dynamic** | Everything else | Warning only — never an error (runtime context is open) |
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -42,6 +42,8 @@ The primary namespace. Contains handler outputs and reserved keys.
 | `ctx.human_response` | Human nodes | The human's input text |
 | `ctx.tool_stdout` | Tool nodes | Standard output from the shell command |
 | `ctx.tool_stderr` | Tool nodes | Standard error from the shell command |
+| `ctx.tool_marker` | Tool nodes | Tool stdout regex match (when `marker_grep` is declared on the source tool node) |
+| `ctx.tool_route` | Tool nodes | Tool stdout `_TRACKER_ROUTE=<value>` sentinel (when `route_required: true`) |
 
 These reserved keys are **always available** — the validator knows about them at parse time and can flag typos.
 

--- a/docs/edges.md
+++ b/docs/edges.md
@@ -182,6 +182,8 @@ Common variables used in conditions:
 | `ctx.outcome` | Agent (auto_status), engine | `"success"`, `"fail"`, `"retry"` |
 | `ctx.tool_stdout` | Tool nodes | Command's stdout output |
 | `ctx.tool_stderr` | Tool nodes | Command's stderr output |
+| `ctx.tool_marker` | Tool nodes | Tool stdout regex match (when `marker_grep` is declared on the source tool node) |
+| `ctx.tool_route` | Tool nodes | Tool stdout `_TRACKER_ROUTE=<value>` sentinel (when `route_required: true`) |
 | `ctx.human_response` | Human nodes | User's text input |
 | `ctx.last_response` | Agent nodes | LLM's response text |
 | `graph.goal` | Workflow header | The workflow's goal string |

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -47,7 +47,7 @@ workflow <Name>
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
 | `human` | `mode` (freeform\|choice\|interview) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
-| `tool` | `command` | `timeout` (e.g. 30s, 5m) |
+| `tool` | `command` | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
 | `subgraph` | `ref` | `params` |
@@ -83,6 +83,7 @@ when not <expr>
 | 6 | Missing tool timeout | Add `timeout: 60s` (or appropriate duration) to every `tool` node. |
 | 7 | Exhaustive conditions flagged | `ctx.outcome = success` + `ctx.outcome = fail` is exhaustive — DIP101/DIP102 are auto-suppressed. No need to add a fallback edge. |
 | 8 | Verbose output sharing stdout with routing marker | When a tool's stdout drives routing, redirect verbose output to a sibling file and `printf` only the marker. Otherwise large output (test logs, stack traces) can crowd out the marker under runtime stdout caps. See `nodes.md` → Tool Nodes → Markers and Verbose Output. |
+| 9 | Hand-parsing tool stdout for routing | Use `marker_grep: "<regex>"` (and optionally `route_required: true`) instead of regexing `ctx.tool_stdout` in edge conditions. Mirrors tracker's TRK101 recommendation; populates `ctx.tool_marker` directly. |
 
 ---
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -263,6 +263,9 @@ Tool nodes execute shell commands and capture their output.
 | `command` | Multiline | — | Shell command(s) to execute. Supports full shell syntax including pipes, conditionals, and multi-line scripts. The command's stdout is captured as `ctx.tool_stdout` and stderr as `ctx.tool_stderr`. |
 | `timeout` | Duration | — | Maximum execution time (e.g., `"30s"`, `"2m"`, `"1m30s"`). If the command exceeds this duration, it is killed. **Recommended** — the linter warns (DIP111) if omitted. |
 | `outputs` | CSV | — | Declared possible stdout values (comma-separated). Used by `dippin coverage` to check whether outgoing edge conditions cover all tool outputs. Advisory — not enforced at runtime. |
+| `marker_grep` | String | — | Regex matched line-by-line against captured stdout. The last match populates `ctx.tool_marker`. Tracker validates and applies the regex at runtime. |
+| `route_required` | Boolean | false | When true, the node fails if the command's stdout contains no `_TRACKER_ROUTE=<value>` sentinel line. The matched value populates `ctx.tool_route`. |
+| `output_limit` | Integer | — | Per-node override for the engine's captured-stdout byte cap. Positive integer; omit (or set 0) to use the engine default. |
 
 ### Command Output
 
@@ -308,6 +311,19 @@ else printf 'tests-fail'; fi
 ```
 
 The same pattern applies to any tool whose output drives routing — build commands, linters, type checkers, custom validators.
+
+**Best (when the runtime supports typed markers):** declare `marker_grep` and let the runtime parse the routing signal directly, freeing stdout for diagnostic output:
+
+```dippin
+  tool RunTests
+    marker_grep: "^(tests_pass|tests_fail)$"
+    timeout: 60s
+    command:
+      pytest 2>&1
+      [ $? -eq 0 ] && printf 'tests_pass\n' || printf 'tests_fail\n'
+```
+
+When `marker_grep` is declared, the runtime populates `ctx.tool_marker` and routing edges can reference it instead of `ctx.tool_stdout`. `route_required: true` makes the absence of any match a hard failure. `output_limit` overrides the per-node stdout cap when the command genuinely needs a larger window.
 
 ---
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -265,7 +265,7 @@ Tool nodes execute shell commands and capture their output.
 | `outputs` | CSV | — | Declared possible stdout values (comma-separated). Used by `dippin coverage` to check whether outgoing edge conditions cover all tool outputs. Advisory — not enforced at runtime. |
 | `marker_grep` | String | — | Regex matched line-by-line against captured stdout. The last match populates `ctx.tool_marker`. Tracker validates and applies the regex at runtime. |
 | `route_required` | Boolean | false | When true, the node fails if the command's stdout contains no `_TRACKER_ROUTE=<value>` sentinel line. The matched value populates `ctx.tool_route`. |
-| `output_limit` | Integer | — | Per-node override for the engine's captured-stdout byte cap. Positive integer; omit (or set 0) to use the engine default. |
+| `output_limit` | Integer | — | Per-node override for the engine's captured-stdout byte cap. Non-negative integer; 0 (or omitted) uses the engine default. `dippin fmt` omits the field when the value is zero. |
 
 ### Command Output
 

--- a/docs/superpowers/plans/2026-05-19-issue-39-tool-routing-fields.md
+++ b/docs/superpowers/plans/2026-05-19-issue-39-tool-routing-fields.md
@@ -1,0 +1,1632 @@
+# Tool Routing Fields (issue #39) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `marker_grep`, `route_required`, `output_limit` to `tool` nodes so authors following tracker's TRK101 advice stop hitting `unrecognized tool field` parse errors. Strings pass through verbatim to tracker via DOT.
+
+**Architecture:** Extend `ir.ToolConfig` with three exported fields. Mirror the existing `apply{Agent,Human}{String,Bool,Parsed}Field` split in the tool parser to stay under the cyclomatic-5 budget. Formatter and DOT exporter use the same "emit when non-default" contract so `.dip ⇄ DOT` round-trips are idempotent. Migrate reads attrs back. Tests, docs, hosted skill, blog, CHANGELOG. Single PR; tag v0.28.0; tracker bumps the dep separately.
+
+**Tech Stack:** Go 1.25, `just` task runner, no new deps. Hugo for site. Tree-sitter / Zed unaffected (generic `field_name` rule already).
+
+**Spec:** [`docs/superpowers/specs/2026-05-19-issue-39-tool-routing-fields-design.md`](../specs/2026-05-19-issue-39-tool-routing-fields-design.md)
+
+---
+
+## Prerequisite reading for the implementing engineer
+
+Skim these before starting — they establish the patterns this plan mirrors:
+
+- `ir/ir.go:127-134` — current `ToolConfig` shape and adjacent configs.
+- `parser/parse_nodes.go:406-417` — current `applyToolField` (4 cases, at the cyclo-5 budget).
+- `parser/parse_nodes.go:232-343` — `applyAgentField` family — the split pattern this plan copies for tool.
+- `parser/parse_nodes.go:346-403` — `applyHumanField` family — secondary reference for the split pattern.
+- `parser/parse_helpers.go:45-67` — `parseInt`, `parseDuration` (existing helpers; no new ones needed).
+- `formatter/format.go:488-500` — current `writeToolFields`.
+- `export/dot.go:303-315` — `applyToolSemanticAttrs` / `applyToolPromptAttrs`.
+- `migrate/migrate.go:467-509` — `buildHumanConfig` / `buildToolConfig` (human config is the split pattern reference).
+- `migrate/parity.go:257-266` — current `compareToolConfigs` (only compares `Command`).
+- `lsp/completion.go:42-65` — `fieldCompletions` shape.
+- `lsp/hover.go:77-106` — `formatNodeConfig`, `formatAgentHover` (the multi-line helper this plan copies for tool).
+- `CLAUDE.md` — complexity budgets, "Test fixtures should match real parser output" (test design).
+- `docs/superpowers/plans/2026-04-22-dip28-tool-safety-defaults.md` — closest past plan; same shape of work, smaller scope.
+
+**CLAUDE.md non-negotiables:**
+- Cyclomatic complexity ≤ 5 per function, cognitive complexity ≤ 7. Extract helpers; don't `//nolint`.
+- Never run raw `go test`; always use `just <recipe>`.
+- Parser tests parse real `.dip` text. Never hand-construct `ir.ToolConfig{...}` to assert field values.
+- After changes, `just check` must pass (build, vet, fmt, test-race, releasecheck, complexity, validate-examples, pack-examples, tree-sitter-test).
+
+---
+
+## Design decisions (locked in; don't re-litigate)
+
+| Decision | Value | Why |
+|---|---|---|
+| Field names | `marker_grep`, `route_required`, `output_limit` | Match tracker attr keys verbatim — tracker reads `n.Attrs["marker_grep"]` etc. |
+| Bool parsing | Strict `val == "true"` | Matches existing `goal_gate`/`auto_status`/`cache_tools`; #43 normalizes later. |
+| `output_limit` units | Raw bytes (int) | Spec defers SI suffixes to a future issue. |
+| Zero/empty handling | Parse stores; formatter / DOT omit when default | Matches existing convention. Authors writing `output_limit: 0` see it disappear on `dippin fmt`; documented in `docs/nodes.md`. |
+| Regex validation | None at parse time | Pass-through — tracker owns runtime semantics (DIP28 precedent). |
+| Field ordering in formatter | `outputs → marker_grep → route_required → output_limit → timeout → reads → writes → command` | Routing-shape fields cluster, then execution, then IO, then command. |
+| Migrate parity | Extend to all `ToolConfig` fields | Backfills pre-existing `Timeout`/`Outputs` gap while in the area. |
+| Tracker repo | Out of scope | Separate follow-up PR pins `dippin-lang@v0.28.0` and updates `extractToolAttrs`. |
+
+---
+
+## File map
+
+**Modify:**
+- `ir/ir.go` (Task 1)
+- `parser/parse_nodes.go` (Tasks 2–5)
+- `parser/testdata/all_features.dip` (Task 6)
+- `formatter/format.go` (Task 7)
+- `export/dot.go` (Task 8)
+- `migrate/migrate.go` (Task 9)
+- `migrate/parity.go` (Task 10)
+- `lsp/completion.go` (Task 11)
+- `lsp/hover.go` (Task 12)
+- `editors/vscode/syntaxes/dippin.tmLanguage.json` (Task 13)
+- `docs/nodes.md`, `docs/llm-reference.md`, `docs/context.md`, `docs/edges.md`, `docs/validation.md` (Tasks 15–16)
+- `site/static/skill.md`, `site/content/language.md` (Task 17)
+- `CHANGELOG.md` (Task 19)
+
+**Create:**
+- `parser/parse_tool_test.go` (new — keeps tool-specific tests separate; Tasks 3–5)
+- `examples/marker_routing.dip` (Task 14)
+- `site/content/blog/whats-new-v028.md` (Task 18)
+
+---
+
+## Task 1: IR — extend `ToolConfig`
+
+**Files:**
+- Modify: `ir/ir.go:127-134`
+
+- [ ] **Step 1: Extend ToolConfig**
+
+```go
+// ToolConfig holds configuration for shell command nodes.
+type ToolConfig struct {
+	Command       string // Shell command (multiline OK)
+	Timeout       time.Duration
+	Outputs       []string // Declared possible stdout values for coverage analysis
+	MarkerGrep    string   // Regex matched line-by-line against stdout; populates ctx.tool_marker
+	RouteRequired bool     // True → node fails if no _TRACKER_ROUTE= sentinel is emitted
+	OutputLimit   int      // Bytes; > 0 = override engine default
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `just build`
+Expected: clean build, no errors.
+
+- [ ] **Step 3: Run full test suite (sanity)**
+
+Run: `just test`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ir/ir.go
+git commit -m "ir: add MarkerGrep/RouteRequired/OutputLimit to ToolConfig
+
+Wires three new exported fields onto tool-node config to support
+tracker's stdout-routing primitives. Parser/formatter/DOT updates
+land in follow-on commits.
+
+Refs #39"
+```
+
+---
+
+## Task 2: Parser — split `applyToolField` into string/bool/parsed helpers
+
+This refactor is required *before* adding cases — current `applyToolField` is at cyclomatic 5; the pre-commit hook will fail otherwise. Pure refactor: behavior unchanged.
+
+**Files:**
+- Modify: `parser/parse_nodes.go:405-417`
+
+- [ ] **Step 1: Run existing parser tests to establish baseline**
+
+Run: `just test-pkg parser`
+Expected: all pass (will re-run after refactor; output count should be identical).
+
+- [ ] **Step 2: Replace `applyToolField` with split helpers**
+
+Replace lines 405-417 with:
+
+```go
+// applyToolField applies tool-specific configuration fields.
+func (p *Parser) applyToolField(cfg *ir.ToolConfig, key, val string, loc ir.SourceLocation) {
+	if applyToolStringField(cfg, key, val) {
+		return
+	}
+	if applyToolBoolField(cfg, key, val) {
+		return
+	}
+	if p.applyToolParsedField(cfg, key, val, loc) {
+		return
+	}
+	p.emitUnknownFieldHint("tool", key, loc)
+}
+
+// applyToolStringField handles string-valued tool fields. Returns true if handled.
+func applyToolStringField(cfg *ir.ToolConfig, key, val string) bool {
+	switch key {
+	case "command":
+		cfg.Command = val
+	case "outputs":
+		cfg.Outputs = splitComma(val)
+	default:
+		return false
+	}
+	return true
+}
+
+// applyToolBoolField handles boolean tool fields. Returns true if handled.
+func applyToolBoolField(cfg *ir.ToolConfig, key, val string) bool {
+	switch key {
+	default:
+		_ = val // no bool fields yet; route_required lands in a follow-on task
+		return false
+	}
+}
+
+// applyToolParsedField handles tool fields needing parsing. Returns true if handled.
+func (p *Parser) applyToolParsedField(cfg *ir.ToolConfig, key, val string, loc ir.SourceLocation) bool {
+	switch key {
+	case "timeout":
+		cfg.Timeout = p.parseDuration(val, key, loc)
+	default:
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 3: Run parser tests (must still pass — refactor is behavior-preserving)**
+
+Run: `just test-pkg parser`
+Expected: all pass, same count as Step 1.
+
+- [ ] **Step 4: Run complexity check**
+
+Run: `just complexity`
+Expected: pass (each new helper has cyclo ≤ 2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add parser/parse_nodes.go
+git commit -m "parser: split applyToolField into string/bool/parsed helpers
+
+Mirrors the existing applyAgent{String,Bool,Parsed}Field shape.
+Behavior unchanged; this prepares the function for the three new
+routing fields without breaching the cyclomatic-5 budget.
+
+Refs #39"
+```
+
+---
+
+## Task 3: Parser — `marker_grep`
+
+**Files:**
+- Modify: `parser/parse_nodes.go` (`applyToolStringField`)
+- Create: `parser/parse_tool_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `parser/parse_tool_test.go`:
+
+```go
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// parseToolFixture parses a minimal workflow with a single tool node and returns
+// the parsed ToolConfig plus any diagnostics. Tests must parse real .dip text —
+// hand-building ir.ToolConfig bypasses the parser and masks bugs (per CLAUDE.md).
+func parseToolFixture(t *testing.T, body string) (ir.ToolConfig, []string) {
+	t.Helper()
+	src := "workflow W\n  goal: \"x\"\n  start: T\n  exit: T\n\n  tool T\n" + body + "\n\n  edges\n"
+	p := NewParser(src, "test.dip")
+	wf, _ := p.Parse()
+	if len(wf.Nodes) == 0 {
+		t.Fatalf("no nodes parsed; diagnostics: %v", p.Diagnostics())
+	}
+	cfg, ok := wf.Nodes[0].Config.(ir.ToolConfig)
+	if !ok {
+		t.Fatalf("node 0 is not a tool: %T", wf.Nodes[0].Config)
+	}
+	return cfg, p.Diagnostics()
+}
+
+func TestParseToolMarkerGrep(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    marker_grep: '^(green|red)$'")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.MarkerGrep != "^(green|red)$" {
+		t.Errorf("MarkerGrep = %q, want %q", cfg.MarkerGrep, "^(green|red)$")
+	}
+}
+```
+
+- [ ] **Step 2: Run test (must fail with unrecognized field)**
+
+Run: `just test-pkg parser`
+Expected: FAIL — diagnostic "unrecognized tool field \"marker_grep\""
+
+- [ ] **Step 3: Add marker_grep to `applyToolStringField`**
+
+In `parser/parse_nodes.go`, extend `applyToolStringField`:
+
+```go
+func applyToolStringField(cfg *ir.ToolConfig, key, val string) bool {
+	switch key {
+	case "command":
+		cfg.Command = val
+	case "outputs":
+		cfg.Outputs = splitComma(val)
+	case "marker_grep":
+		cfg.MarkerGrep = val
+	default:
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run test (must pass)**
+
+Run: `just test-pkg parser`
+Expected: PASS.
+
+- [ ] **Step 5: Add tests for unquoted, empty, and regex special chars**
+
+Append to `parser/parse_tool_test.go`:
+
+```go
+func TestParseToolMarkerGrepUnquoted(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    marker_grep: tests_pass")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.MarkerGrep != "tests_pass" {
+		t.Errorf("MarkerGrep = %q, want %q", cfg.MarkerGrep, "tests_pass")
+	}
+}
+
+func TestParseToolMarkerGrepRegexMetachars(t *testing.T) {
+	// Stored verbatim — dippin does not validate the regex (tracker does).
+	cfg, diags := parseToolFixture(t, `    marker_grep: '^\[(PASS|FAIL)\]\s+\d+$'`)
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !strings.Contains(cfg.MarkerGrep, `\[`) {
+		t.Errorf("MarkerGrep lost metachars: %q", cfg.MarkerGrep)
+	}
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `just test-pkg parser`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add parser/parse_nodes.go parser/parse_tool_test.go
+git commit -m "parser: accept marker_grep on tool nodes
+
+Stores the regex string verbatim; tracker validates and applies it
+at runtime. Tests cover quoted/unquoted forms and regex metachars.
+
+Refs #39"
+```
+
+---
+
+## Task 4: Parser — `route_required`
+
+**Files:**
+- Modify: `parser/parse_nodes.go` (`applyToolBoolField`)
+- Modify: `parser/parse_tool_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `parser/parse_tool_test.go`:
+
+```go
+func TestParseToolRouteRequired(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    route_required: true")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !cfg.RouteRequired {
+		t.Error("RouteRequired = false, want true")
+	}
+}
+
+func TestParseToolRouteRequiredExplicitFalse(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    route_required: false")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.RouteRequired {
+		t.Error("RouteRequired = true, want false")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests (must fail)**
+
+Run: `just test-pkg parser`
+Expected: FAIL — unrecognized field.
+
+- [ ] **Step 3: Add route_required to `applyToolBoolField`**
+
+In `parser/parse_nodes.go`:
+
+```go
+func applyToolBoolField(cfg *ir.ToolConfig, key, val string) bool {
+	switch key {
+	case "route_required":
+		cfg.RouteRequired = (val == "true")
+	default:
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `just test-pkg parser`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add parser/parse_nodes.go parser/parse_tool_test.go
+git commit -m "parser: accept route_required on tool nodes
+
+Strict bool parsing matches existing goal_gate/auto_status/cache_tools
+convention (#43 will normalize all four together later).
+
+Refs #39"
+```
+
+---
+
+## Task 5: Parser — `output_limit`
+
+**Files:**
+- Modify: `parser/parse_nodes.go` (`applyToolParsedField`)
+- Modify: `parser/parse_tool_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `parser/parse_tool_test.go`:
+
+```go
+func TestParseToolOutputLimit(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    output_limit: 1048576")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.OutputLimit != 1048576 {
+		t.Errorf("OutputLimit = %d, want 1048576", cfg.OutputLimit)
+	}
+}
+
+func TestParseToolOutputLimitNegative(t *testing.T) {
+	_, diags := parseToolFixture(t, "    output_limit: -1")
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostic for negative output_limit, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d, "output_limit") && strings.Contains(d, "non-negative") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'non-negative' diagnostic, got: %v", diags)
+	}
+}
+
+func TestParseToolOutputLimitNonNumeric(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    output_limit: abc")
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostic from parseInt, got none")
+	}
+	if cfg.OutputLimit != 0 {
+		t.Errorf("OutputLimit should default to 0 on parse error, got %d", cfg.OutputLimit)
+	}
+}
+
+func TestParseToolAllRoutingFields(t *testing.T) {
+	body := "    marker_grep: pass\n    route_required: true\n    output_limit: 65536"
+	cfg, diags := parseToolFixture(t, body)
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.MarkerGrep != "pass" || !cfg.RouteRequired || cfg.OutputLimit != 65536 {
+		t.Errorf("got %+v", cfg)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests (must fail)**
+
+Run: `just test-pkg parser`
+Expected: FAIL — unrecognized field.
+
+- [ ] **Step 3: Add output_limit to `applyToolParsedField`**
+
+In `parser/parse_nodes.go`:
+
+```go
+func (p *Parser) applyToolParsedField(cfg *ir.ToolConfig, key, val string, loc ir.SourceLocation) bool {
+	switch key {
+	case "timeout":
+		cfg.Timeout = p.parseDuration(val, key, loc)
+	case "output_limit":
+		n := p.parseInt(val, key, loc)
+		if n < 0 {
+			p.diagnostics = append(p.diagnostics, fmt.Sprintf(
+				"invalid output_limit %d at %d:%d (must be non-negative)", n, loc.Line, loc.Column))
+			return true
+		}
+		cfg.OutputLimit = n
+	default:
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `just test-pkg parser`
+Expected: PASS.
+
+- [ ] **Step 5: Run complexity check**
+
+Run: `just complexity`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add parser/parse_nodes.go parser/parse_tool_test.go
+git commit -m "parser: accept output_limit on tool nodes
+
+Non-negative integer (bytes); 0 is engine default. Negative emits
+a diagnostic. Combined-fields test confirms the three new fields
+parse together.
+
+Refs #39"
+```
+
+---
+
+## Task 6: Extend `all_features.dip` for round-trip coverage
+
+This drives the formatter round-trip test in the next task.
+
+**Files:**
+- Modify: `parser/testdata/all_features.dip`
+
+- [ ] **Step 1: Locate the tool node in the fixture**
+
+Run: `grep -n '^  tool ' parser/testdata/all_features.dip`
+Read the tool node's current shape.
+
+- [ ] **Step 2: Add the three new fields to one tool node**
+
+Edit the existing tool node block to include:
+
+```
+    marker_grep: '^(pass|fail)$'
+    route_required: true
+    output_limit: 65536
+```
+
+(Insert after `timeout:`, before `command:` per the canonical formatter order — Task 7 will reorder this naturally.)
+
+- [ ] **Step 3: Run round-trip test (will fail until formatter is updated in Task 7)**
+
+Run: `just test-pkg parser`
+Expected: any round-trip-style test currently using this fixture may fail; that's expected and resolved in Task 7. Do not commit yet.
+
+If no parser-side test uses this fixture for round-trip, just confirm parse succeeds with no diagnostics:
+
+Run: `just test-pkg parser`
+Expected: pass.
+
+- [ ] **Step 4: Do not commit yet** — Task 7 lands the formatter change in the same commit so the fixture stays consistent.
+
+---
+
+## Task 7: Formatter — emit new fields, fix ordering
+
+**Files:**
+- Modify: `formatter/format.go:488-500`
+
+- [ ] **Step 1: Write failing round-trip test (or use existing one if it covers all_features.dip)**
+
+Check: `grep -n 'all_features' formatter/format_test.go`
+If there's a round-trip test that loads `all_features.dip`, it will already fail after Task 6. Otherwise, add:
+
+```go
+func TestFormatToolRoutingFieldsRoundTrip(t *testing.T) {
+	src := `workflow W
+  goal: "x"
+  start: T
+  exit: T
+
+  tool T
+    outputs: pass, fail
+    marker_grep: '^(pass|fail)$'
+    route_required: true
+    output_limit: 65536
+    timeout: 30s
+    command:
+      echo pass
+
+  edges
+`
+	wf1, _ := parser.NewParser(src, "test.dip").Parse()
+	out := Format(wf1)
+	wf2, _ := parser.NewParser(out, "test.dip").Parse()
+	out2 := Format(wf2)
+	if out != out2 {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", out, out2)
+	}
+}
+```
+
+- [ ] **Step 2: Run test (must fail)**
+
+Run: `just test-pkg formatter`
+Expected: FAIL — fields not emitted.
+
+- [ ] **Step 3: Update `writeToolFields`**
+
+Replace:
+
+```go
+func writeToolFields(wr *writer, n *ir.Node, cfg ir.ToolConfig) {
+	writeCommonNodeFields(wr, n)
+	if len(cfg.Outputs) > 0 {
+		wr.line("outputs: %s", strings.Join(cfg.Outputs, ", "))
+	}
+	if cfg.MarkerGrep != "" {
+		wr.line("marker_grep: %s", quoteValue(cfg.MarkerGrep))
+	}
+	if cfg.RouteRequired {
+		wr.line("route_required: true")
+	}
+	if cfg.OutputLimit > 0 {
+		wr.line("output_limit: %d", cfg.OutputLimit)
+	}
+	if cfg.Timeout != 0 {
+		wr.line("timeout: %s", formatDuration(cfg.Timeout))
+	}
+	writeIOFields(wr, n)
+	if cfg.Command != "" {
+		wr.multilineBlock("command", cfg.Command)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `just test-pkg formatter`
+Expected: PASS.
+
+- [ ] **Step 5: Run complexity check**
+
+Run: `just complexity`
+Expected: pass (`writeToolFields` is now ~cyclo 7-ish; if it fails, extract a `writeToolRoutingFields` helper).
+
+If complexity fails, extract:
+
+```go
+func writeToolRoutingFields(wr *writer, cfg ir.ToolConfig) {
+	if cfg.MarkerGrep != "" {
+		wr.line("marker_grep: %s", quoteValue(cfg.MarkerGrep))
+	}
+	if cfg.RouteRequired {
+		wr.line("route_required: true")
+	}
+	if cfg.OutputLimit > 0 {
+		wr.line("output_limit: %d", cfg.OutputLimit)
+	}
+}
+```
+
+Then call it from `writeToolFields` after the `outputs:` line.
+
+- [ ] **Step 6: Run full test suite (including parser tests that depend on all_features.dip)**
+
+Run: `just test`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add formatter/format.go formatter/format_test.go parser/testdata/all_features.dip
+git commit -m "formatter: emit marker_grep/route_required/output_limit
+
+Emits fields when non-default in canonical order: outputs →
+marker_grep → route_required → output_limit → timeout → reads →
+writes → command. Zero/empty/false omitted; round-trip stable.
+all_features.dip fixture extended to drive idempotency check.
+
+Refs #39"
+```
+
+---
+
+## Task 8: DOT export — emit semantic attrs
+
+**Files:**
+- Modify: `export/dot.go:303-308`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `export/dot_test.go`:
+
+```go
+func TestExportDOTToolRoutingFields(t *testing.T) {
+	src := `workflow W
+  goal: "x"
+  start: T
+  exit: T
+
+  tool T
+    marker_grep: '^pass$'
+    route_required: true
+    output_limit: 8192
+    timeout: 30s
+    command:
+      echo pass
+
+  edges
+`
+	wf, _ := parser.NewParser(src, "test.dip").Parse()
+	out, err := ExportDOT(wf, ExportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`marker_grep="^pass$"`,
+		`route_required="true"`,
+		`output_limit="8192"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("DOT output missing %q. Full output:\n%s", want, out)
+		}
+	}
+}
+
+func TestExportDOTToolRoutingOmitWhenZero(t *testing.T) {
+	src := `workflow W
+  goal: "x"
+  start: T
+  exit: T
+
+  tool T
+    timeout: 30s
+    command:
+      echo pass
+
+  edges
+`
+	wf, _ := parser.NewParser(src, "test.dip").Parse()
+	out, _ := ExportDOT(wf, ExportOptions{})
+	for _, unwanted := range []string{"marker_grep", "route_required", "output_limit"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("DOT output unexpectedly contains %q. Full output:\n%s", unwanted, out)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests (must fail)**
+
+Run: `just test-pkg export`
+Expected: FAIL.
+
+- [ ] **Step 3: Update `applyToolSemanticAttrs`**
+
+Replace lines 303-308:
+
+```go
+// applyToolSemanticAttrs adds tool runtime attrs (always exported).
+func applyToolSemanticAttrs(attrs map[string]string, cfg ir.ToolConfig) {
+	if cfg.Timeout != 0 {
+		attrs["timeout"] = formatDuration(cfg.Timeout)
+	}
+	if cfg.MarkerGrep != "" {
+		attrs["marker_grep"] = cfg.MarkerGrep
+	}
+	if cfg.RouteRequired {
+		attrs["route_required"] = "true"
+	}
+	if cfg.OutputLimit > 0 {
+		attrs["output_limit"] = strconv.Itoa(cfg.OutputLimit)
+	}
+}
+```
+
+Add `"strconv"` to imports if not already present.
+
+- [ ] **Step 4: Run tests**
+
+Run: `just test-pkg export`
+Expected: PASS.
+
+- [ ] **Step 5: Run complexity check**
+
+Run: `just complexity`
+Expected: pass (cyclo ~5; if it fails, extract).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add export/dot.go export/dot_test.go
+git commit -m "export: emit tool routing attrs in DOT semantic export
+
+Adds marker_grep / route_required / output_limit to applyToolSemanticAttrs
+with the same emission contract as the formatter (non-default only).
+Tracker reads these via n.Attrs[...].
+
+Refs #39"
+```
+
+---
+
+## Task 9: Migrate — read attrs back
+
+**Files:**
+- Modify: `migrate/migrate.go:496-509`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `migrate/migrate_test.go`:
+
+```go
+func TestBuildToolConfigRoutingAttrs(t *testing.T) {
+	attrs := map[string]string{
+		"tool_command":   "echo hi",
+		"timeout":        "30s",
+		"marker_grep":    "^pass$",
+		"route_required": "true",
+		"output_limit":   "8192",
+	}
+	cfg, err := buildToolConfig(attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MarkerGrep != "^pass$" {
+		t.Errorf("MarkerGrep = %q", cfg.MarkerGrep)
+	}
+	if !cfg.RouteRequired {
+		t.Error("RouteRequired = false")
+	}
+	if cfg.OutputLimit != 8192 {
+		t.Errorf("OutputLimit = %d", cfg.OutputLimit)
+	}
+}
+
+func TestBuildToolConfigOutputLimitInvalid(t *testing.T) {
+	attrs := map[string]string{"output_limit": "not_a_number"}
+	_, err := buildToolConfig(attrs)
+	if err == nil {
+		t.Error("expected error for non-numeric output_limit, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run test (must fail)**
+
+Run: `just test-pkg migrate`
+Expected: FAIL.
+
+- [ ] **Step 3: Refactor `buildToolConfig` and add helpers**
+
+Replace lines 496-509:
+
+```go
+func buildToolConfig(attrs map[string]string) (ir.ToolConfig, error) {
+	cfg := ir.ToolConfig{}
+	if v, ok := attrs["tool_command"]; ok {
+		cfg.Command = v
+	}
+	if v, ok := attrs["marker_grep"]; ok {
+		cfg.MarkerGrep = v
+	}
+	if v, ok := attrs["route_required"]; ok {
+		cfg.RouteRequired = (v == "true")
+	}
+	if err := applyToolTimeoutAttr(&cfg, attrs); err != nil {
+		return cfg, err
+	}
+	if err := applyToolOutputLimitAttr(&cfg, attrs); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func applyToolTimeoutAttr(cfg *ir.ToolConfig, attrs map[string]string) error {
+	v, ok := attrs["timeout"]
+	if !ok {
+		return nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fmt.Errorf("invalid timeout %q: %w", v, err)
+	}
+	cfg.Timeout = d
+	return nil
+}
+
+func applyToolOutputLimitAttr(cfg *ir.ToolConfig, attrs map[string]string) error {
+	v, ok := attrs["output_limit"]
+	if !ok {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fmt.Errorf("invalid output_limit %q: %w", v, err)
+	}
+	cfg.OutputLimit = n
+	return nil
+}
+```
+
+Add `"strconv"` to imports.
+
+- [ ] **Step 4: Run tests**
+
+Run: `just test-pkg migrate`
+Expected: PASS.
+
+- [ ] **Step 5: Complexity check**
+
+Run: `just complexity`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add migrate/migrate.go migrate/migrate_test.go
+git commit -m "migrate: read marker_grep/route_required/output_limit from DOT
+
+Splits buildToolConfig to keep cyclo budget, extracts timeout and
+output_limit attr application into helpers.
+
+Refs #39"
+```
+
+---
+
+## Task 10: Migrate parity — extend `compareToolConfigs`
+
+**Files:**
+- Modify: `migrate/parity.go:257-266`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `migrate/parity_test.go` (or wherever `TestCompareToolConfigs_DifferentCommand` lives — `grep -rn 'compareToolConfigs\|TestCompareToolConfigs' migrate/`):
+
+```go
+func TestCompareToolConfigsDifferentMarkerGrep(t *testing.T) {
+	a := ir.ToolConfig{MarkerGrep: "^pass$"}
+	b := ir.ToolConfig{MarkerGrep: "^fail$"}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for MarkerGrep, got none")
+	}
+}
+
+func TestCompareToolConfigsDifferentRouteRequired(t *testing.T) {
+	a := ir.ToolConfig{RouteRequired: true}
+	b := ir.ToolConfig{RouteRequired: false}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for RouteRequired, got none")
+	}
+}
+
+func TestCompareToolConfigsDifferentOutputLimit(t *testing.T) {
+	a := ir.ToolConfig{OutputLimit: 1024}
+	b := ir.ToolConfig{OutputLimit: 2048}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for OutputLimit, got none")
+	}
+}
+
+func TestCompareToolConfigsDifferentTimeout(t *testing.T) {
+	a := ir.ToolConfig{Timeout: 30 * time.Second}
+	b := ir.ToolConfig{Timeout: 60 * time.Second}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for Timeout, got none")
+	}
+}
+
+func TestCompareToolConfigsDifferentOutputs(t *testing.T) {
+	a := ir.ToolConfig{Outputs: []string{"pass", "fail"}}
+	b := ir.ToolConfig{Outputs: []string{"green", "red"}}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for Outputs, got none")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests (must fail)**
+
+Run: `just test-pkg migrate`
+Expected: most fail (only `MarkerGrep`/`RouteRequired`/`OutputLimit` if Command happens to be empty in both? — check; expect at minimum 3-5 failures).
+
+- [ ] **Step 3: Replace `compareToolConfigs` with helper-extracted version**
+
+```go
+func compareToolConfigs(id, path string, ac ir.ToolConfig, bCfg interface{}) []Difference {
+	bc, ok := bCfg.(ir.ToolConfig)
+	if !ok {
+		return []Difference{configMismatchDiff(id, path, "ToolConfig", bCfg)}
+	}
+	var diffs []Difference
+	diffs = append(diffs, compareToolScalars(id, ac, bc)...)
+	diffs = append(diffs, compareToolSlices(id, ac, bc)...)
+	return diffs
+}
+
+func compareToolScalars(id string, ac, bc ir.ToolConfig) []Difference {
+	var diffs []Difference
+	if !promptsEqual(ac.Command, bc.Command) {
+		diffs = append(diffs, fieldDiff(id, "command", fmt.Sprintf("node %q command differs", id)))
+	}
+	if ac.Timeout != bc.Timeout {
+		diffs = append(diffs, fieldDiff(id, "timeout", fmt.Sprintf("node %q timeout: %s vs %s", id, ac.Timeout, bc.Timeout)))
+	}
+	if ac.MarkerGrep != bc.MarkerGrep {
+		diffs = append(diffs, fieldDiff(id, "marker_grep", fmt.Sprintf("node %q marker_grep: %q vs %q", id, ac.MarkerGrep, bc.MarkerGrep)))
+	}
+	if ac.RouteRequired != bc.RouteRequired {
+		diffs = append(diffs, fieldDiff(id, "route_required", fmt.Sprintf("node %q route_required: %v vs %v", id, ac.RouteRequired, bc.RouteRequired)))
+	}
+	if ac.OutputLimit != bc.OutputLimit {
+		diffs = append(diffs, fieldDiff(id, "output_limit", fmt.Sprintf("node %q output_limit: %d vs %d", id, ac.OutputLimit, bc.OutputLimit)))
+	}
+	return diffs
+}
+
+func compareToolSlices(id string, ac, bc ir.ToolConfig) []Difference {
+	var diffs []Difference
+	if strings.Join(ac.Outputs, ",") != strings.Join(bc.Outputs, ",") {
+		diffs = append(diffs, fieldDiff(id, "outputs", fmt.Sprintf("node %q outputs: %v vs %v", id, ac.Outputs, bc.Outputs)))
+	}
+	return diffs
+}
+```
+
+Add `"strings"` to imports if not already present.
+
+- [ ] **Step 4: Run tests**
+
+Run: `just test-pkg migrate`
+Expected: PASS (existing `_DifferentCommand` test still passes; new tests pass).
+
+- [ ] **Step 5: Complexity check**
+
+Run: `just complexity`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add migrate/parity.go migrate/parity_test.go
+git commit -m "migrate: parity compares all ToolConfig fields
+
+Extends compareToolConfigs to detect drift in Timeout, Outputs,
+MarkerGrep, RouteRequired, OutputLimit. Previously only Command
+was compared; Timeout/Outputs gaps backfilled while in the area.
+
+Refs #39"
+```
+
+---
+
+## Task 11: LSP completion — three new entries
+
+**Files:**
+- Modify: `lsp/completion.go:42-65`
+
+- [ ] **Step 1: Write failing test (if there's a completion test fixture)**
+
+Check: `grep -rn 'fieldCompletions\|TestCompletion' lsp/`
+
+If a test asserts the completion list, add to it:
+
+```go
+func TestFieldCompletionsIncludesRoutingFields(t *testing.T) {
+	items := fieldCompletions()
+	want := map[string]bool{"marker_grep:": false, "route_required:": false, "output_limit:": false}
+	for _, it := range items {
+		if _, ok := want[it.Label]; ok {
+			want[it.Label] = true
+		}
+	}
+	for label, found := range want {
+		if !found {
+			t.Errorf("missing completion for %q", label)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test (must fail)**
+
+Run: `just test-pkg lsp`
+Expected: FAIL.
+
+- [ ] **Step 3: Add three entries**
+
+In `lsp/completion.go`, extend the `fields` slice in `fieldCompletions`:
+
+```go
+{"marker_grep:", "Regex matched against tool stdout; sets ctx.tool_marker"},
+{"route_required:", "Require _TRACKER_ROUTE= sentinel line from tool stdout"},
+{"output_limit:", "Per-node stdout byte cap (positive int)"},
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `just test-pkg lsp`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lsp/completion.go lsp/completion_test.go
+git commit -m "lsp: complete marker_grep/route_required/output_limit
+
+Refs #39"
+```
+
+---
+
+## Task 12: LSP hover — extract `formatToolHover`
+
+**Files:**
+- Modify: `lsp/hover.go:77-106`
+
+- [ ] **Step 1: Write failing test**
+
+Append to wherever hover is tested (`grep -rn 'formatNodeConfig\|TestHover' lsp/`):
+
+```go
+func TestFormatToolHoverWithRoutingFields(t *testing.T) {
+	node := &ir.Node{
+		Kind: ir.NodeTool,
+		Config: ir.ToolConfig{
+			Command:       "echo hi",
+			MarkerGrep:    "^pass$",
+			RouteRequired: true,
+			OutputLimit:   8192,
+		},
+	}
+	out := formatNodeConfig(node, &ir.Workflow{})
+	for _, want := range []string{"marker_grep", "route_required", "output_limit"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("hover missing %q. Output:\n%s", want, out)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test (must fail)**
+
+Run: `just test-pkg lsp`
+Expected: FAIL.
+
+- [ ] **Step 3: Replace the `ToolConfig` branch with a helper**
+
+In `lsp/hover.go`, replace the case:
+
+```go
+case ir.ToolConfig:
+    return formatToolHover(cfg)
+```
+
+Then add `formatToolHover` mirroring `formatAgentHover`:
+
+```go
+// formatToolHover formats tool-specific hover info.
+func formatToolHover(cfg ir.ToolConfig) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Command: `%s`\n", truncateStr(cfg.Command, 80))
+	if cfg.MarkerGrep != "" {
+		fmt.Fprintf(&b, "marker_grep: `%s`\n", cfg.MarkerGrep)
+	}
+	if cfg.RouteRequired {
+		b.WriteString("route_required: true\n")
+	}
+	if cfg.OutputLimit > 0 {
+		fmt.Fprintf(&b, "output_limit: %d bytes\n", cfg.OutputLimit)
+	}
+	return b.String()
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `just test-pkg lsp`
+Expected: PASS.
+
+- [ ] **Step 5: Complexity check**
+
+Run: `just complexity`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lsp/hover.go lsp/hover_test.go
+git commit -m "lsp: surface routing fields in tool hover
+
+Extracts formatToolHover mirroring formatAgentHover and adds
+conditional lines for MarkerGrep, RouteRequired, OutputLimit.
+
+Refs #39"
+```
+
+---
+
+## Task 13: VSCode tmLanguage keyword
+
+**Files:**
+- Modify: `editors/vscode/syntaxes/dippin.tmLanguage.json:148`
+
+- [ ] **Step 1: Locate the field-name regex**
+
+Run: `grep -n 'goal_gate\|auto_status' editors/vscode/syntaxes/dippin.tmLanguage.json`
+Find the alternation list at line 148.
+
+- [ ] **Step 2: Append three keywords**
+
+Insert `marker_grep|route_required|output_limit` into the existing alternation (alphabetical position is fine but match neighboring style).
+
+- [ ] **Step 3: Run tree-sitter check (also exercises the grammar repo)**
+
+Run: `just check`
+Expected: pass (the tmLanguage is JSON, not a grammar; no separate test, but `just check` validates examples and full build).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add editors/vscode/syntaxes/dippin.tmLanguage.json
+git commit -m "editors(vscode): highlight new tool routing field names
+
+Refs #39"
+```
+
+---
+
+## Task 14: Create `examples/marker_routing.dip`
+
+**Files:**
+- Create: `examples/marker_routing.dip`
+
+- [ ] **Step 1: Create the example**
+
+Model after `examples/tool_safety.dip`. Must be lint-clean (DIP111 timeout, no model warnings, etc.):
+
+```dippin
+workflow MarkerRouting
+  goal: "Show typed marker-driven routing on tool nodes"
+  start: RunTests
+  exit: Done
+
+  defaults
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  tool RunTests
+    label: "Run test suite, route by marker"
+    outputs: tests_green, tests_red
+    marker_grep: '^(tests_green|tests_red)$'
+    route_required: true
+    output_limit: 65536
+    timeout: 2m
+    command:
+      #!/bin/sh
+      set -eu
+      if go test ./... > /tmp/test.log 2>&1; then
+        printf 'tests_green\n'
+        printf '_TRACKER_ROUTE=passed\n'
+      else
+        printf 'tests_red\n'
+        printf '_TRACKER_ROUTE=failed\n'
+      fi
+
+  agent Done
+    prompt: "Summarize the routing outcome."
+
+  edges
+    RunTests -> Done when ctx.tool_marker = tests_green
+    RunTests -> Done when ctx.tool_marker = tests_red
+```
+
+- [ ] **Step 2: Validate**
+
+Run: `./dippin validate examples/marker_routing.dip`
+(Or after `just build`: `dippin validate examples/marker_routing.dip`)
+Expected: clean.
+
+Run: `./dippin lint examples/marker_routing.dip`
+Expected: zero warnings.
+
+- [ ] **Step 3: Run integration test**
+
+Run: `just test-pkg validator`
+Expected: `TestLintExamples` and `TestPackExamples` pass with the new example.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/marker_routing.dip
+git commit -m "examples: add marker_routing.dip demoing tool routing fields
+
+Shows marker_grep + route_required + output_limit together with
+a representative go-test runner pattern. Lint-clean.
+
+Refs #39"
+```
+
+---
+
+## Task 15: Docs — `docs/nodes.md`
+
+**Files:**
+- Modify: `docs/nodes.md`
+
+- [ ] **Step 1: Add three rows to the Tool-Specific Fields table (line ~261)**
+
+After the `outputs` row:
+
+```markdown
+| `marker_grep` | String | — | Regex matched line-by-line against captured stdout. The last match populates `ctx.tool_marker`. Tracker validates and applies the regex at runtime. |
+| `route_required` | Boolean | false | When true, the node fails if the command's stdout contains no `_TRACKER_ROUTE=<value>` sentinel line. The matched value populates `ctx.tool_route`. |
+| `output_limit` | Integer | — | Per-node override for the engine's captured-stdout byte cap. Positive integer; omit (or set 0) to use the engine default. |
+```
+
+- [ ] **Step 2: Extend the "Markers and Verbose Output" section (line ~286)**
+
+After the existing prose, append:
+
+```markdown
+**Best (when the runtime supports typed markers):** declare `marker_grep` and let the runtime parse the routing signal directly, freeing stdout for diagnostic output:
+
+```dippin
+  tool RunTests
+    marker_grep: '^(tests_pass|tests_fail)$'
+    timeout: 60s
+    command:
+      pytest 2>&1
+      [ $? -eq 0 ] && printf 'tests_pass\n' || printf 'tests_fail\n'
+```
+
+When `marker_grep` is declared, the runtime populates `ctx.tool_marker` and routing edges can reference it instead of `ctx.tool_stdout`. `route_required: true` makes the absence of any match a hard failure. `output_limit` overrides the per-node stdout cap when the command genuinely needs a larger window.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/nodes.md
+git commit -m "docs(nodes): document marker_grep / route_required / output_limit
+
+Refs #39"
+```
+
+---
+
+## Task 16: Docs — `docs/llm-reference.md`, reserved ctx vars
+
+**Files:**
+- Modify: `docs/llm-reference.md`
+- Modify: `docs/context.md`
+- Modify: `docs/edges.md`
+- Modify: `docs/validation.md`
+
+- [ ] **Step 1: Update llm-reference.md tool row (line ~50)**
+
+Change:
+```markdown
+| `tool` | `command` | `timeout` (e.g. 30s, 5m) |
+```
+to:
+```markdown
+| `tool` | `command` | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes) |
+```
+
+- [ ] **Step 2: Add a row to the common-mistakes table (after row 8)**
+
+```markdown
+| 9 | Hand-parsing tool stdout for routing | Use `marker_grep: '<regex>'` (and optionally `route_required: true`) instead of regexing `ctx.tool_stdout` in edge conditions. Mirrors tracker's TRK101 recommendation; populates `ctx.tool_marker` directly. |
+```
+
+- [ ] **Step 3: Add `ctx.tool_marker` and `ctx.tool_route` to context.md, edges.md, validation.md**
+
+In each file: locate the existing reserved `ctx.*` table or list and add two rows describing the new variables:
+
+```markdown
+| `ctx.tool_marker` | Tool stdout regex match (when `marker_grep` is declared) |
+| `ctx.tool_route` | Tool stdout `_TRACKER_ROUTE=<value>` sentinel (when `route_required` is true) |
+```
+
+Match the surrounding style — `grep -n 'ctx\.tool_stdout' docs/context.md docs/edges.md docs/validation.md` to find the exact insertion point in each.
+
+- [ ] **Step 4: Regenerate the embedded spec**
+
+Run: `just gen-spec`
+Expected: refreshes `docs/generated-spec.md` and `cmd/dippin/generated-spec.md`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ cmd/dippin/generated-spec.md
+git commit -m "docs: add tool routing fields and ctx.tool_marker/route to references
+
+Updates llm-reference.md tool row + common-mistakes table; adds
+ctx.tool_marker / ctx.tool_route to the reserved variable lists
+in context.md, edges.md, validation.md. Regenerates embedded spec.
+
+Refs #39"
+```
+
+---
+
+## Task 17: Website — `skill.md` + `language.md`
+
+**Files:**
+- Modify: `site/static/skill.md`
+- Modify: `site/content/language.md`
+
+- [ ] **Step 1: Update `skill.md` tool field table (line ~117)**
+
+Insert three rows mirroring the docs/nodes.md edits.
+
+- [ ] **Step 2: Update `skill.md` Best Practices section (line ~411)**
+
+After the "Always set timeout" bullet, add:
+
+```markdown
+- **Prefer `marker_grep:`** over regexing `ctx.tool_stdout` in edges when the runtime supports it. Typed routing leaves stdout free for diagnostic output and avoids truncation foot-guns.
+```
+
+- [ ] **Step 3: Update `skill.md` Context Variables table (line ~462)**
+
+Add:
+
+```markdown
+| `ctx.tool_marker` | Tool stdout regex match (when `marker_grep` declared) |
+| `ctx.tool_route` | `_TRACKER_ROUTE=<value>` sentinel (when `route_required: true`) |
+```
+
+- [ ] **Step 4: Update `site/content/language.md` `### tool` section (line ~175)**
+
+Replace the existing tool example with one that shows the new fields too:
+
+```dippin
+  tool RunTests
+    label: "Run test suite"
+    outputs: tests_pass, tests_fail
+    marker_grep: '^(tests_pass|tests_fail)$'
+    timeout: 60s
+    command:
+      pytest --tb=short
+```
+
+Add a short prose line below the example: "Declare `marker_grep` for typed routing (populates `ctx.tool_marker`); `route_required: true` makes a missing `_TRACKER_ROUTE=` sentinel fail the node; `output_limit` overrides the captured-stdout byte cap."
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add site/static/skill.md site/content/language.md
+git commit -m "site: document tool routing fields in skill and language pages
+
+Adds field table rows, Best Practices bullet, Context Variables
+entries to hosted skill.md; updates language.md tool example.
+
+Refs #39"
+```
+
+---
+
+## Task 18: Blog post — `whats-new-v028.md`
+
+**Files:**
+- Create: `site/content/blog/whats-new-v028.md`
+
+- [ ] **Step 1: Determine the release date**
+
+Pick today (or planned tag day). Use it as both `date` and `publishDate`.
+
+- [ ] **Step 2: Create the post**
+
+Mirror `site/content/blog/whats-new-v027.md` frontmatter shape:
+
+```markdown
+---
+title: "What's new in v0.28: typed tool routing"
+date: "2026-MM-DD"
+publishDate: "2026-MM-DD"
+draft: false
+description: "Tool nodes can now declare marker_grep, route_required, and output_limit — typed routing primitives that close the parity gap with tracker's runtime."
+---
+
+## Three new tool-node fields
+
+Issue #39 closes a parser gap: tracker's runtime already supported `marker_grep`, `route_required`, and `output_limit`, but `.dip` source couldn't reach them. Authors following tracker's `TRK101` lint recommendation hit `unrecognized tool field "marker_grep"` from dippin instead of cleaner routing.
+
+```dippin
+  tool RunTests
+    marker_grep: '^(tests_pass|tests_fail)$'
+    route_required: true
+    output_limit: 65536
+    timeout: 2m
+    command:
+      go test ./... 2>&1
+```
+
+### What each field does
+
+- **`marker_grep`** — regex matched against stdout. Last match populates `ctx.tool_marker`. Routing edges can reference it instead of regexing `ctx.tool_stdout`.
+- **`route_required`** — when true, the node fails (`EventToolRouteMissing`) if the command emits no `_TRACKER_ROUTE=<value>` sentinel line. The value populates `ctx.tool_route`.
+- **`output_limit`** — per-node override of the engine's captured-stdout byte cap, for tools that need a larger or smaller window than the global default.
+
+### Why it matters
+
+Without these, authors hit tracker's TRK101 truncation foot-gun and worked around it by enumerating every possible stdout marker as a conditional edge — which made `dippin coverage` flag false-positive non-exhaustive routing. Typed `marker_grep` is the canonical fix; now dippin accepts it.
+
+### Runtime requirement
+
+These fields forward to tracker via DOT export. Routing semantics require **tracker >= v0.<x>.<y>** (the version that ships the matching `extractToolAttrs` change). Older tracker silently ignores the new attrs.
+
+### Coming next
+
+- **#42** — DIP138, lint warning when a tool node parses stdout for routing without declaring `marker_grep` / `outputs`.
+- **#43** — normalize boolean parsing (`true` / `yes` / `1` accepted consistently).
+- **#44** — close the existing `outputs` DOT round-trip gap.
+```
+
+- [ ] **Step 3: Verify Hugo build**
+
+Run: `just site-build` (or whatever the site build command is — `grep -A2 'site-build:' Justfile`)
+Expected: clean build; the new post is included.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/content/blog/whats-new-v028.md
+git commit -m "site(blog): add v0.28 release post for tool routing fields
+
+Refs #39"
+```
+
+---
+
+## Task 19: CHANGELOG + version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add v0.28.0 entry at the top**
+
+Insert before the `## [v0.27.0]` heading:
+
+```markdown
+## [v0.28.0] — 2026-MM-DD
+
+Tool-node routing fields land in the parser and IR. Authors following tracker's `TRK101` recommendation can now declare `marker_grep`, `route_required`, and `output_limit` directly in `.dip` source. Closes #39.
+
+### Added
+
+- `tool.marker_grep` — regex matched line-by-line against captured stdout; populates `ctx.tool_marker` at runtime.
+- `tool.route_required` — boolean; when true, the node fails with `EventToolRouteMissing` if the command emits no `_TRACKER_ROUTE=<value>` sentinel line.
+- `tool.output_limit` — positive integer (bytes) overriding the engine default stdout tail-window for this node.
+- Reserved context variables: `ctx.tool_marker`, `ctx.tool_route`.
+
+### Changed
+
+- `migrate/parity.go compareToolConfigs` now compares all `ToolConfig` fields. Pre-existing `Timeout` / `Outputs` parity gaps backfilled.
+
+### Runtime requirement
+
+These fields pass through DOT export to tracker. Routing semantics require tracker to ship the matching `extractToolAttrs` change; see issue #39 for details.
+
+### Docs
+
+- New blog post: ["What's new in v0.28: typed tool routing"](blog/whats-new-v028.md).
+- `docs/nodes.md` gains a "Best (when the runtime supports typed markers)" note in the Markers and Verbose Output section.
+- Hosted skill (`site/static/skill.md`) updated with new ctx vars and best-practice bullet.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "changelog: v0.28.0 — tool routing fields
+
+Refs #39"
+```
+
+---
+
+## Task 20: Full check, push, tag
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `just check`
+Expected: pass. If anything fails, fix it before tagging.
+
+- [ ] **Step 2: Push branch and open PR**
+
+(Per `commit-commands:commit-push-pr` skill, or manually with `gh pr create`.)
+
+- [ ] **Step 3: Merge PR, pull main**
+
+```bash
+git checkout main
+git pull origin main
+```
+
+- [ ] **Step 4: Tag**
+
+```bash
+just release v0.28.0 "tool routing fields: marker_grep, route_required, output_limit (#39)"
+```
+
+Or manually:
+```bash
+git tag -a v0.28.0 -m "tool routing fields: marker_grep, route_required, output_limit (#39)"
+git push origin v0.28.0
+```
+
+- [ ] **Step 5: Verify GoReleaser**
+
+Check `gh run list --workflow=release.yml --limit 3` for the tag-triggered run; confirm it completes and the Homebrew tap updates.
+
+- [ ] **Step 6: Open tracker follow-up PR**
+
+Separately in the tracker repo: bump `dippin-lang` dep to `v0.28.0`, update `tracker/pipeline/dippin_adapter.go` `extractToolAttrs` to forward the three new fields (sketch in spec out-of-scope section).
+
+---
+
+## Self-review checklist (for the spec author, before handoff)
+
+- [x] Every spec section maps to a task: IR (1), parser (2-5), formatter (7), DOT (8), migrate (9-10), LSP (11-12), VSCode (13), example (14), docs (15-16), website (17), blog (18), changelog (19), release (20).
+- [x] No TODO / TBD / "appropriate error handling" placeholders.
+- [x] Function names consistent across tasks (`applyToolStringField` used in Task 2 and Task 3; `formatToolHover` used in Task 12).
+- [x] Test fixtures parse real `.dip` text per CLAUDE.md.
+- [x] Each task commits before the next starts.
+- [x] `just check` gate at end before tag.

--- a/docs/superpowers/specs/2026-05-19-issue-39-tool-routing-fields-design.md
+++ b/docs/superpowers/specs/2026-05-19-issue-39-tool-routing-fields-design.md
@@ -1,0 +1,102 @@
+# Issue #39 — Tool Routing Fields (`marker_grep`, `route_required`, `output_limit`)
+
+**Status:** Design approved 2026-05-19.
+**Issue:** [#39](https://github.com/2389-research/dippin-lang/issues/39).
+**Target release:** v0.28.0.
+**Deferred follow-ups:** #42 (lint suppression + DIP138), #43 (parseBoolAttr normalization), #44 (outputs DOT export gap).
+
+## Problem
+
+Tracker's runtime supports three tool-node primitives for stdout-driven routing:
+
+- `marker_grep: '<regex>'` — typed routing channel; populates `ctx.tool_marker`.
+- `route_required: true` — paired with `_TRACKER_ROUTE=<value>` sentinel lines; populates `ctx.tool_route`.
+- `output_limit: <bytes>` — per-node stdout tail-window override.
+
+Tracker's `TRK101` lint recommends these as the canonical fix for stdout truncation. Dippin hard-fails: `unrecognized tool field "marker_grep"`. Authors who follow TRK101 advice can't.
+
+Strings pass through verbatim. Dippin does not interpret routing semantics; tracker does.
+
+## IR — `ir/ir.go`
+
+Extend `ToolConfig`:
+
+```go
+type ToolConfig struct {
+    Command       string
+    Timeout       time.Duration
+    Outputs       []string
+    MarkerGrep    string // regex matched line-by-line against captured stdout; populates ctx.tool_marker
+    RouteRequired bool   // true → node fails if no _TRACKER_ROUTE= sentinel is emitted
+    OutputLimit   int    // bytes; > 0 = override engine default
+}
+```
+
+## Parser — `parser/parse_nodes.go`
+
+Three new fields in `applyToolField`:
+- `marker_grep` — string, verbatim
+- `route_required` — strict `val == "true"` (matches existing bool convention; #43 will normalize)
+- `output_limit` — `parseInt`; diagnostic on negative
+
+`applyToolField` is at the cyclomatic-5 budget; adding cases requires the same string/bool/parsed helper split the agent and human handlers already use. The plan covers shape.
+
+## Formatter — `formatter/format.go`
+
+`writeToolFields` emits new fields when non-default, clustering routing/output-shape fields:
+
+```
+outputs → marker_grep → route_required → output_limit → timeout → reads → writes → command
+```
+
+Zero/empty/false values are not emitted (matches existing convention for `goal_gate`, `cmd_timeout`, etc.). Documented in `docs/nodes.md` so authors know writing `output_limit: 0` round-trips to absent.
+
+## DOT export — `export/dot.go`
+
+`applyToolSemanticAttrs` emits `marker_grep` (when non-empty), `route_required` (as `"true"` when set), `output_limit` (decimal int when > 0). Same emission contract as the formatter.
+
+## Migrate — `migrate/migrate.go`, `migrate/parity.go`
+
+`buildToolConfig` reads the three attrs back. `compareToolConfigs` extends equality to all `ToolConfig` fields, backfilling pre-existing `Timeout` / `Outputs` gaps while in the area.
+
+## LSP — `lsp/completion.go`, `lsp/hover.go`
+
+Three new entries in `fieldCompletions`. Tool hover surfaces the new fields when set.
+
+## Docs
+
+- `docs/nodes.md` — three rows in the tool fields table; expand "Markers and Verbose Output" to mention `marker_grep:` as the typed alternative.
+- `docs/llm-reference.md` — tool row + a row in the common-mistakes table referencing TRK101.
+- `docs/context.md`, `docs/edges.md`, `docs/validation.md` — add `ctx.tool_marker` and `ctx.tool_route` to the reserved `ctx.*` variable lists.
+
+## Website
+
+- `site/static/skill.md` — mirror docs changes; add `ctx.tool_marker` / `ctx.tool_route` to the Context Variables table.
+- `site/content/language.md` — `### tool` section gets the new fields.
+- `site/content/blog/whats-new-v028.md` — short release post in the `whats-new-v027.md` style. Use Hugo `publishDate` set to the v0.28.0 tag date so it doesn't go live before the binary publishes (single-PR approach; `draft: true` flip is the alternative).
+
+## Tooling
+
+- `editors/vscode/syntaxes/dippin.tmLanguage.json` — append three field-name keywords to the existing alternation.
+- Tree-sitter / Zed — no change (generic `field_name` rule).
+
+## Example
+
+New `examples/marker_routing.dip` — lint-clean, exercises all three fields, picked up by `TestLintExamples` for parser regression coverage.
+
+## Tests
+
+Per-layer happy path + round-trip via `parser/testdata/all_features.dip` extension. Migrate parity gets explicit mismatch tests for each new field (plus the backfilled `Timeout` / `Outputs`). The plan enumerates specific cases.
+
+## CHANGELOG & release
+
+- CHANGELOG entry under `## [v0.28.0]` in existing v0.27 style (Added: three fields + two ctx vars; Changed: parity backfill).
+- Tag `v0.28.0`; GoReleaser publishes binaries + Homebrew tap.
+- Tracker bumps `go.mod` to `dippin-lang@v0.28.0` in a follow-up PR; that same PR updates `extractToolAttrs` to forward the three attrs. Unkeyed `ir.ToolConfig{...}` literals (if any) surface and get fixed inline there.
+
+## Out of scope (tracked separately)
+
+- **#42** — Coverage / DIP101 / DIP102 suppression when `marker_grep` is declared. Reserves DIP138.
+- **#43** — `parseBoolAttr` helper to normalize the four bool fields.
+- **#44** — DOT round-trip for `ToolConfig.Outputs`.
+- SI/IEC suffix parsing for `output_limit` (raw bytes for v1).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -635,7 +635,7 @@ warning[DIP121]: edge Gate → Pass: condition references "ctx.score" but node "
 
 **What triggers it**: An edge from node A has a condition like `ctx.score = high`, but node A's `IO.Writes` doesn't include `score`. Only fires when the source node has non-empty `writes` declarations.
 
-**Skipped for**: Reserved runtime variables (`ctx.outcome`, `ctx.status`, `ctx.tool_stdout`, `ctx.tool_stderr`, `ctx.internal.*`, `graph.*`, `params.*`).
+**Skipped for**: Reserved runtime variables (`ctx.outcome`, `ctx.status`, `ctx.tool_stdout`, `ctx.tool_stderr`, `ctx.tool_marker`, `ctx.tool_route`, `ctx.internal.*`, `graph.*`, `params.*`).
 
 **How to fix**: Add the variable to the source node's `writes` list, or verify the condition references the correct variable.
 

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -145,7 +145,7 @@
           }
         },
         {
-          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|class|reads|writes)\\s*(:)",
+          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|marker_grep|route_required|output_limit|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|class|reads|writes)\\s*(:)",
           "captures": {
             "1": { "name": "entity.name.tag.field.dippin" },
             "2": { "name": "punctuation.separator.key-value.dippin" }

--- a/examples/marker_routing.dip
+++ b/examples/marker_routing.dip
@@ -1,0 +1,33 @@
+workflow MarkerRouting
+  goal: "Show typed marker-driven routing on tool nodes"
+  start: RunTests
+  exit: Done
+
+  defaults
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  tool RunTests
+    label: "Run test suite, route by marker"
+    outputs: tests_green, tests_red
+    marker_grep: "^(tests_green|tests_red)$"
+    route_required: true
+    output_limit: 65536
+    timeout: 2m
+    command:
+      #!/bin/sh
+      set -eu
+      if go test ./... > /tmp/test.log 2>&1; then
+        printf 'tests_green\n'
+        printf '_TRACKER_ROUTE=passed\n'
+      else
+        printf 'tests_red\n'
+        printf '_TRACKER_ROUTE=failed\n'
+      fi
+
+  agent Done
+    prompt: "Summarize the routing outcome."
+
+  edges
+    RunTests -> Done when ctx.tool_marker = tests_green
+    RunTests -> Done when ctx.tool_marker = tests_red

--- a/export/dot.go
+++ b/export/dot.go
@@ -7,6 +7,7 @@ package export
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -300,10 +301,19 @@ func applyAgentRuntimeAttrs(attrs map[string]string, cfg ir.AgentConfig) {
 	}
 }
 
-// applyToolSemanticAttrs adds tool timeout (runtime, always exported).
+// applyToolSemanticAttrs adds tool runtime attrs (always exported).
 func applyToolSemanticAttrs(attrs map[string]string, cfg ir.ToolConfig) {
 	if cfg.Timeout != 0 {
 		attrs["timeout"] = formatDuration(cfg.Timeout)
+	}
+	if cfg.MarkerGrep != "" {
+		attrs["marker_grep"] = cfg.MarkerGrep
+	}
+	if cfg.RouteRequired {
+		attrs["route_required"] = "true"
+	}
+	if cfg.OutputLimit > 0 {
+		attrs["output_limit"] = strconv.Itoa(cfg.OutputLimit)
 	}
 }
 

--- a/export/dot_test.go
+++ b/export/dot_test.go
@@ -1396,3 +1396,63 @@ func TestExportToolSafetyVarsCollision(t *testing.T) {
 		t.Errorf("expected tool_commands_allow from Defaults, got:\n%s", out)
 	}
 }
+
+func TestExportDOTToolRoutingFields(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:  "tool_routing_test",
+		Goal:  "test routing",
+		Start: "T",
+		Exit:  "T",
+		Nodes: []*ir.Node{
+			{
+				ID:   "T",
+				Kind: ir.NodeTool,
+				Config: ir.ToolConfig{
+					Command:       "echo pass",
+					Timeout:       30 * time.Second,
+					MarkerGrep:    "^pass$",
+					RouteRequired: true,
+					OutputLimit:   8192,
+				},
+			},
+		},
+		Edges: []*ir.Edge{},
+	}
+	out := ExportDOT(wf, ExportOptions{})
+	for _, want := range []string{
+		`marker_grep="^pass$"`,
+		`route_required="true"`,
+		`output_limit="8192"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("DOT output missing %q. Full output:\n%s", want, out)
+		}
+	}
+}
+
+func TestExportDOTToolRoutingOmitWhenZero(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:  "tool_omit_test",
+		Goal:  "test omission",
+		Start: "T",
+		Exit:  "T",
+		Nodes: []*ir.Node{
+			{
+				ID:   "T",
+				Kind: ir.NodeTool,
+				Config: ir.ToolConfig{
+					Command: "echo pass",
+					Timeout: 30 * time.Second,
+					// MarkerGrep, RouteRequired, OutputLimit all zero/default
+				},
+			},
+		},
+		Edges: []*ir.Edge{},
+	}
+	out := ExportDOT(wf, ExportOptions{})
+	for _, unwanted := range []string{"marker_grep", "route_required", "output_limit"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("DOT output unexpectedly contains %q. Full output:\n%s", unwanted, out)
+		}
+	}
+}

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -485,11 +485,24 @@ func writeHumanTimeoutFields(wr *writer, cfg ir.HumanConfig) {
 	}
 }
 
+func writeToolRoutingFields(wr *writer, cfg ir.ToolConfig) {
+	if cfg.MarkerGrep != "" {
+		wr.line("marker_grep: %s", quoteValue(cfg.MarkerGrep))
+	}
+	if cfg.RouteRequired {
+		wr.line("route_required: true")
+	}
+	if cfg.OutputLimit > 0 {
+		wr.line("output_limit: %d", cfg.OutputLimit)
+	}
+}
+
 func writeToolFields(wr *writer, n *ir.Node, cfg ir.ToolConfig) {
 	writeCommonNodeFields(wr, n)
 	if len(cfg.Outputs) > 0 {
 		wr.line("outputs: %s", strings.Join(cfg.Outputs, ", "))
 	}
+	writeToolRoutingFields(wr, cfg)
 	if cfg.Timeout != 0 {
 		wr.line("timeout: %s", formatDuration(cfg.Timeout))
 	}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -126,9 +126,12 @@ func (HumanConfig) nodeConfig() {}
 
 // ToolConfig holds configuration for shell command nodes.
 type ToolConfig struct {
-	Command string // Shell command (multiline OK)
-	Timeout time.Duration
-	Outputs []string // Declared possible stdout values for coverage analysis
+	Command       string // Shell command (multiline OK)
+	Timeout       time.Duration
+	Outputs       []string // Declared possible stdout values for coverage analysis
+	MarkerGrep    string   // Regex matched line-by-line against stdout; populates ctx.tool_marker
+	RouteRequired bool     // True → node fails if no _TRACKER_ROUTE= sentinel is emitted
+	OutputLimit   int      // Bytes; > 0 = override engine default
 }
 
 func (ToolConfig) nodeConfig() {}

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -51,6 +51,9 @@ func fieldCompletions() []protocol.CompletionItem {
 		{"goal_gate:", "Fail pipeline if node fails"},
 		{"reasoning_effort:", "Reasoning effort (none|minimal|low|medium|high|xhigh|max)"},
 		{"fidelity:", "Fidelity level"},
+		{"marker_grep:", "Regex matched against tool stdout; sets ctx.tool_marker"},
+		{"route_required:", "Require _TRACKER_ROUTE= sentinel line from tool stdout"},
+		{"output_limit:", "Per-node stdout byte cap (positive int)"},
 	}
 	var items []protocol.CompletionItem
 	for _, f := range fields {

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -53,7 +53,7 @@ func fieldCompletions() []protocol.CompletionItem {
 		{"fidelity:", "Fidelity level"},
 		{"marker_grep:", "Regex matched against tool stdout; sets ctx.tool_marker"},
 		{"route_required:", "Require _TRACKER_ROUTE= sentinel line from tool stdout"},
-		{"output_limit:", "Per-node stdout byte cap (positive int)"},
+		{"output_limit:", "Per-node stdout byte cap (non-negative int; 0 = engine default)"},
 	}
 	var items []protocol.CompletionItem
 	for _, f := range fields {

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -81,10 +81,26 @@ func formatNodeConfig(n *ir.Node, w *ir.Workflow) string {
 	case ir.HumanConfig:
 		return fmt.Sprintf("Mode: %s\n", cfg.Mode)
 	case ir.ToolConfig:
-		return fmt.Sprintf("Command: `%s`\n", truncateStr(cfg.Command, 80))
+		return formatToolHover(cfg)
 	default:
 		return ""
 	}
+}
+
+// formatToolHover formats tool-specific hover info.
+func formatToolHover(cfg ir.ToolConfig) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Command: `%s`\n", truncateStr(cfg.Command, 80))
+	if cfg.MarkerGrep != "" {
+		fmt.Fprintf(&b, "marker_grep: `%s`\n", cfg.MarkerGrep)
+	}
+	if cfg.RouteRequired {
+		b.WriteString("route_required: true\n")
+	}
+	if cfg.OutputLimit > 0 {
+		fmt.Fprintf(&b, "output_limit: %d bytes\n", cfg.OutputLimit)
+	}
+	return b.String()
 }
 
 // formatAgentHover formats agent-specific hover info.

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -381,6 +381,21 @@ func TestFieldCompletions(t *testing.T) {
 	}
 }
 
+func TestFieldCompletionsIncludesRoutingFields(t *testing.T) {
+	items := fieldCompletions()
+	want := map[string]bool{"marker_grep:": false, "route_required:": false, "output_limit:": false}
+	for _, it := range items {
+		if _, ok := want[it.Label]; ok {
+			want[it.Label] = true
+		}
+	}
+	for label, found := range want {
+		if !found {
+			t.Errorf("missing completion for %q", label)
+		}
+	}
+}
+
 func TestConvertDiagnostic(t *testing.T) {
 	d := validator.Diagnostic{
 		Code:     "DIP001",

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"strings"
 	"testing"
 
 	"go.lsp.dev/protocol"
@@ -299,6 +300,24 @@ func TestFormatNodeConfig_Tool(t *testing.T) {
 	result := formatNodeConfig(n, nil)
 	if result == "" {
 		t.Error("expected non-empty tool config hover")
+	}
+}
+
+func TestFormatToolHoverWithRoutingFields(t *testing.T) {
+	node := &ir.Node{
+		Kind: ir.NodeTool,
+		Config: ir.ToolConfig{
+			Command:       "echo hi",
+			MarkerGrep:    "^pass$",
+			RouteRequired: true,
+			OutputLimit:   8192,
+		},
+	}
+	out := formatNodeConfig(node, &ir.Workflow{})
+	for _, want := range []string{"marker_grep", "route_required", "output_limit"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("hover missing %q. Output:\n%s", want, out)
+		}
 	}
 }
 

--- a/migrate/coverage_test.go
+++ b/migrate/coverage_test.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/2389-research/dippin-lang/ir"
 )
@@ -381,6 +382,51 @@ func TestCompareToolConfigs_DifferentCommand(t *testing.T) {
 	diffs := compareToolConfigs("T", "node:T", tc1, tc2)
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+}
+
+func TestCompareToolConfigsDifferentMarkerGrep(t *testing.T) {
+	a := ir.ToolConfig{MarkerGrep: "^pass$"}
+	b := ir.ToolConfig{MarkerGrep: "^fail$"}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for MarkerGrep, got none")
+	}
+}
+
+func TestCompareToolConfigsDifferentRouteRequired(t *testing.T) {
+	a := ir.ToolConfig{RouteRequired: true}
+	b := ir.ToolConfig{RouteRequired: false}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for RouteRequired, got none")
+	}
+}
+
+func TestCompareToolConfigsDifferentOutputLimit(t *testing.T) {
+	a := ir.ToolConfig{OutputLimit: 1024}
+	b := ir.ToolConfig{OutputLimit: 2048}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for OutputLimit, got none")
+	}
+}
+
+func TestCompareToolConfigsDifferentTimeout(t *testing.T) {
+	a := ir.ToolConfig{Timeout: 30 * time.Second}
+	b := ir.ToolConfig{Timeout: 60 * time.Second}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for Timeout, got none")
+	}
+}
+
+func TestCompareToolConfigsDifferentOutputs(t *testing.T) {
+	a := ir.ToolConfig{Outputs: []string{"pass", "fail"}}
+	b := ir.ToolConfig{Outputs: []string{"green", "red"}}
+	diffs := compareToolConfigs("T", "", a, b)
+	if len(diffs) == 0 {
+		t.Error("expected difference for Outputs, got none")
 	}
 }
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -495,17 +495,52 @@ func applyHumanTimeoutAction(cfg *ir.HumanConfig, attrs map[string]string) error
 
 func buildToolConfig(attrs map[string]string) (ir.ToolConfig, error) {
 	cfg := ir.ToolConfig{}
+	applyToolStringAttrs(&cfg, attrs)
+	if err := applyToolTimeoutAttr(&cfg, attrs); err != nil {
+		return cfg, err
+	}
+	if err := applyToolOutputLimitAttr(&cfg, attrs); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func applyToolStringAttrs(cfg *ir.ToolConfig, attrs map[string]string) {
 	if v, ok := attrs["tool_command"]; ok {
 		cfg.Command = v
 	}
-	if v, ok := attrs["timeout"]; ok {
-		d, err := time.ParseDuration(v)
-		if err != nil {
-			return cfg, fmt.Errorf("invalid timeout %q: %w", v, err)
-		}
-		cfg.Timeout = d
+	if v, ok := attrs["marker_grep"]; ok {
+		cfg.MarkerGrep = v
 	}
-	return cfg, nil
+	if v, ok := attrs["route_required"]; ok {
+		cfg.RouteRequired = (v == "true")
+	}
+}
+
+func applyToolTimeoutAttr(cfg *ir.ToolConfig, attrs map[string]string) error {
+	v, ok := attrs["timeout"]
+	if !ok {
+		return nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fmt.Errorf("invalid timeout %q: %w", v, err)
+	}
+	cfg.Timeout = d
+	return nil
+}
+
+func applyToolOutputLimitAttr(cfg *ir.ToolConfig, attrs map[string]string) error {
+	v, ok := attrs["output_limit"]
+	if !ok {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fmt.Errorf("invalid output_limit %q: %w", v, err)
+	}
+	cfg.OutputLimit = n
+	return nil
 }
 
 func buildParallelConfig(attrs map[string]string) ir.ParallelConfig {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -539,6 +539,9 @@ func applyToolOutputLimitAttr(cfg *ir.ToolConfig, attrs map[string]string) error
 	if err != nil {
 		return fmt.Errorf("invalid output_limit %q: %w", v, err)
 	}
+	if n < 0 {
+		return fmt.Errorf("invalid output_limit %d: must be non-negative", n)
+	}
 	cfg.OutputLimit = n
 	return nil
 }

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2560,3 +2560,14 @@ func TestBuildToolConfigOutputLimitNegative(t *testing.T) {
 		t.Error("expected error for negative output_limit, got nil")
 	}
 }
+
+func TestBuildToolConfigOutputLimitZero(t *testing.T) {
+	attrs := map[string]string{"tool_command": "echo test", "output_limit": "0"}
+	cfg, err := buildToolConfig(attrs)
+	if err != nil {
+		t.Fatalf("unexpected error for output_limit=0: %v", err)
+	}
+	if cfg.OutputLimit != 0 {
+		t.Errorf("OutputLimit = %d, want 0 (engine default)", cfg.OutputLimit)
+	}
+}

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2552,3 +2552,11 @@ func TestBuildToolConfigOutputLimitInvalid(t *testing.T) {
 		t.Error("expected error for non-numeric output_limit, got nil")
 	}
 }
+
+func TestBuildToolConfigOutputLimitNegative(t *testing.T) {
+	attrs := map[string]string{"output_limit": "-1"}
+	_, err := buildToolConfig(attrs)
+	if err == nil {
+		t.Error("expected error for negative output_limit, got nil")
+	}
+}

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -2521,3 +2521,34 @@ func TestMigrate_ManagerLoop_PartialConfigAtStartNode(t *testing.T) {
 		t.Fatalf("Supervise kind = %v, want NodeManagerLoop (partial manager_loop attrs should still resolve)", n)
 	}
 }
+
+func TestBuildToolConfigRoutingAttrs(t *testing.T) {
+	attrs := map[string]string{
+		"tool_command":   "echo hi",
+		"timeout":        "30s",
+		"marker_grep":    "^pass$",
+		"route_required": "true",
+		"output_limit":   "8192",
+	}
+	cfg, err := buildToolConfig(attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MarkerGrep != "^pass$" {
+		t.Errorf("MarkerGrep = %q", cfg.MarkerGrep)
+	}
+	if !cfg.RouteRequired {
+		t.Error("RouteRequired = false")
+	}
+	if cfg.OutputLimit != 8192 {
+		t.Errorf("OutputLimit = %d", cfg.OutputLimit)
+	}
+}
+
+func TestBuildToolConfigOutputLimitInvalid(t *testing.T) {
+	attrs := map[string]string{"output_limit": "not_a_number"}
+	_, err := buildToolConfig(attrs)
+	if err == nil {
+		t.Error("expected error for non-numeric output_limit, got nil")
+	}
+}

--- a/migrate/parity.go
+++ b/migrate/parity.go
@@ -259,10 +259,56 @@ func compareToolConfigs(id, path string, ac ir.ToolConfig, bCfg interface{}) []D
 	if !ok {
 		return []Difference{configMismatchDiff(id, path, "ToolConfig", bCfg)}
 	}
+	var diffs []Difference
+	diffs = append(diffs, compareToolScalars(id, ac, bc)...)
+	diffs = append(diffs, compareToolSlices(id, ac, bc)...)
+	return diffs
+}
+
+func compareToolScalars(id string, ac, bc ir.ToolConfig) []Difference {
+	var diffs []Difference
+	diffs = append(diffs, compareToolCommandAndTimeout(id, ac, bc)...)
+	diffs = append(diffs, compareToolMarkerAndRoute(id, ac, bc)...)
+	diffs = append(diffs, compareToolOutputLimit(id, ac, bc)...)
+	return diffs
+}
+
+func compareToolCommandAndTimeout(id string, ac, bc ir.ToolConfig) []Difference {
+	var diffs []Difference
 	if !promptsEqual(ac.Command, bc.Command) {
-		return []Difference{fieldDiff(id, "command", fmt.Sprintf("node %q command differs", id))}
+		diffs = append(diffs, fieldDiff(id, "command", fmt.Sprintf("node %q command differs", id)))
 	}
-	return nil
+	if ac.Timeout != bc.Timeout {
+		diffs = append(diffs, fieldDiff(id, "timeout", fmt.Sprintf("node %q timeout: %s vs %s", id, ac.Timeout, bc.Timeout)))
+	}
+	return diffs
+}
+
+func compareToolMarkerAndRoute(id string, ac, bc ir.ToolConfig) []Difference {
+	var diffs []Difference
+	if ac.MarkerGrep != bc.MarkerGrep {
+		diffs = append(diffs, fieldDiff(id, "marker_grep", fmt.Sprintf("node %q marker_grep: %q vs %q", id, ac.MarkerGrep, bc.MarkerGrep)))
+	}
+	if ac.RouteRequired != bc.RouteRequired {
+		diffs = append(diffs, fieldDiff(id, "route_required", fmt.Sprintf("node %q route_required: %v vs %v", id, ac.RouteRequired, bc.RouteRequired)))
+	}
+	return diffs
+}
+
+func compareToolOutputLimit(id string, ac, bc ir.ToolConfig) []Difference {
+	var diffs []Difference
+	if ac.OutputLimit != bc.OutputLimit {
+		diffs = append(diffs, fieldDiff(id, "output_limit", fmt.Sprintf("node %q output_limit: %d vs %d", id, ac.OutputLimit, bc.OutputLimit)))
+	}
+	return diffs
+}
+
+func compareToolSlices(id string, ac, bc ir.ToolConfig) []Difference {
+	var diffs []Difference
+	if strings.Join(ac.Outputs, ",") != strings.Join(bc.Outputs, ",") {
+		diffs = append(diffs, fieldDiff(id, "outputs", fmt.Sprintf("node %q outputs: %v vs %v", id, ac.Outputs, bc.Outputs)))
+	}
+	return diffs
 }
 
 func compareHumanConfigs(id, path string, ac ir.HumanConfig, bCfg interface{}) []Difference {

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -423,6 +423,8 @@ func applyToolStringField(cfg *ir.ToolConfig, key, val string) bool {
 		cfg.Command = val
 	case "outputs":
 		cfg.Outputs = splitComma(val)
+	case "marker_grep":
+		cfg.MarkerGrep = val
 	default:
 		return false
 	}

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -404,16 +404,49 @@ func applyHumanInterviewField(cfg *ir.HumanConfig, key, val string) bool {
 
 // applyToolField applies tool-specific configuration fields.
 func (p *Parser) applyToolField(cfg *ir.ToolConfig, key, val string, loc ir.SourceLocation) {
+	if applyToolStringField(cfg, key, val) {
+		return
+	}
+	if applyToolBoolField(cfg, key, val) {
+		return
+	}
+	if p.applyToolParsedField(cfg, key, val, loc) {
+		return
+	}
+	p.emitUnknownFieldHint("tool", key, loc)
+}
+
+// applyToolStringField handles string-valued tool fields. Returns true if handled.
+func applyToolStringField(cfg *ir.ToolConfig, key, val string) bool {
 	switch key {
 	case "command":
 		cfg.Command = val
-	case "timeout":
-		cfg.Timeout = p.parseDuration(val, key, loc)
 	case "outputs":
 		cfg.Outputs = splitComma(val)
 	default:
-		p.emitUnknownFieldHint("tool", key, loc)
+		return false
 	}
+	return true
+}
+
+// applyToolBoolField handles boolean tool fields. Returns true if handled.
+func applyToolBoolField(cfg *ir.ToolConfig, key, val string) bool {
+	switch key {
+	default:
+		_ = val // no bool fields yet; route_required lands in a follow-on task
+		return false
+	}
+}
+
+// applyToolParsedField handles tool fields needing parsing. Returns true if handled.
+func (p *Parser) applyToolParsedField(cfg *ir.ToolConfig, key, val string, loc ir.SourceLocation) bool {
+	switch key {
+	case "timeout":
+		cfg.Timeout = p.parseDuration(val, key, loc)
+	default:
+		return false
+	}
+	return true
 }
 
 // applySubgraphField applies subgraph-specific configuration fields.

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -434,10 +434,12 @@ func applyToolStringField(cfg *ir.ToolConfig, key, val string) bool {
 // applyToolBoolField handles boolean tool fields. Returns true if handled.
 func applyToolBoolField(cfg *ir.ToolConfig, key, val string) bool {
 	switch key {
+	case "route_required":
+		cfg.RouteRequired = (val == "true")
 	default:
-		_ = val // no bool fields yet; route_required lands in a follow-on task
 		return false
 	}
+	return true
 }
 
 // applyToolParsedField handles tool fields needing parsing. Returns true if handled.

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -447,6 +447,14 @@ func (p *Parser) applyToolParsedField(cfg *ir.ToolConfig, key, val string, loc i
 	switch key {
 	case "timeout":
 		cfg.Timeout = p.parseDuration(val, key, loc)
+	case "output_limit":
+		n := p.parseInt(val, key, loc)
+		if n < 0 {
+			p.diagnostics = append(p.diagnostics, fmt.Sprintf(
+				"invalid output_limit %d at %d:%d (must be non-negative)", n, loc.Line, loc.Column))
+			return true
+		}
+		cfg.OutputLimit = n
 	default:
 		return false
 	}

--- a/parser/parse_tool_test.go
+++ b/parser/parse_tool_test.go
@@ -55,3 +55,23 @@ func TestParseToolMarkerGrepRegexMetachars(t *testing.T) {
 		t.Errorf("MarkerGrep lost metachars: %q", cfg.MarkerGrep)
 	}
 }
+
+func TestParseToolRouteRequired(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    route_required: true")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !cfg.RouteRequired {
+		t.Error("RouteRequired = false, want true")
+	}
+}
+
+func TestParseToolRouteRequiredExplicitFalse(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    route_required: false")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.RouteRequired {
+		t.Error("RouteRequired = true, want false")
+	}
+}

--- a/parser/parse_tool_test.go
+++ b/parser/parse_tool_test.go
@@ -75,3 +75,50 @@ func TestParseToolRouteRequiredExplicitFalse(t *testing.T) {
 		t.Error("RouteRequired = true, want false")
 	}
 }
+
+func TestParseToolOutputLimit(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    output_limit: 1048576")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.OutputLimit != 1048576 {
+		t.Errorf("OutputLimit = %d, want 1048576", cfg.OutputLimit)
+	}
+}
+
+func TestParseToolOutputLimitNegative(t *testing.T) {
+	_, diags := parseToolFixture(t, "    output_limit: -1")
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostic for negative output_limit, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d, "output_limit") && strings.Contains(d, "non-negative") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'non-negative' diagnostic, got: %v", diags)
+	}
+}
+
+func TestParseToolOutputLimitNonNumeric(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    output_limit: abc")
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostic from parseInt, got none")
+	}
+	if cfg.OutputLimit != 0 {
+		t.Errorf("OutputLimit should default to 0 on parse error, got %d", cfg.OutputLimit)
+	}
+}
+
+func TestParseToolAllRoutingFields(t *testing.T) {
+	body := "    marker_grep: pass\n    route_required: true\n    output_limit: 65536"
+	cfg, diags := parseToolFixture(t, body)
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.MarkerGrep != "pass" || !cfg.RouteRequired || cfg.OutputLimit != 65536 {
+		t.Errorf("got %+v", cfg)
+	}
+}

--- a/parser/parse_tool_test.go
+++ b/parser/parse_tool_test.go
@@ -1,0 +1,57 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// parseToolFixture parses a minimal workflow with a single tool node and returns
+// the parsed ToolConfig plus any diagnostics. Tests must parse real .dip text —
+// hand-building ir.ToolConfig bypasses the parser and masks bugs (per CLAUDE.md).
+func parseToolFixture(t *testing.T, body string) (ir.ToolConfig, []string) {
+	t.Helper()
+	src := "workflow W\n  start: T\n  exit: T\n\n  tool T\n" + body + "\n\n  edges\n    T -> T\n"
+	p := NewParser(src, "test.dip")
+	wf, _ := p.Parse()
+	if len(wf.Nodes) == 0 {
+		t.Fatalf("no nodes parsed; diagnostics: %v", p.Diagnostics())
+	}
+	cfg, ok := wf.Nodes[0].Config.(ir.ToolConfig)
+	if !ok {
+		t.Fatalf("node 0 is not a tool: %T", wf.Nodes[0].Config)
+	}
+	return cfg, p.Diagnostics()
+}
+
+func TestParseToolMarkerGrep(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    marker_grep: '^(green|red)$'")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.MarkerGrep != "^(green|red)$" {
+		t.Errorf("MarkerGrep = %q, want %q", cfg.MarkerGrep, "^(green|red)$")
+	}
+}
+
+func TestParseToolMarkerGrepUnquoted(t *testing.T) {
+	cfg, diags := parseToolFixture(t, "    marker_grep: tests_pass")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if cfg.MarkerGrep != "tests_pass" {
+		t.Errorf("MarkerGrep = %q, want %q", cfg.MarkerGrep, "tests_pass")
+	}
+}
+
+func TestParseToolMarkerGrepRegexMetachars(t *testing.T) {
+	// Stored verbatim — dippin does not validate the regex (tracker does).
+	cfg, diags := parseToolFixture(t, `    marker_grep: '^\[(PASS|FAIL)\]\s+\d+$'`)
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !strings.Contains(cfg.MarkerGrep, `\[`) {
+		t.Errorf("MarkerGrep lost metachars: %q", cfg.MarkerGrep)
+	}
+}

--- a/parser/parse_tool_test.go
+++ b/parser/parse_tool_test.go
@@ -26,7 +26,7 @@ func parseToolFixture(t *testing.T, body string) (ir.ToolConfig, []string) {
 }
 
 func TestParseToolMarkerGrep(t *testing.T) {
-	cfg, diags := parseToolFixture(t, "    marker_grep: '^(green|red)$'")
+	cfg, diags := parseToolFixture(t, `    marker_grep: "^(green|red)$"`)
 	if len(diags) != 0 {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
@@ -47,7 +47,7 @@ func TestParseToolMarkerGrepUnquoted(t *testing.T) {
 
 func TestParseToolMarkerGrepRegexMetachars(t *testing.T) {
 	// Stored verbatim — dippin does not validate the regex (tracker does).
-	cfg, diags := parseToolFixture(t, `    marker_grep: '^\[(PASS|FAIL)\]\s+\d+$'`)
+	cfg, diags := parseToolFixture(t, `    marker_grep: "^\[(PASS|FAIL)\]\s+\d+$"`)
 	if len(diags) != 0 {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -232,30 +232,9 @@ func (p *Parser) consumeUntilNewline() {
 
 // unquoteRaw unquotes a double-quoted string, handling basic escape sequences.
 func unquoteRaw(raw string) string {
-	if len(raw) < 2 {
+	if len(raw) < 2 || raw[0] != '"' || raw[len(raw)-1] != '"' {
 		return raw
 	}
-	if isDoubleQuoted(raw) {
-		return unquoteDouble(raw)
-	}
-	if isSingleQuoted(raw) {
-		return raw[1 : len(raw)-1]
-	}
-	return raw
-}
-
-// isDoubleQuoted checks if a string is wrapped in double quotes.
-func isDoubleQuoted(s string) bool {
-	return len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"'
-}
-
-// isSingleQuoted checks if a string is wrapped in single quotes.
-func isSingleQuoted(s string) bool {
-	return len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\''
-}
-
-// unquoteDouble removes double quotes and processes escape sequences.
-func unquoteDouble(raw string) string {
 	unquoted := raw[1 : len(raw)-1]
 	unquoted = strings.ReplaceAll(unquoted, `\"`, `"`)
 	unquoted = strings.ReplaceAll(unquoted, `\\`, `\`)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -32,6 +32,11 @@ func (p *Parser) Parse() (*ir.Workflow, error) {
 	return p.workflow, nil
 }
 
+// Diagnostics returns the accumulated diagnostic messages.
+func (p *Parser) Diagnostics() []string {
+	return p.diagnostics
+}
+
 // parseTopLevel consumes top-level tokens looking for workflow declarations.
 func (p *Parser) parseTopLevel() {
 	for p.lexer.PeekToken().Type != TokenEOF {
@@ -227,9 +232,30 @@ func (p *Parser) consumeUntilNewline() {
 
 // unquoteRaw unquotes a double-quoted string, handling basic escape sequences.
 func unquoteRaw(raw string) string {
-	if len(raw) < 2 || raw[0] != '"' || raw[len(raw)-1] != '"' {
+	if len(raw) < 2 {
 		return raw
 	}
+	if isDoubleQuoted(raw) {
+		return unquoteDouble(raw)
+	}
+	if isSingleQuoted(raw) {
+		return raw[1 : len(raw)-1]
+	}
+	return raw
+}
+
+// isDoubleQuoted checks if a string is wrapped in double quotes.
+func isDoubleQuoted(s string) bool {
+	return len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"'
+}
+
+// isSingleQuoted checks if a string is wrapped in single quotes.
+func isSingleQuoted(s string) bool {
+	return len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\''
+}
+
+// unquoteDouble removes double quotes and processes escape sequences.
+func unquoteDouble(raw string) string {
 	unquoted := raw[1 : len(raw)-1]
 	unquoted = strings.ReplaceAll(unquoted, `\"`, `"`)
 	unquoted = strings.ReplaceAll(unquoted, `\\`, `\`)

--- a/parser/testdata/all_features.dip
+++ b/parser/testdata/all_features.dip
@@ -45,6 +45,15 @@ workflow all_features
 
   fan_in join <- worker_a, worker_b
 
+  tool Check
+    outputs: pass, fail
+    marker_grep: "^(pass|fail)$"
+    route_required: true
+    output_limit: 65536
+    timeout: 30s
+    command:
+      echo pass
+
   agent Done
     prompt: "Finished."
 
@@ -63,4 +72,5 @@ workflow all_features
     Ask -> Review
     Review -> Coder
     Coder -> split
-    join -> Done
+    join -> Check
+    Check -> Done

--- a/site/content/blog/whats-new-v028.md
+++ b/site/content/blog/whats-new-v028.md
@@ -1,0 +1,50 @@
+---
+title: "What's New in Dippin v0.28"
+date: "2026-05-19"
+description: "Typed tool routing — marker_grep, route_required, and output_limit close a parser/runtime parity gap with tracker's TRK101."
+tagStyle: "release"
+tagLabel: "RELEASE"
+category: "Releases"
+readTime: "3 min read"
+related:
+  - url: "whats-new-v027.html"
+    title: "What's New in Dippin v0.27"
+    summary: "Model catalog refresh — 11+ new IDs across six providers, seven price corrections, and a retirement calendar worth pinning somewhere."
+  - url: "whats-new-v026.html"
+    title: "What's New in v0.26"
+    summary: "The workflow `requires:` keyword — declare environmental dependencies so runtimes can preflight."
+---
+
+Issue [#39](https://github.com/2389-research/dippin-lang/issues/39) closes a parser gap. Tracker's runtime already supported `marker_grep`, `route_required`, and `output_limit` for stdout-driven routing, but `.dip` source couldn't reach them — authors following tracker's TRK101 lint recommendation hit `unrecognized tool field "marker_grep"` from dippin instead of a cleaner pipeline.
+
+## Three new tool-node fields
+
+```dippin
+tool RunTests
+  marker_grep: "^(tests_pass|tests_fail)$"
+  route_required: true
+  output_limit: 65536
+  timeout: 2m
+  command:
+    go test ./... 2>&1
+```
+
+- **`marker_grep`** — regex matched against captured stdout. The last match populates `ctx.tool_marker`, so routing edges can reference it instead of parsing raw `ctx.tool_stdout`.
+- **`route_required`** — when true, the node fails (`EventToolRouteMissing`) if the command emits no `_TRACKER_ROUTE=<value>` sentinel line. The matched value populates `ctx.tool_route`.
+- **`output_limit`** — per-node override of the engine's captured-stdout byte cap, for tools that need a larger or smaller window than the global default.
+
+## Why it matters
+
+Without these fields, authors working around tracker's TRK101 truncation foot-gun had to enumerate every possible stdout marker as a conditional edge. That made `dippin coverage` flag false-positive non-exhaustive routing on nodes that were actually fully covered. Typed `marker_grep` is the canonical fix; now dippin accepts it.
+
+## Runtime requirement
+
+These fields forward through DOT export to tracker. Routing semantics require the matching `extractToolAttrs` change in tracker; the dippin v0.28 release pairs with a tracker version that pins `dippin-lang@v0.28.0`. Older tracker versions silently ignore the new attrs.
+
+## Coming next
+
+- **[#42](https://github.com/2389-research/dippin-lang/issues/42)** — DIP138 lint, recommending `marker_grep` when a tool node parses stdout for routing without declaring it.
+- **[#43](https://github.com/2389-research/dippin-lang/issues/43)** — normalize boolean parsing (`true` / `yes` / `1` accepted consistently).
+- **[#44](https://github.com/2389-research/dippin-lang/issues/44)** — close the existing `outputs` DOT round-trip gap.
+
+Full changelog: [CHANGELOG.md](https://github.com/2389-research/dippin-lang/blob/main/CHANGELOG.md).

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,31 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.28.0] — 2026-05-19
+
+Tool-node routing fields land in the parser and IR. Authors following tracker's `TRK101` recommendation can now declare `marker_grep`, `route_required`, and `output_limit` directly in `.dip` source. Closes [#39](https://github.com/2389-research/dippin-lang/issues/39).
+
+### Added
+
+- `tool.marker_grep` — regex matched line-by-line against captured stdout; populates `ctx.tool_marker` at runtime.
+- `tool.route_required` — boolean; when true, the node fails with `EventToolRouteMissing` if the command emits no `_TRACKER_ROUTE=<value>` sentinel line.
+- `tool.output_limit` — positive integer (bytes) overriding the engine default stdout tail-window for this node.
+- Reserved context variables: `ctx.tool_marker`, `ctx.tool_route`.
+
+### Changed
+
+- `migrate/parity.go compareToolConfigs` now compares all `ToolConfig` fields. Pre-existing `Timeout` / `Outputs` parity gaps backfilled.
+
+### Runtime requirement
+
+These fields pass through DOT export to tracker. Routing semantics require tracker to ship the matching `extractToolAttrs` change; see issue [#39](https://github.com/2389-research/dippin-lang/issues/39) for details.
+
+### Docs
+
+- New blog post: ["What's New in Dippin v0.28"](blog/whats-new-v028.md).
+- `docs/nodes.md` gains a "Best" subsection in Markers and Verbose Output demonstrating `marker_grep`.
+- Hosted skill (`site/static/skill.md`) updated with new context variables and best-practice bullet.
+
 ## [v0.27.0] — 2026-05-18
 
 Model catalog and pricing verification pass against canonical provider docs. `Last verified: 2026-05-18` in `validator/lint_model.go` and `cost/pricing.go`. No breaking changes to public APIs — but the cost table values move and the catalog accepts new IDs, so downstream tooling that snapshots dippin's data should re-snapshot.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -12,7 +12,7 @@ Tool-node routing fields land in the parser and IR. Authors following tracker's 
 
 - `tool.marker_grep` — regex matched line-by-line against captured stdout; populates `ctx.tool_marker` at runtime.
 - `tool.route_required` — boolean; when true, the node fails with `EventToolRouteMissing` if the command emits no `_TRACKER_ROUTE=<value>` sentinel line.
-- `tool.output_limit` — positive integer (bytes) overriding the engine default stdout tail-window for this node.
+- `tool.output_limit` — non-negative integer (bytes); 0 uses the engine default stdout tail-window. `dippin fmt` omits the field when the value is zero.
 - Reserved context variables: `ctx.tool_marker`, `ctx.tool_route`.
 
 ### Changed
@@ -25,7 +25,7 @@ These fields pass through DOT export to tracker. Routing semantics require track
 
 ### Docs
 
-- New blog post: ["What's New in Dippin v0.28"](blog/whats-new-v028.md).
+- New blog post: [`site/content/blog/whats-new-v028.md`](site/content/blog/whats-new-v028.md).
 - `docs/nodes.md` gains a "Best" subsection in Markers and Verbose Output demonstrating `marker_grep`.
 - Hosted skill (`site/static/skill.md`) updated with new context variables and best-practice bullet.
 

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -176,15 +176,17 @@ Human nodes pause execution and wait for human input. Two modes: `choice` (prede
 
 Tool nodes execute shell commands. The command's stdout is captured as `ctx.tool_stdout` and stderr as `ctx.tool_stderr`. Always include a `timeout`.
 
-```
+```dippin
   tool RunTests
     label: "Run test suite"
+    outputs: tests_pass, tests_fail
+    marker_grep: "^(tests_pass|tests_fail)$"
     timeout: 60s
     command:
-      #!/bin/sh
-      set -eu
-      pytest --tb=short 2>&1
+      pytest --tb=short
 ```
+
+Declare `marker_grep` for typed routing (populates `ctx.tool_marker`); `route_required: true` makes a missing `_TRACKER_ROUTE=` sentinel fail the node; `output_limit` overrides the captured-stdout byte cap.
 
 ### parallel
 

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -121,7 +121,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `outputs` | CSV | Possible stdout values for condition checks |
 | `marker_grep` | string | Regex matched against stdout; sets `ctx.tool_marker`. Tracker validates at runtime. |
 | `route_required` | bool | When true, fails the node if no `_TRACKER_ROUTE=<value>` sentinel line is emitted. |
-| `output_limit` | int | Per-node stdout byte cap (positive integer); omit to use engine default. |
+| `output_limit` | int | Per-node stdout byte cap (non-negative integer); 0 (or omitted) uses the engine default. |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -119,6 +119,9 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 | `command` | multiline | Shell command. Supports pipes, here-docs, case/esac. |
 | `timeout` | duration | **Required** (DIP111). e.g. `30s`, `5m` |
 | `outputs` | CSV | Possible stdout values for condition checks |
+| `marker_grep` | string | Regex matched against stdout; sets `ctx.tool_marker`. Tracker validates at runtime. |
+| `route_required` | bool | When true, fails the node if no `_TRACKER_ROUTE=<value>` sentinel line is emitted. |
+| `output_limit` | int | Per-node stdout byte cap (positive integer); omit to use engine default. |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -411,6 +414,7 @@ The primary loop for authoring .dip files:
 ## Best Practices
 
 - **Always set `timeout`** on tool nodes — no timeout means infinite hang
+- **Prefer `marker_grep:`** over regexing `ctx.tool_stdout` in edges when the runtime supports it. Typed routing leaves stdout free for diagnostic output and avoids truncation foot-guns.
 - **Use `auto_status: true`** on agent nodes that drive conditional routing via `ctx.outcome`
 - **Use `success`/`fail`** as condition values — the linter recognizes these as exhaustive
 - **Mark back-edges `restart: true`** — loops without it trigger DIP005
@@ -464,6 +468,8 @@ The primary loop for authoring .dip files:
 | `ctx.outcome` | `auto_status: true` on agent, or tool exit status |
 | `ctx.human_response` | Freeform human input |
 | `ctx.tool_stdout` | Tool command stdout |
+| `ctx.tool_marker` | Tool stdout regex match (when `marker_grep` declared) |
+| `ctx.tool_route` | `_TRACKER_ROUTE=<value>` sentinel (when `route_required: true`) |
 | `ctx.preferred_label` | Human choice selection (maps to edge label) |
 | `ctx.interview_answers` | Interview mode answers (via `answers_key`) |
 | `params.<key>` | Parent subgraph params |

--- a/validator/lint_condition_types.go
+++ b/validator/lint_condition_types.go
@@ -14,6 +14,7 @@ var reservedVarPrefixes = []string{
 	"ctx.status",
 	"ctx.tool_stdout",
 	"ctx.tool_stderr",
+	"ctx.tool_marker",
 	"ctx.internal.",
 	"graph.",
 	"params.",

--- a/validator/lint_condition_types.go
+++ b/validator/lint_condition_types.go
@@ -15,6 +15,7 @@ var reservedVarPrefixes = []string{
 	"ctx.tool_stdout",
 	"ctx.tool_stderr",
 	"ctx.tool_marker",
+	"ctx.tool_route",
 	"ctx.internal.",
 	"graph.",
 	"params.",


### PR DESCRIPTION
## Summary

Closes #39. Adds three new tool-node fields to dippin-lang so authors following tracker's `TRK101` advice stop hitting `unrecognized tool field` parse errors:

- **`marker_grep: '<regex>'`** — regex matched line-by-line against captured stdout; populates `ctx.tool_marker`.
- **`route_required: true`** — when true, the node fails with `EventToolRouteMissing` if the command emits no `_TRACKER_ROUTE=<value>` sentinel line; populates `ctx.tool_route`.
- **`output_limit: <bytes>`** — per-node stdout tail-window override; positive int.

Strings pass through verbatim — dippin does not interpret routing semantics; tracker does. Target release: **v0.28.0**.

## What's in the PR

- IR field additions on `ir.ToolConfig`
- Parser split into `applyToolString/Bool/ParsedField` (cyclo budget) + three new cases
- Formatter emits non-default values in canonical order (`outputs → marker_grep → route_required → output_limit → timeout → ...`)
- DOT export emits the three attrs with the same emit-when-set contract
- `migrate/migrate.go buildToolConfig` reads them back; `migrate/parity.go compareToolConfigs` extended to all fields (backfills pre-existing Timeout/Outputs parity gap)
- LSP completion entries + `formatToolHover` extraction
- VSCode tmLanguage keyword regex updated
- New `examples/marker_routing.dip` (lint-clean, picked up by `TestLintExamples`)
- `ctx.tool_marker` and `ctx.tool_route` reserved in validator + docs
- Docs: `docs/nodes.md`, `docs/llm-reference.md`, `docs/context.md`, `docs/edges.md`, `docs/validation.md`
- Site: `site/static/skill.md`, `site/content/language.md`, new blog post `site/content/blog/whats-new-v028.md`
- CHANGELOG v0.28.0 entry

Spec and plan land on `main` as separate docs commits (already on the base branch); this PR is just the implementation.

## Follow-up issues (deferred from spec)

- **#42** — Lint suppression for `marker_grep` / DIP138
- **#43** — `parseBoolAttr` normalization across all four bool fields
- **#44** — Close `ToolConfig.Outputs` DOT round-trip gap

## Known minor observations (non-blocking)

- `migrate` doesn't read `outputs` from DOT (pre-existing, that's #44).
- `migrate/applyToolOutputLimitAttr` doesn't reject negatives like the parser does (asymmetric; not a correctness issue since `≤0` = engine default).
- Commit order: the formatter commit ended up at the top after a rebase recovery. All changes present; chronology is cosmetic.

## Tracker side (separate PR, separate repo)

`tracker/pipeline/dippin_adapter.go extractToolAttrs` needs to forward the three new fields once dippin v0.28.0 is tagged. Sketch is in the spec's "Tracker-side sketch" section.

## Test plan

- [x] `just check` clean (build, vet, golangci-lint, fmt, test-race, releasecheck, complexity, validate-examples, pack-examples, tree-sitter-test)
- [x] Parser tests cover marker_grep (quoted/unquoted/metachars), route_required (true/false), output_limit (valid/negative/non-numeric/all-three)
- [x] Formatter round-trip via extended `all_features.dip`
- [x] DOT export presence + omission tests
- [x] Migrate read-back + parity mismatch tests for all six ToolConfig fields
- [x] LSP completion + hover tests
- [x] `TestLintExamples` lints `examples/marker_routing.dip` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three tool-node routing controls and two reserved runtime context variables for marker-driven routing and per-node output limits.

* **Documentation**
  * Updated language reference, examples, best-practices, validator docs, and published v0.28 blog and changelog; added a marker-routing example workflow.

* **Chores**
  * Migration/parity behavior and DOT/export semantics updated; LSP/editor completions and hovers extended; validator reserved-vars list expanded.

* **Tests**
  * Added parser, migrate, export, LSP, and formatter tests covering the new routing fields and behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->