### PR TITLE
v0.29.0: tool-routing follow-ups (#42 #43 #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.29.0] — 2026-05-19
+
+Three follow-ups to v0.28.0's tool-routing surface. Closes [#42](https://github.com/2389-research/dippin-lang/issues/42), [#43](https://github.com/2389-research/dippin-lang/issues/43), [#44](https://github.com/2389-research/dippin-lang/issues/44).
+
+### Added
+
+- `DIP138` reserved for a future advisory: "tool node routes on stdout but declares no `marker_grep` / `outputs`". Code + description + explanation entry only; no firing logic in this release.
+- `outputs:` now survives a `.dip → DOT → .dip` round-trip. DOT export emits `outputs="a,b,c"` on tool nodes that declare outputs, and `dippin migrate dot→.dip` reads it back.
+
+### Changed
+
+- `DIP101` / `DIP102` no longer fire on tool nodes that declare `marker_grep:`. Those nodes route via the typed `ctx.tool_marker` channel — outgoing conditional edges on them are intentional routing, not unsafe reachability. Removes the false-positive coverage hit that tracker's `TRK101` option (d) guidance triggered.
+- Parser bool fields (`goal_gate`, `auto_status`, `cache_tools`, `route_required`) now accept `true/false`, `1/0`, `yes/no`, `on/off` case-insensitively via a new shared `parseBoolAttr` helper. Anything else now produces a parse diagnostic instead of silently coercing to `false`. The migrate (DOT-input) path keeps strict equality since DOT attrs are machine-emitted.
+
+### Runtime requirement
+
+None. All changes are dippin-internal; tracker is unaffected.
+
+### Docs
+
+- `docs/nodes.md` "Markers and Verbose Output" notes the DIP101/DIP102 suppression and the accepted boolean forms.
+- `docs/llm-reference.md` common-mistakes table cross-references the suppression behavior.
+- Hosted skill (`site/static/skill.md`) updated to match.
+
 ## [v0.28.0] — 2026-05-19
 
 Tool-node routing fields land in the parser and IR. Authors following tracker's `TRK101` recommendation can now declare `marker_grep`, `route_required`, and `output_limit` directly in `.dip` source. Closes [#39](https://github.com/2389-research/dippin-lang/issues/39).

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -86,6 +86,8 @@ when not <expr>
 | 7 | Exhaustive conditions flagged | `ctx.outcome = success` + `ctx.outcome = fail` is exhaustive — DIP101/DIP102 are auto-suppressed. No need to add a fallback edge. |
 | 8 | Verbose output sharing stdout with routing marker | When a tool's stdout drives routing, redirect verbose output to a sibling file and `printf` only the marker. Otherwise large output (test logs, stack traces) can crowd out the marker under runtime stdout caps. See `nodes.md` → Tool Nodes → Markers and Verbose Output. |
 | 9 | Hand-parsing tool stdout for routing | Use `marker_grep: "<regex>"` (and optionally `route_required: true`) instead of regexing `ctx.tool_stdout` in edge conditions. Mirrors tracker's TRK101 recommendation; populates `ctx.tool_marker` directly. |
+| 10 | DIP101/DIP102 flagged on marker-routed tool node | If the tool already declares `marker_grep:`, the validator treats it as a safe routing source and suppresses both warnings. If you're still seeing them, the source node isn't a `tool`, or `marker_grep` is empty. |
+| 11 | Boolean field rejected as invalid | Boolean fields (`goal_gate`, `auto_status`, `cache_tools`, `route_required`) accept `true/false`, `1/0`, `yes/no`, `on/off`, case-insensitive. Anything else is a parse error — pre-v0.29 silently coerced unknown values to `false`. |
 
 ---
 
@@ -95,6 +97,8 @@ When outgoing edges from a node cover all possible values, DIP101 and DIP102 war
 
 - `ctx.outcome`: `{success, fail}` or `{success, failure}`
 - `outcome`: `{success, fail}` or `{success, failure}`
+
+Tool nodes that declare `marker_grep:` are also treated as exhaustive (typed routing via `ctx.tool_marker`).
 
 This means the common pattern below is valid with zero warnings:
 
@@ -587,7 +591,8 @@ The primary loop for authoring .dip files:
 ## Best Practices
 
 - **Always set `timeout`** on tool nodes — no timeout means infinite hang
-- **Prefer `marker_grep:`** over regexing `ctx.tool_stdout` in edges when the runtime supports it. Typed routing leaves stdout free for diagnostic output and avoids truncation foot-guns.
+- **Prefer `marker_grep:`** over regexing `ctx.tool_stdout` in edges when the runtime supports it. Typed routing leaves stdout free for diagnostic output and avoids truncation foot-guns. Declaring `marker_grep:` also suppresses DIP101/DIP102 on the source node — the validator treats it as a safe typed-routing channel.
+- **Boolean fields** (`goal_gate`, `auto_status`, `cache_tools`, `route_required`) accept `true/false`, `1/0`, `yes/no`, `on/off` case-insensitively. Anything else is a parse diagnostic.
 - **Use `auto_status: true`** on agent nodes that drive conditional routing via `ctx.outcome`
 - **Use `success`/`fail`** as condition values — the linter recognizes these as exhaustive
 - **Mark back-edges `restart: true`** — loops without it trigger DIP005

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -84,6 +84,8 @@ when not <expr>
 | 7 | Exhaustive conditions flagged | `ctx.outcome = success` + `ctx.outcome = fail` is exhaustive — DIP101/DIP102 are auto-suppressed. No need to add a fallback edge. |
 | 8 | Verbose output sharing stdout with routing marker | When a tool's stdout drives routing, redirect verbose output to a sibling file and `printf` only the marker. Otherwise large output (test logs, stack traces) can crowd out the marker under runtime stdout caps. See `nodes.md` → Tool Nodes → Markers and Verbose Output. |
 | 9 | Hand-parsing tool stdout for routing | Use `marker_grep: "<regex>"` (and optionally `route_required: true`) instead of regexing `ctx.tool_stdout` in edge conditions. Mirrors tracker's TRK101 recommendation; populates `ctx.tool_marker` directly. |
+| 10 | DIP101/DIP102 flagged on marker-routed tool node | If the tool already declares `marker_grep:`, the validator treats it as a safe routing source and suppresses both warnings. If you're still seeing them, the source node isn't a `tool`, or `marker_grep` is empty. |
+| 11 | Boolean field rejected as invalid | Boolean fields (`goal_gate`, `auto_status`, `cache_tools`, `route_required`) accept `true/false`, `1/0`, `yes/no`, `on/off`, case-insensitive. Anything else is a parse error — pre-v0.29 silently coerced unknown values to `false`. |
 
 ---
 
@@ -93,6 +95,8 @@ When outgoing edges from a node cover all possible values, DIP101 and DIP102 war
 
 - `ctx.outcome`: `{success, fail}` or `{success, failure}`
 - `outcome`: `{success, fail}` or `{success, failure}`
+
+Tool nodes that declare `marker_grep:` are also treated as exhaustive (typed routing via `ctx.tool_marker`).
 
 This means the common pattern below is valid with zero warnings:
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -325,6 +325,14 @@ The same pattern applies to any tool whose output drives routing — build comma
 
 When `marker_grep` is declared, the runtime populates `ctx.tool_marker` and routing edges can reference it instead of `ctx.tool_stdout`. `route_required: true` makes the absence of any match a hard failure. `output_limit` overrides the per-node stdout cap when the command genuinely needs a larger window.
 
+**Lint:** A tool node that declares `marker_grep:` is treated as a "safe routing source" — outgoing conditional edges that test `ctx.tool_marker` no longer trip `DIP101` (unreachable target) or `DIP102` (no default edge), even with a single conditional edge. The declaration is an explicit author signal that routing is typed.
+
+---
+
+## Boolean fields
+
+`goal_gate`, `auto_status`, `cache_tools`, and `route_required` all accept `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`, case-insensitively. Any other value emits a parse diagnostic — invalid bools no longer silently coerce to `false`.
+
 ---
 
 ## Parallel Nodes

--- a/export/dot.go
+++ b/export/dot.go
@@ -312,8 +312,17 @@ func applyToolSemanticAttrs(attrs map[string]string, cfg ir.ToolConfig) {
 	if cfg.RouteRequired {
 		attrs["route_required"] = "true"
 	}
+	applyToolOutputsAttrs(attrs, cfg)
+}
+
+// applyToolOutputsAttrs writes the output_limit and outputs DOT attrs.
+// Extracted from applyToolSemanticAttrs to keep cyclomatic complexity ≤ 5.
+func applyToolOutputsAttrs(attrs map[string]string, cfg ir.ToolConfig) {
 	if cfg.OutputLimit > 0 {
 		attrs["output_limit"] = strconv.Itoa(cfg.OutputLimit)
+	}
+	if len(cfg.Outputs) > 0 {
+		attrs["outputs"] = strings.Join(cfg.Outputs, ",")
 	}
 }
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -515,6 +515,9 @@ func applyToolStringAttrs(cfg *ir.ToolConfig, attrs map[string]string) {
 	if v, ok := attrs["route_required"]; ok {
 		cfg.RouteRequired = (v == "true")
 	}
+	if v, ok := attrs["outputs"]; ok {
+		cfg.Outputs = splitComma(v)
+	}
 }
 
 func applyToolTimeoutAttr(cfg *ir.ToolConfig, attrs map[string]string) error {

--- a/migrate/roundtrip_test.go
+++ b/migrate/roundtrip_test.go
@@ -127,6 +127,65 @@ func extractDOTAttr(dot, key string) string {
 	return dot[start : start+end]
 }
 
+// TestRoundtripPreservesToolOutputs verifies that ToolConfig.Outputs
+// survives a .dip → DOT → .dip migration. Regression test for the
+// silent-drop bug in v0.28.0 where applyToolSemanticAttrs never
+// emitted the outputs DOT attr.
+func TestRoundtripPreservesToolOutputs(t *testing.T) {
+	src := `workflow MarkerRouting
+  start: S
+  exit: D
+  agent S
+    prompt: "start"
+  tool T
+    command: echo hi
+    outputs: tests_green, tests_red
+    marker_grep: "^(tests_green|tests_red)$"
+  agent D
+    prompt: "done"
+  edges
+    S -> T
+    T -> D when ctx.tool_marker = tests_green
+    T -> D when ctx.tool_marker = tests_red
+`
+	w1, err := dipparser.NewParser(src, "rt.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dot := export.ExportDOT(w1, export.ExportOptions{IncludePrompts: true})
+
+	// DOT must contain outputs attr with comma-joined values.
+	if !strings.Contains(dot, `outputs="tests_green,tests_red"`) {
+		t.Errorf("DOT output missing outputs attr; got:\n%s", dot)
+	}
+
+	w2, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("migrate: %v\nDOT:\n%s", err, dot)
+	}
+
+	var got []string
+	for _, n := range w2.Nodes {
+		if n.ID != "T" {
+			continue
+		}
+		cfg, ok := n.Config.(ir.ToolConfig)
+		if !ok {
+			t.Fatalf("node T config is %T, want ir.ToolConfig", n.Config)
+		}
+		got = cfg.Outputs
+	}
+	want := []string{"tests_green", "tests_red"}
+	if len(got) != len(want) {
+		t.Fatalf("Outputs after round-trip = %v, want %v; DOT:\n%s", got, want, dot)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Outputs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // TestRoundTripToolSafetyDefaults verifies that tool-safety defaults
 // round-trip losslessly through parse → ExportDOT → Migrate.
 func TestRoundTripToolSafetyDefaults(t *testing.T) {

--- a/parser/parse_bool_test.go
+++ b/parser/parse_bool_test.go
@@ -1,0 +1,131 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// TestParseBoolAttrFields verifies that all four bool fields
+// (goal_gate, auto_status, cache_tools, route_required) accept
+// the canonical truthy/falsy forms case-insensitively, and that
+// any other value produces a parse diagnostic.
+func TestParseBoolAttrFields(t *testing.T) {
+	cases := []struct {
+		name        string
+		field       string // "goal_gate" | "auto_status" | "cache_tools" | "route_required"
+		val         string
+		wantBool    bool
+		wantDiagSub string // substring expected in diagnostics; "" means no diag
+	}{
+		// agent fields — goal_gate
+		{"goal_gate=true", "goal_gate", "true", true, ""},
+		{"goal_gate=FALSE", "goal_gate", "FALSE", false, ""},
+		{"goal_gate=yes", "goal_gate", "yes", true, ""},
+		{"goal_gate=no", "goal_gate", "no", false, ""},
+		{"goal_gate=1", "goal_gate", "1", true, ""},
+		{"goal_gate=0", "goal_gate", "0", false, ""},
+		{"goal_gate=on", "goal_gate", "on", true, ""},
+		{"goal_gate=Off", "goal_gate", "Off", false, ""},
+		{"goal_gate=maybe", "goal_gate", "maybe", false, "invalid boolean"},
+		{"goal_gate=2", "goal_gate", "2", false, "invalid boolean"},
+
+		// agent fields — auto_status
+		{"auto_status=yes", "auto_status", "yes", true, ""},
+		{"auto_status=garbage", "auto_status", "garbage", false, "invalid boolean"},
+
+		// agent fields — cache_tools
+		{"cache_tools=on", "cache_tools", "on", true, ""},
+		{"cache_tools=nope", "cache_tools", "nope", false, "invalid boolean"},
+
+		// tool field — route_required
+		{"route_required=YES", "route_required", "YES", true, ""},
+		{"route_required=true", "route_required", "true", true, ""},
+		{"route_required=False", "route_required", "False", false, ""},
+		{"route_required=maybe", "route_required", "maybe", false, "invalid boolean"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := buildBoolFieldDip(tc.field, tc.val)
+			p := NewParser(src, "test.dip")
+			w, _ := p.Parse()
+			diags := p.Diagnostics()
+			got := readBoolField(t, w, tc.field)
+			if got != tc.wantBool {
+				t.Errorf("field %s = %q: got %v, want %v", tc.field, tc.val, got, tc.wantBool)
+			}
+			joined := strings.Join(diags, "\n")
+			if tc.wantDiagSub == "" {
+				if joined != "" {
+					t.Errorf("expected no diagnostics, got: %s", joined)
+				}
+				return
+			}
+			if !strings.Contains(joined, tc.wantDiagSub) {
+				t.Errorf("expected diagnostic containing %q, got: %s", tc.wantDiagSub, joined)
+			}
+		})
+	}
+}
+
+// buildBoolFieldDip produces a minimal valid .dip workflow that exercises
+// one of the four bool fields. The agent / tool node is the start node so
+// the workflow always has at least one node.
+func buildBoolFieldDip(field, val string) string {
+	switch field {
+	case "goal_gate", "auto_status", "cache_tools":
+		return "workflow X\n" +
+			"  start: A\n" +
+			"  exit: A\n" +
+			"  agent A\n" +
+			"    " + field + ": " + val + "\n"
+	case "route_required":
+		return "workflow X\n" +
+			"  start: T\n" +
+			"  exit: T\n" +
+			"  tool T\n" +
+			"    command: echo hi\n" +
+			"    " + field + ": " + val + "\n"
+	}
+	panic("unknown field: " + field)
+}
+
+// readBoolField extracts the value of the bool field under test from the
+// parsed workflow.
+func readBoolField(t *testing.T, w *ir.Workflow, field string) bool {
+	t.Helper()
+	if len(w.Nodes) == 0 {
+		t.Fatal("workflow has no nodes")
+	}
+	n := w.Nodes[0]
+	switch field {
+	case "goal_gate":
+		cfg, ok := n.Config.(ir.AgentConfig)
+		if !ok {
+			t.Fatalf("expected AgentConfig, got %T", n.Config)
+		}
+		return cfg.GoalGate
+	case "auto_status":
+		cfg, ok := n.Config.(ir.AgentConfig)
+		if !ok {
+			t.Fatalf("expected AgentConfig, got %T", n.Config)
+		}
+		return cfg.AutoStatus
+	case "cache_tools":
+		cfg, ok := n.Config.(ir.AgentConfig)
+		if !ok {
+			t.Fatalf("expected AgentConfig, got %T", n.Config)
+		}
+		return cfg.CacheTools
+	case "route_required":
+		cfg, ok := n.Config.(ir.ToolConfig)
+		if !ok {
+			t.Fatalf("expected ToolConfig, got %T", n.Config)
+		}
+		return cfg.RouteRequired
+	}
+	t.Fatalf("unknown field: %s", field)
+	return false
+}

--- a/parser/parse_helpers.go
+++ b/parser/parse_helpers.go
@@ -65,3 +65,23 @@ func (p *Parser) parseDuration(val string, key string, loc ir.SourceLocation) ti
 	}
 	return d
 }
+
+// parseBoolAttr normalizes boolean field parsing across node configs.
+// Accepts (case-insensitive, surrounding whitespace tolerated):
+//   - truthy: true, 1, yes, on
+//   - falsy:  false, 0, no, off
+//
+// Any other value produces a parse diagnostic and returns false.
+func (p *Parser) parseBoolAttr(val string, key string, loc ir.SourceLocation) bool {
+	s := strings.ToLower(strings.TrimSpace(val))
+	switch s {
+	case "true", "1", "yes", "on":
+		return true
+	case "false", "0", "no", "off":
+		return false
+	}
+	p.diagnostics = append(p.diagnostics, fmt.Sprintf(
+		"invalid boolean %q for %s at %d:%d (use true/false, 1/0, yes/no, on/off)",
+		val, key, loc.Line, loc.Column))
+	return false
+}

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -296,7 +296,7 @@ func applyAgentRuntimeField(cfg *ir.AgentConfig, key, val string) bool {
 
 // applyAgentComplexField handles fields needing parsing for agent config.
 func (p *Parser) applyAgentComplexField(cfg *ir.AgentConfig, key, val string, loc ir.SourceLocation) {
-	if applyAgentBoolField(cfg, key, val) {
+	if p.applyAgentBoolField(cfg, key, val, loc) {
 		return
 	}
 	if key == "params" {
@@ -310,14 +310,14 @@ func (p *Parser) applyAgentComplexField(cfg *ir.AgentConfig, key, val string, lo
 }
 
 // applyAgentBoolField handles boolean and string agent fields.
-func applyAgentBoolField(cfg *ir.AgentConfig, key, val string) bool {
+func (p *Parser) applyAgentBoolField(cfg *ir.AgentConfig, key, val string, loc ir.SourceLocation) bool {
 	switch key {
 	case "goal_gate":
-		cfg.GoalGate = (val == "true")
+		cfg.GoalGate = p.parseBoolAttr(val, key, loc)
 	case "auto_status":
-		cfg.AutoStatus = (val == "true")
+		cfg.AutoStatus = p.parseBoolAttr(val, key, loc)
 	case "cache_tools":
-		cfg.CacheTools = (val == "true")
+		cfg.CacheTools = p.parseBoolAttr(val, key, loc)
 	case "compaction":
 		cfg.Compaction = val
 	default:
@@ -407,7 +407,7 @@ func (p *Parser) applyToolField(cfg *ir.ToolConfig, key, val string, loc ir.Sour
 	if applyToolStringField(cfg, key, val) {
 		return
 	}
-	if applyToolBoolField(cfg, key, val) {
+	if p.applyToolBoolField(cfg, key, val, loc) {
 		return
 	}
 	if p.applyToolParsedField(cfg, key, val, loc) {
@@ -432,10 +432,10 @@ func applyToolStringField(cfg *ir.ToolConfig, key, val string) bool {
 }
 
 // applyToolBoolField handles boolean tool fields. Returns true if handled.
-func applyToolBoolField(cfg *ir.ToolConfig, key, val string) bool {
+func (p *Parser) applyToolBoolField(cfg *ir.ToolConfig, key, val string, loc ir.SourceLocation) bool {
 	switch key {
 	case "route_required":
-		cfg.RouteRequired = (val == "true")
+		cfg.RouteRequired = p.parseBoolAttr(val, key, loc)
 	default:
 		return false
 	}

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,30 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.29.0] — 2026-05-19
+
+Three follow-ups to v0.28.0's tool-routing surface. Closes [#42](https://github.com/2389-research/dippin-lang/issues/42), [#43](https://github.com/2389-research/dippin-lang/issues/43), [#44](https://github.com/2389-research/dippin-lang/issues/44).
+
+### Added
+
+- `DIP138` reserved for a future advisory: "tool node routes on stdout but declares no `marker_grep` / `outputs`". Code + description + explanation entry only; no firing logic in this release.
+- `outputs:` now survives a `.dip → DOT → .dip` round-trip. DOT export emits `outputs="a,b,c"` on tool nodes that declare outputs, and `dippin migrate dot→.dip` reads it back.
+
+### Changed
+
+- `DIP101` / `DIP102` no longer fire on tool nodes that declare `marker_grep:`. Those nodes route via the typed `ctx.tool_marker` channel — outgoing conditional edges on them are intentional routing, not unsafe reachability. Removes the false-positive coverage hit that tracker's `TRK101` option (d) guidance triggered.
+- Parser bool fields (`goal_gate`, `auto_status`, `cache_tools`, `route_required`) now accept `true/false`, `1/0`, `yes/no`, `on/off` case-insensitively via a new shared `parseBoolAttr` helper. Anything else now produces a parse diagnostic instead of silently coercing to `false`. The migrate (DOT-input) path keeps strict equality since DOT attrs are machine-emitted.
+
+### Runtime requirement
+
+None. All changes are dippin-internal; tracker is unaffected.
+
+### Docs
+
+- `docs/nodes.md` "Markers and Verbose Output" notes the DIP101/DIP102 suppression and the accepted boolean forms.
+- `docs/llm-reference.md` common-mistakes table cross-references the suppression behavior.
+- Hosted skill (`site/static/skill.md`) updated to match.
+
 ## [v0.28.0] — 2026-05-19
 
 Tool-node routing fields land in the parser and IR. Authors following tracker's `TRK101` recommendation can now declare `marker_grep`, `route_required`, and `output_limit` directly in `.dip` source. Closes [#39](https://github.com/2389-research/dippin-lang/issues/39).

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -414,7 +414,8 @@ The primary loop for authoring .dip files:
 ## Best Practices
 
 - **Always set `timeout`** on tool nodes — no timeout means infinite hang
-- **Prefer `marker_grep:`** over regexing `ctx.tool_stdout` in edges when the runtime supports it. Typed routing leaves stdout free for diagnostic output and avoids truncation foot-guns.
+- **Prefer `marker_grep:`** over regexing `ctx.tool_stdout` in edges when the runtime supports it. Typed routing leaves stdout free for diagnostic output and avoids truncation foot-guns. Declaring `marker_grep:` also suppresses DIP101/DIP102 on the source node — the validator treats it as a safe typed-routing channel.
+- **Boolean fields** (`goal_gate`, `auto_status`, `cache_tools`, `route_required`) accept `true/false`, `1/0`, `yes/no`, `on/off` case-insensitively. Anything else is a parse diagnostic.
 - **Use `auto_status: true`** on agent nodes that drive conditional routing via `ctx.outcome`
 - **Use `success`/`fail`** as condition values — the linter recognizes these as exhaustive
 - **Mark back-edges `restart: true`** — loops without it trigger DIP005

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -390,5 +390,12 @@ func nodeValidationExplanations() map[string]Explanation {
 			Fix:     "Set stop_condition (e.g., stack.child.outcome = success) or max_cycles to bound supervision.",
 			Example: "manager_loop Supervise\n  subgraph_ref: inner\n  stop_condition: stack.child.outcome = success  // or: max_cycles: 20",
 		},
+		DIP138: {
+			Code:    DIP138,
+			Summary: "tool node routes on stdout but declares no marker_grep / outputs",
+			Trigger: "A tool node has outgoing conditional edges that test ctx.tool_stdout but the tool itself declares neither marker_grep nor outputs. The workflow is using untyped stdout-text routing where the typed marker_grep channel (ctx.tool_marker) is clearer. (Reserved: no firing logic in v0.29.0.)",
+			Fix:     "Add marker_grep: \"<regex>\" to the tool node and switch edges to test ctx.tool_marker, or declare outputs: <values> so coverage analysis can see the routing set.",
+			Example: "tool Check\n  command: echo done\n  marker_grep: \"^(done|more)$\"\nedges\n  Check -> Next when ctx.tool_marker = done",
+		},
 	}
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP137).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP138).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge
@@ -39,6 +39,7 @@ const (
 	DIP135 = "DIP135" // manager_loop subgraph_ref missing or file does not exist
 	DIP136 = "DIP136" // manager_loop control field has invalid value (poll_interval or max_cycles)
 	DIP137 = "DIP137" // unbounded manager_loop: no stop_condition and no max_cycles
+	DIP138 = "DIP138" // tool node routes on stdout but declares no marker_grep / outputs (reserved)
 )
 
 func init() {
@@ -80,4 +81,5 @@ func init() {
 	CodeDescription[DIP135] = "manager_loop subgraph_ref missing or file does not exist"
 	CodeDescription[DIP136] = "manager_loop control field has invalid value (poll_interval or max_cycles)"
 	CodeDescription[DIP137] = "unbounded manager_loop: no stop_condition and no max_cycles"
+	CodeDescription[DIP138] = "tool node routes on stdout but declares no marker_grep / outputs"
 }

--- a/validator/lint_marker_grep_test.go
+++ b/validator/lint_marker_grep_test.go
@@ -1,0 +1,98 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/2389-research/dippin-lang/parser"
+	"github.com/2389-research/dippin-lang/validator"
+)
+
+// TestLintMarkerGrepSuppression verifies that a tool node declaring
+// marker_grep: routes via the typed ctx.tool_marker channel — outgoing
+// conditional edges on such nodes are intentional and should NOT trigger
+// DIP101 (unreachable via conditional) or DIP102 (no default edge).
+//
+// The companion negative case asserts that without marker_grep the same
+// shape still fires both warnings, guarding against accidental over-
+// suppression.
+//
+// Tests parse real .dip text through the production parser so they exercise
+// the same code path as user workflows (per CLAUDE.md guidance).
+func TestLintMarkerGrepSuppression(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantCodes []string // codes that MUST appear; empty = none of DIP101/DIP102
+	}{
+		{
+			name: "DIP101/DIP102: marker_grep on tool node suppresses both",
+			src: `workflow MarkerSafe
+  start: T
+  exit: D
+  tool T
+    command: echo hi
+    marker_grep: "^(go|stop)$"
+  agent D
+    prompt: "done"
+  edges
+    T -> D when ctx.tool_marker = go
+`,
+			wantCodes: []string{}, // no DIP101, no DIP102
+		},
+		{
+			name: "DIP101/DIP102: without marker_grep, same shape fires both",
+			src: `workflow MarkerUnsafe
+  start: T
+  exit: D
+  tool T
+    command: echo hi
+  agent D
+    prompt: "done"
+  edges
+    T -> D when ctx.tool_marker = go
+`,
+			wantCodes: []string{validator.DIP101, validator.DIP102},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			p := parser.NewParser(tt.src, tt.name+".dip")
+			w, err := p.Parse()
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+
+			result := validator.Lint(w)
+
+			gotCodes := make([]string, len(result.Diagnostics))
+			for i, d := range result.Diagnostics {
+				gotCodes[i] = d.Code
+			}
+
+			// Every expected code must appear at least once.
+			for _, want := range tt.wantCodes {
+				found := false
+				for _, got := range gotCodes {
+					if got == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected %s diagnostic, got none. All codes: %v", want, gotCodes)
+				}
+			}
+
+			// When wantCodes is empty, DIP101 and DIP102 specifically must NOT fire.
+			if len(tt.wantCodes) == 0 {
+				for _, got := range gotCodes {
+					if got == validator.DIP101 || got == validator.DIP102 {
+						t.Errorf("unexpected %s diagnostic (expected suppression). All codes: %v", got, gotCodes)
+					}
+				}
+			}
+		})
+	}
+}

--- a/validator/lint_reachability.go
+++ b/validator/lint_reachability.go
@@ -20,7 +20,7 @@ func lintConditionalReachability(w *ir.Workflow) []Diagnostic {
 	exhaustiveSources := findExhaustiveSources(w)
 
 	for _, n := range w.Nodes {
-		if d, ok := checkConditionalReachability(n, w.Start, incoming, outgoing, exhaustiveSources); ok {
+		if d, ok := checkConditionalReachability(w, n, w.Start, incoming, outgoing, exhaustiveSources); ok {
 			diags = append(diags, d)
 		}
 	}
@@ -28,7 +28,7 @@ func lintConditionalReachability(w *ir.Workflow) []Diagnostic {
 }
 
 // checkConditionalReachability checks a single node for DIP101.
-func checkConditionalReachability(n *ir.Node, start string, incoming, outgoing map[string][]*ir.Edge, exhaustive map[string]bool) (Diagnostic, bool) {
+func checkConditionalReachability(w *ir.Workflow, n *ir.Node, start string, incoming, outgoing map[string][]*ir.Edge, exhaustive map[string]bool) (Diagnostic, bool) {
 	if n.ID == start {
 		return Diagnostic{}, false
 	}
@@ -36,7 +36,7 @@ func checkConditionalReachability(n *ir.Node, start string, incoming, outgoing m
 	if len(edges) == 0 {
 		return Diagnostic{}, false
 	}
-	if allEdgesConditional(edges) && !allSourcesSafe(edges, outgoing, exhaustive) {
+	if allEdgesConditional(edges) && !allSourcesSafe(w, edges, outgoing, exhaustive) {
 		return Diagnostic{
 			Code:     DIP101,
 			Severity: SeverityWarning,
@@ -49,13 +49,10 @@ func checkConditionalReachability(n *ir.Node, start string, incoming, outgoing m
 }
 
 // allSourcesSafe returns true if every source node feeding these edges
-// either has exhaustive outgoing conditions OR has at least one
-// unconditional outgoing edge. A source with an unconditional edge
-// has normal execution flow — the conditional branch to our target
-// is intentional routing that fires when the condition matches.
-func allSourcesSafe(edges []*ir.Edge, outgoing map[string][]*ir.Edge, exhaustive map[string]bool) bool {
+// is a "safe source" — see sourceIsSafe.
+func allSourcesSafe(w *ir.Workflow, edges []*ir.Edge, outgoing map[string][]*ir.Edge, exhaustive map[string]bool) bool {
 	for _, e := range edges {
-		if !sourceIsSafe(e.From, outgoing, exhaustive) {
+		if !sourceIsSafe(w, e.From, outgoing, exhaustive) {
 			return false
 		}
 	}
@@ -63,13 +60,32 @@ func allSourcesSafe(edges []*ir.Edge, outgoing map[string][]*ir.Edge, exhaustive
 }
 
 // sourceIsSafe returns true if a source node guarantees its conditional
-// destinations are intentional: either via exhaustive conditions or by
-// having an unconditional outgoing edge (mixed routing).
-func sourceIsSafe(nodeID string, outgoing map[string][]*ir.Edge, exhaustive map[string]bool) bool {
+// destinations are intentional: via exhaustive conditions, an unconditional
+// outgoing edge (mixed routing), or marker_grep-driven typed routing.
+func sourceIsSafe(w *ir.Workflow, nodeID string, outgoing map[string][]*ir.Edge, exhaustive map[string]bool) bool {
 	if exhaustive[nodeID] {
 		return true
 	}
-	return hasUnconditionalEdge(outgoing[nodeID])
+	if hasUnconditionalEdge(outgoing[nodeID]) {
+		return true
+	}
+	return toolHasMarkerRouting(w, nodeID)
+}
+
+// toolHasMarkerRouting returns true if the node is a tool with a non-empty
+// marker_grep declaration. Such nodes route via ctx.tool_marker, a typed
+// channel that the engine populates; outgoing conditional edges are
+// intentional routing and DIP101/DIP102 should not fire on them.
+func toolHasMarkerRouting(w *ir.Workflow, nodeID string) bool {
+	n := w.Node(nodeID)
+	if n == nil {
+		return false
+	}
+	cfg, ok := n.Config.(ir.ToolConfig)
+	if !ok {
+		return false
+	}
+	return cfg.MarkerGrep != ""
 }
 
 // hasUnconditionalEdge returns true if any edge in the set has no condition.
@@ -105,7 +121,8 @@ func allEdgesConditional(edges []*ir.Edge) bool {
 // but no unconditional (default/fallback) edge. Without a default edge,
 // execution may get stuck at this node if no condition matches.
 //
-// Nodes whose outgoing conditions are exhaustive are not flagged.
+// Nodes whose outgoing conditions are exhaustive, or tool nodes with
+// marker_grep-driven typed routing, are not flagged.
 func lintDefaultEdge(w *ir.Workflow) []Diagnostic {
 	var diags []Diagnostic
 	exhaustiveSources := findExhaustiveSources(w)
@@ -115,7 +132,7 @@ func lintDefaultEdge(w *ir.Workflow) []Diagnostic {
 		if len(outgoing) == 0 {
 			continue
 		}
-		if hasMissingDefault(outgoing) && !exhaustiveSources[n.ID] {
+		if hasMissingDefault(outgoing) && !nodeIsSafeRouter(w, exhaustiveSources, n.ID) {
 			diags = append(diags, Diagnostic{
 				Code:     DIP102,
 				Severity: SeverityWarning,
@@ -126,6 +143,13 @@ func lintDefaultEdge(w *ir.Workflow) []Diagnostic {
 		}
 	}
 	return diags
+}
+
+// nodeIsSafeRouter returns true if the node's outgoing conditional edges
+// are intentional routing — either because the conditions are exhaustive
+// or because the node is a tool with marker_grep-driven typed routing.
+func nodeIsSafeRouter(w *ir.Workflow, exhaustive map[string]bool, nodeID string) bool {
+	return exhaustive[nodeID] || toolHasMarkerRouting(w, nodeID)
 }
 
 // hasMissingDefault returns true if edges contain conditional edges but no unconditional one.


### PR DESCRIPTION
## Summary

Three follow-ups to v0.28.0's tool-routing surface, bundled as v0.29.0.

- **#42** — Suppress DIP101/DIP102 on tool nodes with `marker_grep:`. The validator now treats a non-empty `marker_grep` declaration as a "safe routing source", so single-edge marker-routed workflows no longer trip false positives. DIP138 is reserved (constant + description + explanation only — no firing logic) for a future advisory.
- **#43** — Normalize bool parsing across `goal_gate`, `auto_status`, `cache_tools`, `route_required` via a new `parseBoolAttr` helper. Accepts `true/false`, `1/0`, `yes/no`, `on/off` case-insensitively. Anything else is a parse diagnostic instead of silently coercing to `false` — closes the `route_required: yes` foot-gun.
- **#44** — DOT export now emits `outputs="…"` on tool nodes that declare outputs, and `dippin migrate dot→.dip` reads it back. Closes the silent-drop bug where `.dip → DOT → .dip` collapsed `cfg.Outputs` to nil.

Spec: `docs/superpowers/specs/2026-05-19-tool-routing-followups-design.md`
Plan: `docs/superpowers/plans/2026-05-19-tool-routing-followups.md`

Closes #42, closes #43, closes #44.

## Test plan
- [x] `parser/parse_bool_test.go` — table-driven coverage of all 4 fields × accepted truthy/falsy + rejected forms
- [x] `validator/lint_marker_grep_test.go` — marker_grep suppresses DIP101+DIP102; control case (no marker_grep) still fires both
- [x] `migrate/roundtrip_test.go` — `.dip → DOT → .dip` preserves `outputs:`
- [x] `migrate/parity.go compareToolSlices` unchanged (parity already shipped in v0.28.0)
- [x] Existing DIP101/DIP102 coverage on exhaustive partitions, complementary pairs, and success/fail still fires correctly
- [x] Full pre-commit suite green: build, vet, golangci-lint, gofmt, all tests with race, releasecheck, gocyclo, gocognit, validate-examples

## Out of scope (filed as follow-up)
While building the #44 round-trip test, the implementer surfaced a pre-existing migrate bug: when a tool node IS the workflow's `start:` node, `resolveStartExitKind` doesn't recover `ToolConfig` and the node round-trips as `AgentConfig`. The test workflow uses an agent as `start:` to avoid the bug. Will be filed as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool `outputs` attribute now preserves through DOT round-trips.
  * Boolean fields accept multiple formats (`true`/`false`, `yes`/`no`, `1`/`0`, `on`/`off`) case-insensitively with validation diagnostics.
  * DIP101/DIP102 warnings suppressed for tool nodes declaring marker-based routing.
  * Introduced DIP138 advisory for tool routing guidance.

* **Documentation**
  * Updated changelog, skill docs, and reference materials with revised tool-routing and boolean-parsing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->