### PR TITLE
fix(coverage): respect shell redirection in extractor (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.30.0] — 2026-05-21
+
+### Fixed
+
+- `dippin coverage` no longer flags file-redirected `echo`/`printf` statements as uncovered tool outputs. The extractor now uses an AST walker (`mvdan.cc/sh/v3/syntax`) and skips statements that redirect to files (`>`, `>>`, `&>`, `>&`), feed into pipes, or are nested inside command substitution. Pipelines using the "log to file, printf marker on stdout" pattern correctly report `covered` instead of `partial`. (#40)
+
+### Closed
+
+- #40 — coverage flags file-redirected echo/printf as uncovered outputs
+
 ## [v0.29.0] — 2026-05-19
 
 Three follow-ups to v0.28.0's tool-routing surface. Closes [#42](https://github.com/2389-research/dippin-lang/issues/42), [#43](https://github.com/2389-research/dippin-lang/issues/43), [#44](https://github.com/2389-research/dippin-lang/issues/44).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ## [v0.30.0] — 2026-05-21
 
+Coverage extractor now respects shell redirection. Closes [#40](https://github.com/2389-research/dippin-lang/issues/40).
+
 ### Fixed
 
-- `dippin coverage` no longer flags file-redirected `echo`/`printf` statements as uncovered tool outputs. The extractor now uses an AST walker (`mvdan.cc/sh/v3/syntax`) and skips statements that redirect to files (`>`, `>>`, `&>`, `>&`), feed into pipes, or are nested inside command substitution. Pipelines using the "log to file, printf marker on stdout" pattern correctly report `covered` instead of `partial`. (#40)
-
-### Closed
-
-- #40 — coverage flags file-redirected echo/printf as uncovered outputs
+- `dippin coverage` no longer flags file-redirected `echo`/`printf` statements as uncovered tool outputs. The extractor switched from regex matching to an AST walker built on `mvdan.cc/sh/v3/syntax`.
+- Statements that redirect to files (`>`, `>>`, `&>`, `>&`), feed into pipes, or are nested inside command substitution are now correctly skipped. Pipelines using the "log to file, printf marker on stdout" pattern flip from `partial` to `covered`.
 
 ## [v0.29.0] — 2026-05-19
 

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -174,15 +174,39 @@ func walkForOutputs(outputs *[]string, seen map[string]bool) func(syntax.Node) b
 }
 
 // stmtIsRedirected returns true if a statement's stdout does not reach
-// the engine — either via a file/fd redirect or a pipe.
+// the engine — either via a stdout-affecting redirect or a pipe. Stdin
+// redirects (`<`) and stderr-only redirects (`2>err.log`, `2>&1`) leave
+// stdout intact and do NOT cause the statement to be skipped.
 func stmtIsRedirected(s *syntax.Stmt) bool {
-	if len(s.Redirs) > 0 {
-		return true
+	for _, r := range s.Redirs {
+		if redirAffectsStdout(r) {
+			return true
+		}
 	}
 	if bin, ok := s.Cmd.(*syntax.BinaryCmd); ok {
 		return bin.Op == syntax.Pipe || bin.Op == syntax.PipeAll
 	}
 	return false
+}
+
+// redirAffectsStdout reports whether a single redirect diverts fd 1 away
+// from the engine's stdout. The `&>` / `&>>` operators always do; the
+// per-fd operators (`>`, `>>`, `>&`, `>|`, `<>`) only do when the source
+// fd is unset (defaults to 1) or explicitly "1".
+func redirAffectsStdout(r *syntax.Redirect) bool {
+	switch r.Op {
+	case syntax.RdrAll, syntax.AppAll:
+		return true
+	case syntax.RdrOut, syntax.AppOut, syntax.DplOut, syntax.RdrClob, syntax.RdrInOut:
+		return redirTargetsStdout(r.N)
+	}
+	return false
+}
+
+// redirTargetsStdout returns true if a redirect's fd number is unset
+// (defaults to stdout) or explicitly the literal "1".
+func redirTargetsStdout(n *syntax.Lit) bool {
+	return n == nil || n.Value == "1"
 }
 
 // collectFromCall extracts literal output args from an echo or printf call.

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -6,12 +6,12 @@
 package coverage
 
 import (
-	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
 	"github.com/2389-research/dippin-lang/simulate"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 // Report is the top-level result of a coverage analysis.
@@ -43,14 +43,6 @@ type ReachabilityReport struct {
 type TerminationReport struct {
 	AllPathsTerminate bool     `json:"all_paths_terminate"`
 	SinkNodes         []string `json:"sink_nodes,omitempty"`
-}
-
-// outputPatterns matches printf/echo string literals in shell commands.
-var outputPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`printf\s+'([^']+)'`),
-	regexp.MustCompile(`printf\s+"([^"]+)"`),
-	regexp.MustCompile(`printf\s+'%s'\s+'([^']+)'`),
-	regexp.MustCompile(`echo\s+'([^']+)'`),
 }
 
 // Analyze runs coverage analysis on a workflow and returns a report.
@@ -142,20 +134,153 @@ func toSet(items []string) map[string]bool {
 	return s
 }
 
-// extractToolOutputs finds printf/echo string literals in a shell command.
+// echoFlags are echo invocations that should be skipped when extracting
+// literal output values from an echo call's arguments.
+var echoFlags = map[string]bool{
+	"-n": true, "-e": true, "-E": true, "--": true,
+}
+
+// extractToolOutputs finds printf/echo string literals in a shell command
+// whose stdout reaches the engine. Statements that redirect to files or
+// feed into pipes are skipped, as are echo/printf calls nested inside
+// command substitution. Returns nil on shell parse errors — DIP123 catches
+// syntax problems upstream.
 func extractToolOutputs(command string) []string {
-	seen := make(map[string]bool)
-	var outputs []string
-	for _, pat := range outputPatterns {
-		for _, m := range pat.FindAllStringSubmatch(command, -1) {
-			val := m[1]
-			if !seen[val] && !isFormatSpecifier(val) {
-				seen[val] = true
-				outputs = append(outputs, val)
-			}
-		}
+	parser := syntax.NewParser(syntax.KeepComments(false))
+	prog, err := parser.Parse(strings.NewReader(command), "")
+	if err != nil {
+		return nil
 	}
+	var outputs []string
+	seen := make(map[string]bool)
+	syntax.Walk(prog, walkForOutputs(&outputs, seen))
 	return outputs
+}
+
+// walkForOutputs returns a syntax.Walk callback that collects literal
+// echo/printf args from statements whose stdout reaches the engine.
+func walkForOutputs(outputs *[]string, seen map[string]bool) func(syntax.Node) bool {
+	return func(node syntax.Node) bool {
+		switch n := node.(type) {
+		case *syntax.Stmt:
+			return !stmtIsRedirected(n)
+		case *syntax.CmdSubst:
+			return false
+		case *syntax.CallExpr:
+			collectFromCall(n, outputs, seen)
+		}
+		return true
+	}
+}
+
+// stmtIsRedirected returns true if a statement's stdout does not reach
+// the engine — either via a file/fd redirect or a pipe.
+func stmtIsRedirected(s *syntax.Stmt) bool {
+	if len(s.Redirs) > 0 {
+		return true
+	}
+	if bin, ok := s.Cmd.(*syntax.BinaryCmd); ok {
+		return bin.Op == syntax.Pipe || bin.Op == syntax.PipeAll
+	}
+	return false
+}
+
+// collectFromCall extracts literal output args from an echo or printf call.
+func collectFromCall(call *syntax.CallExpr, outputs *[]string, seen map[string]bool) {
+	if len(call.Args) == 0 {
+		return
+	}
+	name := extractWordLiteralLocal(call.Args[0])
+	switch name {
+	case "echo":
+		collectEchoArgs(call.Args[1:], outputs, seen)
+	case "printf":
+		collectPrintfArgs(call.Args[1:], outputs, seen)
+	}
+}
+
+// collectEchoArgs extracts literal args from `echo`, skipping flag args.
+func collectEchoArgs(args []*syntax.Word, outputs *[]string, seen map[string]bool) {
+	for _, w := range args {
+		lit := extractWordLiteralLocal(w)
+		if lit == "" || echoFlags[lit] {
+			continue
+		}
+		addOutput(lit, outputs, seen)
+	}
+}
+
+// collectPrintfArgs extracts literal args from `printf`. The two-arg
+// `printf '%s' 'value'` and `printf '%s\n' 'value'` patterns extract the
+// value; otherwise the format-string itself is the output literal.
+func collectPrintfArgs(args []*syntax.Word, outputs *[]string, seen map[string]bool) {
+	if len(args) == 0 {
+		return
+	}
+	first := extractWordLiteralLocal(args[0])
+	if first == "" {
+		return
+	}
+	if isFormatTwoArg(first, args) {
+		if val := extractWordLiteralLocal(args[1]); val != "" {
+			addOutput(val, outputs, seen)
+		}
+		return
+	}
+	addOutput(first, outputs, seen)
+}
+
+// isFormatTwoArg returns true if printf was invoked with a bare `%s` or
+// `%s\n` format string and exactly one value arg.
+func isFormatTwoArg(first string, args []*syntax.Word) bool {
+	return (first == "%s" || first == "%s\\n") && len(args) == 2
+}
+
+// addOutput appends a literal output value if it hasn't been seen and
+// isn't itself a format specifier.
+func addOutput(val string, outputs *[]string, seen map[string]bool) {
+	if seen[val] || isFormatSpecifier(val) {
+		return
+	}
+	seen[val] = true
+	*outputs = append(*outputs, val)
+}
+
+// extractWordLiteralLocal returns the literal string content of a simple
+// Word arg, handling bare, single-quoted, and double-quoted forms.
+// Returns "" if the word contains expansions or substitutions.
+func extractWordLiteralLocal(w *syntax.Word) string {
+	if w == nil || len(w.Parts) != 1 {
+		return ""
+	}
+	return extractPartLiteral(w.Parts[0])
+}
+
+// extractPartLiteral returns the literal content of a single WordPart,
+// or "" if the part is not a simple literal.
+func extractPartLiteral(part syntax.WordPart) string {
+	switch p := part.(type) {
+	case *syntax.Lit:
+		return p.Value
+	case *syntax.SglQuoted:
+		return p.Value
+	case *syntax.DblQuoted:
+		return extractDblQuotedLit(p)
+	}
+	return ""
+}
+
+// extractDblQuotedLit returns the literal content of a double-quoted
+// word part, or "" if it contains expansions.
+func extractDblQuotedLit(d *syntax.DblQuoted) string {
+	if len(d.Parts) != 1 {
+		return ""
+	}
+	lit, ok := d.Parts[0].(*syntax.Lit)
+	if !ok {
+		return ""
+	}
+	return lit.Value
 }
 
 // isFormatSpecifier returns true if the string looks like a printf format string.

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -236,6 +236,12 @@ func TestExtractToolOutputs(t *testing.T) {
 
 		// Issue #40 — && / || (non-pipe BinaryCmd) descends into both sides
 		{"echo_and", "echo 'a' && echo 'b'", []string{"a", "b"}},
+
+		// PR review — only stdout-affecting redirects should skip the statement
+		{"stdin_redirect_keeps_stdout", "printf 'ok' < input.txt", []string{"ok"}},
+		{"stderr_only_redirect", "printf 'ok' 2>err.log", []string{"ok"}},
+		{"stderr_dup_to_stdout", "printf 'ok' 2>&1", []string{"ok"}},
+		{"fd1_explicit_redirect", "printf 'gone' 1>out.log\nprintf 'kept'", []string{"kept"}},
 	}
 
 	for _, tt := range tests {

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -205,6 +205,7 @@ func TestExtractToolOutputs(t *testing.T) {
 		command string
 		want    []string
 	}{
+		// Existing cases (regression coverage)
 		{"single_printf", "printf 'pass'", []string{"pass"}},
 		{"double_quote_printf", `printf "fail"`, []string{"fail"}},
 		{"echo", "echo 'done'", []string{"done"}},
@@ -212,6 +213,26 @@ func TestExtractToolOutputs(t *testing.T) {
 		{"multiple", "printf 'a'\nprintf 'b'", []string{"a", "b"}},
 		{"no_match", "run-binary", nil},
 		{"dedup", "printf 'x'\nprintf 'x'", []string{"x"}},
+
+		// Issue #40 — file-redirected statements must not extract
+		{"redirect_overwrite", "echo 'foo' > log.txt\nprintf 'green'", []string{"green"}},
+		{"redirect_append_and_pipe", "echo 'foo' >> log\necho 'bar' | tee /tmp/x\nprintf 'green'", []string{"green"}},
+		{"stderr_redirect", "echo 'oops' >&2\nprintf 'real'", []string{"real"}},
+
+		// Issue #40 — preserve format-two-arg pattern with newline format
+		{"printf_format_newline", "printf '%s\\n' 'inline'\nprintf 'tail'", []string{"inline", "tail"}},
+
+		// Issue #40 — echo with flags now extracts (regex missed it)
+		{"echo_with_flags", "echo -n 'foo'", []string{"foo"}},
+
+		// Issue #40 — command substitution: inner skipped, outer's only arg is non-literal
+		{"echo_command_sub", "echo $(printf 'inner')\nprintf 'outer'", []string{"outer"}},
+
+		// Issue #40 — subshell without redirect still writes to stdout
+		{"subshell_unredirected", "( echo 'inside' )\nprintf 'outside'", []string{"inside", "outside"}},
+
+		// Issue #40 — parse errors return nil (no regex fallback)
+		{"malformed_shell", "echo 'unclosed", nil},
 	}
 
 	for _, tt := range tests {

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -233,6 +233,9 @@ func TestExtractToolOutputs(t *testing.T) {
 
 		// Issue #40 — parse errors return nil (no regex fallback)
 		{"malformed_shell", "echo 'unclosed", nil},
+
+		// Issue #40 — && / || (non-pipe BinaryCmd) descends into both sides
+		{"echo_and", "echo 'a' && echo 'b'", []string{"a", "b"}},
 	}
 
 	for _, tt := range tests {

--- a/examples/coverage_redirection.dip
+++ b/examples/coverage_redirection.dip
@@ -1,3 +1,5 @@
+# Regression for issue #40: echoes redirected to a file must not count
+# as stdout coverage; only the final printf should reach the engine.
 workflow CoverageRedirection
   goal: "Demonstrate that file-redirected echoes no longer trip coverage"
   start: RunTests

--- a/examples/coverage_redirection.dip
+++ b/examples/coverage_redirection.dip
@@ -1,0 +1,27 @@
+workflow CoverageRedirection
+  goal: "Demonstrate that file-redirected echoes no longer trip coverage"
+  start: RunTests
+  exit: Done
+
+  tool RunTests
+    timeout: 2m
+    command:
+      set -eu
+      echo 'capturing test baseline' > /tmp/coverage_redirection.log
+      echo 'build_system=python' >> /tmp/coverage_redirection.log
+      if true; then printf 'validation_pass'; else printf 'validation_fail'; fi
+
+  agent Pass
+    prompt: Summarize the successful run.
+
+  agent Fail
+    prompt: Summarize the failed run.
+
+  agent Done
+    prompt: Final report.
+
+  edges
+    RunTests -> Pass  when ctx.tool_stdout = validation_pass
+    RunTests -> Fail  when ctx.tool_stdout = validation_fail
+    Pass -> Done
+    Fail -> Done

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,16 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.30.0] — 2026-05-21
+
+### Fixed
+
+- `dippin coverage` no longer flags file-redirected `echo`/`printf` statements as uncovered tool outputs. The extractor now uses an AST walker (`mvdan.cc/sh/v3/syntax`) and skips statements that redirect to files (`>`, `>>`, `&>`, `>&`), feed into pipes, or are nested inside command substitution. Pipelines using the "log to file, printf marker on stdout" pattern correctly report `covered` instead of `partial`. (#40)
+
+### Closed
+
+- #40 — coverage flags file-redirected echo/printf as uncovered outputs
+
 ## [v0.29.0] — 2026-05-19
 
 Three follow-ups to v0.28.0's tool-routing surface. Closes [#42](https://github.com/2389-research/dippin-lang/issues/42), [#43](https://github.com/2389-research/dippin-lang/issues/43), [#44](https://github.com/2389-research/dippin-lang/issues/44).

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -6,13 +6,12 @@ layout: "changelog"
 ---
 ## [v0.30.0] — 2026-05-21
 
+Coverage extractor now respects shell redirection. Closes [#40](https://github.com/2389-research/dippin-lang/issues/40).
+
 ### Fixed
 
-- `dippin coverage` no longer flags file-redirected `echo`/`printf` statements as uncovered tool outputs. The extractor now uses an AST walker (`mvdan.cc/sh/v3/syntax`) and skips statements that redirect to files (`>`, `>>`, `&>`, `>&`), feed into pipes, or are nested inside command substitution. Pipelines using the "log to file, printf marker on stdout" pattern correctly report `covered` instead of `partial`. (#40)
-
-### Closed
-
-- #40 — coverage flags file-redirected echo/printf as uncovered outputs
+- `dippin coverage` no longer flags file-redirected `echo`/`printf` statements as uncovered tool outputs. The extractor switched from regex matching to an AST walker built on `mvdan.cc/sh/v3/syntax`.
+- Statements that redirect to files (`>`, `>>`, `&>`, `>&`), feed into pipes, or are nested inside command substitution are now correctly skipped. Pipelines using the "log to file, printf marker on stdout" pattern flip from `partial` to `covered`.
 
 ## [v0.29.0] — 2026-05-19
 


### PR DESCRIPTION
## Summary

- Replace the regex-based `extractToolOutputs` in `coverage/coverage.go` with an AST walker built on `mvdan.cc/sh/v3/syntax` (already a project dependency, already used by `validator/lint_tool_helpers.go:extractBinary`).
- Statements that redirect to files (`>`, `>>`, `&>`, `>&`), feed into pipes, or nest `echo`/`printf` inside command substitution are now skipped — they don't reach the engine's stdout.
- Add `examples/coverage_redirection.dip` exercising the bug pattern from issue #40 and verifying the `RunTests` node reports `covered`.
- Tag v0.30.0 after merge.

## Test plan

- [x] `just check` green locally (pre-commit hook ran build, vet, golangci-lint, gofmt, test-race, complexity, validate-examples, release checks)
- [ ] CI green
- [x] `examples/coverage_redirection.dip` lints clean and reports \`covered\`
- [ ] Spot-check on \`2389-research/pipelines\` PR #13 — confirm \`build-and-ship/refactor-express.dip\` flips from A/90 to A/100

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781982459&installation_id=131176874&pr_number=50&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F50&signature=3c734e282d895121aa43f44c32c28175e491ccdf96107d12d82f152122a4de6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Coverage extractor now correctly respects shell redirections, file writes, command substitutions, and pipelines so reported tool output reflects actual stdout seen by the engine
  * Pipelines using the "log to file, printf marker on stdout" pattern are reclassified as covered

* **New Features**
  * Added an example workflow demonstrating coverage redirection behavior

* **Documentation**
  * Changelog updated for v0.30.0 describing the coverage fixes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->