### PR TITLE
fix(site): /blog rendered as raw RSS XML

### DIFF
--- a/site/content/blog/_index.md
+++ b/site/content/blog/_index.md
@@ -1,5 +1,4 @@
 ---
 title: "Blog"
 description: "Tutorials, guides, and deep dives into Dippin workflow authoring."
-url: /blog.html
 ---

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -36,6 +36,15 @@ disableKinds = ["taxonomy", "term"]
   isPlainText = true
   notAlternative = true
 
+# Override built-in RSS so it honors uglyURLs.
+# Default RSS has noUgly = true, which writes /blog/index.xml; we want /blog.xml
+# alongside /blog.html so the feed URL matches the section's HTML URL.
+[outputFormats.RSS]
+  mediaType = "application/rss+xml"
+  baseName = "index"
+  noUgly = false
+  rel = "alternate"
+
 [outputs]
   home = ["HTML", "llmstxt", "sitemapmd"]
 


### PR DESCRIPTION
## Summary

`https://dippin.org/blog` was serving raw RSS XML instead of the rendered blog list page. Hugo's `url:` front-matter override on `site/content/blog/_index.md` applied to *every* output format, so both the HTML list page and the built-in RSS feed wrote to `/blog.html`. RSS clobbered HTML; browsers got `application/rss+xml` content with a `text/html` Content-Type, which shows up as visible markup. Introduced in 4ab75b8.

## Fix

- Drop `url: /blog.html` from `site/content/blog/_index.md`. Under `uglyURLs = true` and Hugo 0.147.5 (pinned in `netlify.toml`), the section's HTML naturally renders to `/blog.html`, making the override redundant.
- Override the built-in RSS output format in `site/hugo.toml` with `noUgly = false` so the feed renders to `/blog.xml` (instead of the default `/blog/index.xml`). Keeps the existing menu link valid and gives the feed a URL that matches the HTML.

After the fix:
- `/blog.html` → 200 `text/html`, rendered list of all 16 posts
- `/blog.xml` → 200 `application/xml`, RSS feed with all 16 items, self-link `https://dippin.org/blog.xml`
- `/blog/<post>.html` → unchanged

## Hugo version caveat

Hugo 0.158+ stopped honoring `uglyURLs` for section index pages — it always writes `blog/index.html` regardless. This fix only works because `netlify.toml` pins `HUGO_VERSION = "0.147.5"`. If we ever bump the Netlify Hugo, this section will need another look (probably an explicit custom output format).

## Test plan

- [x] Reproduced bug on `main`: built `site/` with Hugo 0.147.5, confirmed `public/blog.html` was XML.
- [x] Applied fix, rebuilt with Hugo 0.147.5: `public/blog.html` is HTML, `public/blog.xml` is RSS.
- [x] Started `hugo server` locally — `/blog.html`, `/blog.xml`, and `/` all return correct content-types and content.
- [x] Verified internal links: menu `/blog.html`, individual post permalinks unchanged, RSS items link to correct post URLs.
- [ ] Netlify deploy preview confirms `/blog` and `/blog.xml` look right.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782490715&installation_id=131176874&pr_number=63&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F63&signature=875a508db1a2cde5facd32e8f55d5468c7b5b9fd65ce0a7377f40a23e366d648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated blog RSS feed configuration to ensure consistent URL formatting alongside the blog HTML page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->