### PR TITLE
v0.31.0: yes_no human mode + tool-as-start round-trip (#45, #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.31.0] — 2026-05-22
+
+Two small dippin-internal fixes. Closes [#45](https://github.com/2389-research/dippin-lang/issues/45), [#49](https://github.com/2389-research/dippin-lang/issues/49).
+
+### Fixed
+
+- `mode: yes_no` on `human` nodes no longer trips DIP127. The tracker runtime supports `yes_no` as a documented mode; dippin's validator now accepts it alongside `choice`, `freeform`, and `interview`. The four-mode list is cascaded through the validator help text, the DIP127 explanation, `docs/validation.md`, `docs/nodes.md`, `docs/llm-reference.md`, the hosted skill (`site/static/skill.md`), the LSP completion tooltip, the integration guide, and the IR field comment.
+- Tool nodes used as the workflow's `start:` node no longer collapse to `AgentConfig` after a `.dip → DOT → .dip` round-trip. `migrate.resolveStartExitKind` now recovers `NodeTool` from the start-marker `Mdiamond` shape by sniffing tool-specific DOT attributes (`tool_command`, `marker_grep`, `outputs`, `route_required`, `output_limit`).
+
+### Runtime requirement
+
+None. Both fixes are dippin-internal; tracker is unaffected.
+
 ## [v0.30.0] — 2026-05-21
 
 Coverage extractor now respects shell redirection. Closes [#40](https://github.com/2389-research/dippin-lang/issues/40).

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -280,6 +280,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 - `choice`: Outgoing edge labels become buttons. Human selects one.
 - `freeform`: Open text input → `ctx.human_response`
 - `interview`: Structured Q&A from upstream agent output. Don't combine with choice-style edges (DIP129).
+- `yes_no`: Binary Y/N prompt — two outgoing edges labeled `[Y]` and `[N]`.
 
 ### tool — shell command
 

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -48,7 +48,7 @@ workflow <Name>
 | Kind | Required Fields | Optional Fields |
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
-| `human` | `mode` (freeform\|choice\|interview) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
+| `human` | `mode` (freeform\|choice\|interview\|yes_no) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
 | `tool` | `command` | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
@@ -266,7 +266,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `mode` | string | **Required.** `choice`, `freeform`, or `interview` (DIP127) |
+| `mode` | string | **Required.** `choice`, `freeform`, `interview`, or `yes_no` (DIP127) |
 | `default` | string | Default choice (meaningless in interview mode — DIP128) |
 | `prompt` | multiline | Prompt text |
 | `questions_key` | string | Context key for interview questions |
@@ -582,7 +582,7 @@ The primary loop for authoring .dip files:
 | DIP124 | `${ctx.*}` in tool command | Remove — runtime variables expand to empty at parse time |
 | DIP125 | Command binary not on PATH | Install the binary or fix the command |
 | DIP126 | Subgraph ref file missing | Check `ref:` path |
-| DIP127 | Invalid human mode | Use: `choice`, `freeform`, `interview` |
+| DIP127 | Invalid human mode | Use: `choice`, `freeform`, `interview`, `yes_no` |
 | DIP130 | Invalid response_format | Use: `json_object`, `json_schema` |
 | DIP131 | Schema/format mismatch | `response_schema` requires `response_format: json_schema`, and vice versa — both must be present together |
 | DIP132 | Invalid JSON in response_schema | Fix the JSON syntax |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -185,7 +185,7 @@ case ir.AgentConfig:
     fmt.Println(cfg.Model)
     fmt.Println(cfg.GoalGate)
 case ir.HumanConfig:
-    fmt.Println(cfg.Mode)         // "choice", "freeform", or "interview"
+    fmt.Println(cfg.Mode)         // "choice", "freeform", "interview", or "yes_no"
     fmt.Println(cfg.Default)
     fmt.Println(cfg.QuestionsKey) // interview mode: context key for questions
     fmt.Println(cfg.AnswersKey)   // interview mode: context key for answers

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -46,7 +46,7 @@ workflow <Name>
 | Kind | Required Fields | Optional Fields |
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
-| `human` | `mode` (freeform\|choice\|interview) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
+| `human` | `mode` (freeform\|choice\|interview\|yes_no) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
 | `tool` | `command` | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -174,7 +174,7 @@ Human nodes pause execution and wait for human input. They support three interac
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mode` | String | — | Interaction mode: `"choice"` (select from edge labels), `"freeform"` (open text), or `"interview"` (structured Q&A from upstream agent output). |
+| `mode` | String | — | Interaction mode: `"choice"` (select from edge labels), `"freeform"` (open text), `"interview"` (structured Q&A from upstream agent output), or `"yes_no"` (binary Y/N prompt). |
 | `default` | String | — | Default selection if no input. Only meaningful for `"choice"` mode. |
 | `questions_key` | String | `interview_questions` | Context key to read questions from. Interview mode only. |
 | `answers_key` | String | `interview_answers` | Context key to write answers to. Interview mode only. |

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -739,10 +739,10 @@ A human node has a `mode` value that is not one of the recognized modes.
 ```
 warning[DIP127]: node "Gate" has mode "interactive" which is not a recognized human mode
   --> pipeline.dip:12:3
-  = help: valid modes: choice, freeform, interview
+  = help: valid modes: choice, freeform, interview, yes_no
 ```
 
-**What triggers it**: A human node declares a mode other than `choice`, `freeform`, or `interview`.
+**What triggers it**: A human node declares a mode other than `choice`, `freeform`, `interview`, or `yes_no`.
 
 **How to fix**: Change the mode to a valid value.
 

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -113,7 +113,7 @@ func (AgentConfig) nodeConfig() {}
 
 // HumanConfig holds configuration for human gate nodes.
 type HumanConfig struct {
-	Mode          string        // "choice" | "freeform" | "interview"
+	Mode          string        // "choice" | "freeform" | "interview" | "yes_no"
 	Default       string        // Default choice
 	Prompt        string        // Instructions shown to the human
 	QuestionsKey  string        // Context key to read questions from (interview mode)

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -46,7 +46,7 @@ func fieldCompletions() []protocol.CompletionItem {
 		{"provider:", "LLM provider name"},
 		{"max_turns:", "Maximum agentic turns"},
 		{"label:", "Display label"},
-		{"mode:", "Human node mode (choice|freeform)"},
+		{"mode:", "Human node mode (choice|freeform|interview|yes_no)"},
 		{"command:", "Tool node shell command"},
 		{"goal_gate:", "Fail pipeline if node fails"},
 		{"reasoning_effort:", "Reasoning effort (none|minimal|low|medium|high|xhigh|max)"},

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -319,8 +319,12 @@ func hasManagerLoopAttrs(attrs map[string]string) bool {
 // hasToolConfigAttrs reports whether attrs contain any tool-config-specific
 // key. Used to detect tool nodes when their kind-based shape was overridden
 // to Mdiamond/Msquare by start/exit marker export. The five keys below are
-// unique to ir.ToolConfig and cannot collide with any other node kind; the
-// shared timeout attr is intentionally excluded.
+// unique to ir.ToolConfig and cannot collide with any other node kind. Four
+// (marker_grep, outputs, route_required, output_limit) are always emitted;
+// tool_command only appears when IncludePrompts=true, so a bare tool node
+// with only command: exported without IncludePrompts is not recoverable
+// here — that case is out of scope (see issue #49 plan). The shared timeout
+// attr is intentionally excluded to avoid collision with HumanConfig.
 func hasToolConfigAttrs(attrs map[string]string) bool {
 	toolKeys := []string{"tool_command", "marker_grep", "outputs", "route_required", "output_limit"}
 	for _, key := range toolKeys {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -316,15 +316,34 @@ func hasManagerLoopAttrs(attrs map[string]string) bool {
 	return false
 }
 
+// hasToolConfigAttrs reports whether attrs contain any tool-config-specific
+// key. Used to detect tool nodes when their kind-based shape was overridden
+// to Mdiamond/Msquare by start/exit marker export. The five keys below are
+// unique to ir.ToolConfig and cannot collide with any other node kind; the
+// shared timeout attr is intentionally excluded.
+func hasToolConfigAttrs(attrs map[string]string) bool {
+	toolKeys := []string{"tool_command", "marker_grep", "outputs", "route_required", "output_limit"}
+	for _, key := range toolKeys {
+		if _, ok := attrs[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveStartExitKind disambiguates start/exit-marker shapes (Mdiamond, Msquare)
-// by checking for any manager_loop-specific attribute. Start/exit override the
-// kind-based shape in export, so migrate has to recover the original kind from
-// attrs. Checking any manager_loop key (not just subgraph_ref) ensures partial
-// configurations (e.g., poll_interval set but subgraph_ref missing) are not
-// silently downgraded to NodeAgent, losing all configured fields.
+// by checking for kind-specific attributes. Start/exit override the kind-based
+// shape in export, so migrate has to recover the original kind from attrs.
+// Manager-loop attrs are checked first, then tool-config attrs; partial
+// configurations of either kind are detected so nothing is silently downgraded
+// to NodeAgent. Tool detection is bounded to tool-specific keys (the shared
+// timeout attr is excluded to avoid collision with HumanConfig).
 func resolveStartExitKind(attrs map[string]string) ir.NodeKind {
 	if hasManagerLoopAttrs(attrs) {
 		return ir.NodeManagerLoop
+	}
+	if hasToolConfigAttrs(attrs) {
+		return ir.NodeTool
 	}
 	return ir.NodeAgent
 }

--- a/migrate/roundtrip_test.go
+++ b/migrate/roundtrip_test.go
@@ -133,10 +133,8 @@ func extractDOTAttr(dot, key string) string {
 // emitted the outputs DOT attr.
 func TestRoundtripPreservesToolOutputs(t *testing.T) {
 	src := `workflow MarkerRouting
-  start: S
+  start: T
   exit: D
-  agent S
-    prompt: "start"
   tool T
     command: echo hi
     outputs: tests_green, tests_red
@@ -144,7 +142,6 @@ func TestRoundtripPreservesToolOutputs(t *testing.T) {
   agent D
     prompt: "done"
   edges
-    S -> T
     T -> D when ctx.tool_marker = tests_green
     T -> D when ctx.tool_marker = tests_red
 `
@@ -220,5 +217,70 @@ func TestRoundTripToolSafetyDefaults(t *testing.T) {
 	if w2.Defaults.ToolDenylistAdd != "rm -rf /" {
 		t.Errorf("tool_denylist_add after round-trip = %q, want %q; DOT:\n%s",
 			w2.Defaults.ToolDenylistAdd, "rm -rf /", dot)
+	}
+}
+
+// TestRoundtripPreservesToolAsStart verifies that a tool node used as
+// the workflow's start: node round-trips through .dip → DOT → .dip with
+// its ToolConfig intact. Regression test for #49 — DOT export overrides
+// the diamond shape to Mdiamond for the start marker, and migrate's
+// resolveStartExitKind previously collapsed any non-manager_loop start
+// node to NodeAgent, silently dropping the ToolConfig.
+func TestRoundtripPreservesToolAsStart(t *testing.T) {
+	src := `workflow ToolAsStart
+  start: T
+  exit: D
+  tool T
+    command: echo hi
+    outputs: a, b
+    marker_grep: "^(a|b)$"
+  agent D
+    prompt: "done"
+  edges
+    T -> D when ctx.tool_marker = a
+    T -> D when ctx.tool_marker = b
+`
+	w1, err := dipparser.NewParser(src, "rt.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dot := export.ExportDOT(w1, export.ExportOptions{IncludePrompts: true})
+
+	w2, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("migrate: %v\nDOT:\n%s", err, dot)
+	}
+
+	var toolNode *ir.Node
+	for _, n := range w2.Nodes {
+		if n.ID == "T" {
+			toolNode = n
+			break
+		}
+	}
+	if toolNode == nil {
+		t.Fatalf("node T not found in migrated workflow; DOT:\n%s", dot)
+	}
+	if toolNode.Kind != ir.NodeTool {
+		t.Fatalf("node T kind = %v, want ir.NodeTool; DOT:\n%s", toolNode.Kind, dot)
+	}
+	cfg, ok := toolNode.Config.(ir.ToolConfig)
+	if !ok {
+		t.Fatalf("node T config is %T, want ir.ToolConfig; DOT:\n%s", toolNode.Config, dot)
+	}
+	if cfg.MarkerGrep != "^(a|b)$" {
+		t.Errorf("MarkerGrep = %q, want %q", cfg.MarkerGrep, "^(a|b)$")
+	}
+	want := []string{"a", "b"}
+	if len(cfg.Outputs) != len(want) {
+		t.Fatalf("Outputs = %v, want %v; DOT:\n%s", cfg.Outputs, want, dot)
+	}
+	for i := range want {
+		if cfg.Outputs[i] != want[i] {
+			t.Errorf("Outputs[%d] = %q, want %q", i, cfg.Outputs[i], want[i])
+		}
+	}
+	if cfg.Command != "echo hi" {
+		t.Errorf("Command = %q, want %q", cfg.Command, "echo hi")
 	}
 }

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,19 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.31.0] — 2026-05-22
+
+Two small dippin-internal fixes. Closes [#45](https://github.com/2389-research/dippin-lang/issues/45), [#49](https://github.com/2389-research/dippin-lang/issues/49).
+
+### Fixed
+
+- `mode: yes_no` on `human` nodes no longer trips DIP127. The tracker runtime supports `yes_no` as a documented mode; dippin's validator now accepts it alongside `choice`, `freeform`, and `interview`. The four-mode list is cascaded through the validator help text, the DIP127 explanation, `docs/validation.md`, `docs/nodes.md`, `docs/llm-reference.md`, the hosted skill (`site/static/skill.md`), the LSP completion tooltip, the integration guide, and the IR field comment.
+- Tool nodes used as the workflow's `start:` node no longer collapse to `AgentConfig` after a `.dip → DOT → .dip` round-trip. `migrate.resolveStartExitKind` now recovers `NodeTool` from the start-marker `Mdiamond` shape by sniffing tool-specific DOT attributes (`tool_command`, `marker_grep`, `outputs`, `route_required`, `output_limit`).
+
+### Runtime requirement
+
+None. Both fixes are dippin-internal; tracker is unaffected.
+
 ## [v0.30.0] — 2026-05-21
 
 Coverage extractor now respects shell redirection. Closes [#40](https://github.com/2389-research/dippin-lang/issues/40).

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -185,10 +185,10 @@ These flag likely bugs or questionable patterns. Warnings alone exit 0.
 
 <div class="diag-card warning">
   <span class="diag-code">DIP127</span> — Invalid human node mode
-  <p>The <code>mode:</code> value on a human node must be <code>choice</code>, <code>freeform</code>, or <code>interview</code>.</p>
+  <p>The <code>mode:</code> value on a human node must be <code>choice</code>, <code>freeform</code>, <code>interview</code>, or <code>yes_no</code>.</p>
   <pre>warning[DIP127]: invalid human node mode "dialog"
   --&gt; pipeline.dip:22:5
-  = help: use one of: choice, freeform, interview</pre>
+  = help: use one of: choice, freeform, interview, yes_no</pre>
 </div>
 
 <div class="diag-card warning">

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -89,7 +89,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `mode` | string | **Required.** `choice`, `freeform`, or `interview` (DIP127) |
+| `mode` | string | **Required.** `choice`, `freeform`, `interview`, or `yes_no` (DIP127) |
 | `default` | string | Default choice (meaningless in interview mode — DIP128) |
 | `prompt` | multiline | Prompt text |
 | `questions_key` | string | Context key for interview questions |
@@ -405,7 +405,7 @@ The primary loop for authoring .dip files:
 | DIP124 | `${ctx.*}` in tool command | Remove — runtime variables expand to empty at parse time |
 | DIP125 | Command binary not on PATH | Install the binary or fix the command |
 | DIP126 | Subgraph ref file missing | Check `ref:` path |
-| DIP127 | Invalid human mode | Use: `choice`, `freeform`, `interview` |
+| DIP127 | Invalid human mode | Use: `choice`, `freeform`, `interview`, `yes_no` |
 | DIP130 | Invalid response_format | Use: `json_object`, `json_schema` |
 | DIP131 | Schema/format mismatch | `response_schema` requires `response_format: json_schema`, and vice versa — both must be present together |
 | DIP132 | Invalid JSON in response_schema | Fix the JSON syntax |

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -103,6 +103,7 @@ Indentation: 2 spaces. Comments: `#` line comments (literal inside multiline blo
 - `choice`: Outgoing edge labels become buttons. Human selects one.
 - `freeform`: Open text input → `ctx.human_response`
 - `interview`: Structured Q&A from upstream agent output. Don't combine with choice-style edges (DIP129).
+- `yes_no`: Binary Y/N prompt — two outgoing edges labeled `[Y]` and `[N]`.
 
 ### tool — shell command
 

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -316,8 +316,8 @@ func nodeValidationExplanations() map[string]Explanation {
 		DIP127: {
 			Code:    DIP127,
 			Summary: "invalid human node mode",
-			Trigger: "A human node has a mode value other than choice, freeform, or interview.",
-			Fix:     "Change mode to one of: choice, freeform, interview.",
+			Trigger: "A human node has a mode value other than choice, freeform, interview, or yes_no.",
+			Fix:     "Change mode to one of: choice, freeform, interview, yes_no.",
 			Example: "human Gate\n  mode: interactive  // invalid — did you mean interview?",
 		},
 		DIP128: {

--- a/validator/lint_human.go
+++ b/validator/lint_human.go
@@ -10,6 +10,7 @@ var validHumanModes = map[string]bool{
 	"choice":    true,
 	"freeform":  true,
 	"interview": true,
+	"yes_no":    true,
 }
 
 func lintHumanMode(w *ir.Workflow) []Diagnostic {
@@ -25,7 +26,7 @@ func lintHumanMode(w *ir.Workflow) []Diagnostic {
 				Severity: SeverityWarning,
 				Message:  fmt.Sprintf("node %q has mode %q which is not a recognized human mode", n.ID, cfg.Mode),
 				Location: n.Source,
-				Help:     "valid modes: choice, freeform, interview",
+				Help:     "valid modes: choice, freeform, interview, yes_no",
 			})
 		}
 	}

--- a/validator/lint_test.go
+++ b/validator/lint_test.go
@@ -1675,7 +1675,7 @@ func TestLint_DIP127_InvalidHumanMode(t *testing.T) {
 }
 
 func TestLint_DIP127_ValidModes(t *testing.T) {
-	for _, mode := range []string{"choice", "freeform", "interview", ""} {
+	for _, mode := range []string{"choice", "freeform", "interview", "yes_no", ""} {
 		w := cleanMinimalWorkflow()
 		w.Nodes[0].Kind = ir.NodeHuman
 		w.Nodes[0].Config = ir.HumanConfig{Mode: mode}


### PR DESCRIPTION
## Summary

Two small, independent dippin-internal fixes bundled as v0.31.0.

- **#45** — `mode: yes_no` on `human` nodes no longer trips DIP127. Adds `yes_no` to `validHumanModes` and cascades the four-mode list through ten authoritative locations (validator help, DIP127 explanation, IR field comment, LSP completion tooltip, integration guide, hosted Claude skill, `docs/nodes.md`, `docs/llm-reference.md`, `docs/validation.md`, `site/content/validation.md`, regenerated `cmd/dippin/generated-spec.md`).
- **#49** — Tool nodes used as the workflow's `start:` node now round-trip through DOT with `ToolConfig` intact. `migrate.resolveStartExitKind` gains a `hasToolConfigAttrs` heuristic mirroring the existing `hasManagerLoopAttrs` pattern.
- v0.29.0's `TestRoundtripPreservesToolOutputs` no longer needs its intermediate-agent workaround — removed.

Spec: `docs/superpowers/specs/2026-05-22-v0.31.0-design.md` (on main)
Plan: `docs/superpowers/plans/2026-05-22-v0.31.0-implementation.md` (on main)

## Out of scope (pre-existing drift, not introduced by this PR)

A doc audit during review surfaced three locations whose mode list predates the v0.x release that added `interview` (they list only `choice` + `freeform`). Not touched here since they aren't an internal inconsistency caused by adding `yes_no`:

- `README.md:256, 357`
- `site/content/language.md:166` ("Two modes:")
- `site/content/glossary.md:30` (uses fictional `confirm`)

A follow-up "doc hygiene" PR can sweep these once.

## Test plan

- [x] `just test-pkg validator` — DIP127 tests pass (`TestLint_DIP127_ValidModes` now covers `yes_no`; `TestLint_DIP127_InvalidHumanMode` still rejects `"invalid"`)
- [x] `just test-pkg migrate` — new `TestRoundtripPreservesToolAsStart` passes; modified `TestRoundtripPreservesToolOutputs` (workaround removed, `start: T` directly) still passes
- [x] `just test-pkg lsp` — completion tooltip change
- [x] Pre-commit hook (build, vet, golangci-lint, gofmt, tests, complexity, validate-examples) — all green on every commit

## Post-merge

Tag `v0.31.0` on main and push (triggers GoReleaser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781989083&installation_id=131176874&pr_number=51&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F51&signature=93fd6c9c35ebabcc0653cb56bea88e6003b23149c85ea1a06c2b37c71a47c41b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Human nodes now accept `mode: yes_no` without validation errors
  * Improved tool node recognition during workflow migration from diagrams

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->