### PR TITLE
feat(site): surface /blog.xml RSS feed

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -83,6 +83,11 @@
     Content-Type = "text/plain; charset=utf-8"
 
 [[headers]]
+  for = "/blog.xml"
+  [headers.values]
+    Content-Type = "application/rss+xml; charset=utf-8"
+
+[[headers]]
   for = "/.well-known/api-catalog"
   [headers.values]
     Content-Type = "application/linkset+json"

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -7,6 +7,7 @@
       <a href="https://github.com/2389-research/dippin-lang/tree/main/docs" data-tinylytics-event="footer.docs">Docs</a>
       <a href="{{ "glossary.html" | relURL }}" data-tinylytics-event="footer.glossary">Glossary</a>
       <a href="{{ "changelog.html" | relURL }}" data-tinylytics-event="footer.changelog">Changelog</a>
+      <a href="{{ "blog.xml" | relURL }}" data-tinylytics-event="footer.rss">RSS</a>
     </div>
   </div>
   <div class="footer-copy">

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -17,6 +17,9 @@
 {{- if .IsHome }}
 <link rel="alternate" type="text/plain" href="{{ "llms.txt" | absURL }}">
 {{- end }}
+{{- if or .IsHome (eq .Section "blog") }}
+<link rel="alternate" type="application/rss+xml" title="Dippin Blog" href="{{ "blog.xml" | absURL }}">
+{{- end }}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,500;0,9..144,700;1,9..144,400&family=IBM+Plex+Mono:wght@400;500;600&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="{{ "style.css" | relURL }}">


### PR DESCRIPTION
## Summary

Follow-up to #63 — now that `/blog.xml` exists, make it discoverable.

- **`head.html`**: add `<link rel="alternate" type="application/rss+xml" title="Dippin Blog" href="…/blog.xml">` on the home page, the blog list, and individual blog posts. Feed readers autodiscover the feed from any of those entry points; doc/section pages stay untouched.
- **`footer.html`**: add a visible "RSS" link alongside GitHub / Docs / Glossary / Changelog. Tinylytics event: `footer.rss`.
- **`netlify.toml`**: serve `/blog.xml` with `Content-Type: application/rss+xml; charset=utf-8` so RSS readers that key off the response header (not the file extension) get the right type. Matches the existing pattern for `llms.txt`, `skill.md`, etc.

## Test plan

- [x] Built `site/` with Hugo 0.147.5 (Netlify-pinned version).
- [x] Confirmed `<link rel="alternate" type="application/rss+xml">` appears in `public/index.html`, `public/blog.html`, `public/blog/whats-new-v028.html`.
- [x] Confirmed it does NOT appear on `public/language.html` (scope is correct).
- [x] Confirmed footer "RSS" link appears on home, blog list, and post pages.
- [ ] Netlify deploy preview shows the correct `Content-Type` header on `/blog.xml`.
- [ ] Subscribe to the feed from a reader (e.g. NetNewsWire / Feedly) to confirm autodiscovery works.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782493739&installation_id=131176874&pr_number=64&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F64&signature=141423b978d980bf98697658aa07ee437619c670d0299260dbd9677c0de25083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RSS feed support with proper HTTP header configuration
  * Added RSS feed links to site footer and page metadata for easy content discovery and subscription

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->