### PR TITLE
v0.33.0: command_file: directive on tool nodes (#52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,9 @@ jobs:
           failed=0
           for f in examples/*.dip; do
             formatted=$(./dippin fmt "$f" 2>/dev/null)
-            tmp=$(mktemp /tmp/roundtrip-XXXXXX.dip)
+            # Write tmp file in source dir so command_file: relative paths resolve.
+            # Dot-prefix hides it from any subsequent glob.
+            tmp=$(mktemp "$(dirname "$f")/.roundtrip-XXXXXX.dip")
             echo "$formatted" > "$tmp"
             if ! ./dippin validate "$tmp" > /dev/null 2>&1; then
               echo "::error::$f fails round-trip: formatted output doesn't validate"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.33.0] — RELEASE_DATE
+
+New `command_file:` directive on tool nodes replaces inline `command:` heredocs with external file references. Solves the heredoc-bloat pattern seen in long tracker workflows. Dippin-only release — no tracker coordination required (tracker reads inlined `Command` from `.dipx` bundles unchanged).
+
+### Added
+- `command_file: <path>` directive on tool nodes. Path is relative to the `.dip` source directory.
+- `parser.ResolveFileDirectives(w, baseDir)` — separate-pass file loader called by CLI entry points. Parser itself stays pure.
+- Path security in the resolver: absolute-path reject, parent-tree-escape reject, symlink reject (via `Lstat`), 4 MiB size cap. Error messages reference user-written paths, not resolved absolute paths.
+- Parser-time error when both `command:` and `command_file:` are set on the same tool node.
+- `examples/external_files.dip` + `examples/external_files/setup.sh` demonstrate the directive.
+
+### Notes
+- LSP and `cmd/wasm` (playground) skip the resolver. They see `cfg.CommandFile != "" && cfg.Command == ""`, which is the correct unresolved-IR view.
+- DOT round-trip is lossy for the directive form — pack-then-unpack rewrites `command_file:` to inline `command:`. Tracker reads from `.dipx` bundles where content is already inlined; no current consumer needs the path preserved through DOT. Deferred to a follow-up issue ([#69](https://github.com/2389-research/dippin-lang/issues/69)).
+
 ## [v0.32.0] — 2026-05-27
 
 New agent-node safety primitive: `tool_access: none` strips an LLM's tool catalog. Joint release with tracker `v0.31.0` — the dippin field is meaningless without tracker enforcement, so they ship together (see [#41](https://github.com/2389-research/dippin-lang/issues/41) for context, including the v0.28.2 runaway-agent incident this bounds).

--- a/cmd/dippin/cli.go
+++ b/cmd/dippin/cli.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/2389-research/dippin-lang/dipx"
@@ -231,6 +232,22 @@ func parseSingleFileArg(name, usage string, args []string, stderr io.Writer) (st
 	return fs.Arg(0), ExitCode(-1)
 }
 
+// parseAndResolveDip parses .dip source text and resolves any file directives
+// (e.g. command_file:) against the source file's directory. This is the shared
+// CLI-side parse path — LSP/WASM intentionally skip the resolver and view the
+// unresolved IR.
+func parseAndResolveDip(data []byte, path string) (*ir.Workflow, error) {
+	p := parser.NewParser(string(data), path)
+	w, err := p.Parse()
+	if err != nil {
+		return nil, err
+	}
+	if err := parser.ResolveFileDirectives(w, filepath.Dir(path)); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
 // parseFile reads and parses a .dip or .dipx file, returning the entry workflow.
 // Unlike loadWorkflow it does not handle .dot — that's only used by the
 // migrate-related commands. .dipx bundles are integrity-verified via dipx.Load.
@@ -246,8 +263,7 @@ func parseFile(path string) (*ir.Workflow, error) {
 	if err != nil {
 		return nil, err
 	}
-	p := parser.NewParser(string(data), path)
-	return p.Parse()
+	return parseAndResolveDip(data, path)
 }
 
 // loadWorkflow reads a file and parses it to IR. It auto-detects .dot vs .dip
@@ -270,8 +286,7 @@ func loadWorkflow(path string) (*ir.Workflow, error) {
 	if strings.HasSuffix(path, ".dot") {
 		return migrate.Migrate(string(data))
 	}
-	p := parser.NewParser(string(data), path)
-	return p.Parse()
+	return parseAndResolveDip(data, path)
 }
 
 // renderError formats a Go error as a diagnostic and writes it to stderr.

--- a/cmd/dippin/cmd_pack.go
+++ b/cmd/dippin/cmd_pack.go
@@ -37,6 +37,12 @@ func (c *CLI) CmdPack(args []string) ExitCode {
 
 // runPack implements `dippin pack <entry.dip> [-o output] [--dry-run]`.
 // Returns one of exitDipx* per the .dipx CLI contract.
+//
+// Before invoking dipx.Pack on the user-supplied entry, we build a shadow
+// source tree with all command_file: directives resolved to inline command:
+// blocks. dipx.Pack then walks the shadow tree, so the produced bundle is
+// self-contained and does not require the referenced script files to exist
+// when the bundle is later opened.
 func runPack(stdout, stderr io.Writer, args []string) int {
 	entry, dest, dryRun, code := parsePackArgs(stderr, args)
 	if code != -1 {
@@ -45,16 +51,29 @@ func runPack(stdout, stderr io.Writer, args []string) int {
 	if code := validateEntryPrePack(stderr, entry); code != exitDipxOK {
 		return code
 	}
+	shadowEntry, cleanup, err := prepShadowSourceTree(entry)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitDipxUserError
+	}
+	defer cleanup()
+	return dispatchPack(stdout, stderr, shadowEntry, dest, dryRun)
+}
+
+// dispatchPack routes the resolved shadow entry to the right dipx.Pack sink
+// (dry-run discard, stdout, or atomic file). Extracted so runPack stays under
+// the project's cyclomatic-5 cap.
+func dispatchPack(stdout, stderr io.Writer, shadowEntry, dest string, dryRun bool) int {
 	ctx := context.Background()
 	if dryRun {
-		_, err := dipx.Pack(ctx, entry, io.Discard)
+		_, err := dipx.Pack(ctx, shadowEntry, io.Discard)
 		return classifyExit(stderr, err)
 	}
 	if dest == "-" {
-		_, err := dipx.Pack(ctx, entry, stdout)
+		_, err := dipx.Pack(ctx, shadowEntry, stdout)
 		return classifyExit(stderr, err)
 	}
-	return packToFile(stderr, ctx, entry, dest)
+	return packToFile(stderr, ctx, shadowEntry, dest)
 }
 
 // validateEntryPrePack runs structural validation (DIP001-DIP009) on the entry

--- a/cmd/dippin/cmd_pack_test.go
+++ b/cmd/dippin/cmd_pack_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"archive/zip"
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/2389-research/dippin-lang/dipx"
@@ -178,4 +181,104 @@ func TestIsIntegrityErr_RejectsNonIntegrity(t *testing.T) {
 	if isIntegrityErr(dipx.ErrSubgraphParse) {
 		t.Error("isIntegrityErr(ErrSubgraphParse) = true, want false")
 	}
+}
+
+// TestRunPack_InlinesCommandFile confirms that a .dip referencing a script
+// via `command_file:` produces a self-contained bundle: the script content
+// appears inside the bundled .dip as an inline `command:` block, and the
+// external script file is not bundled. This is the core fix for the PR #71
+// concern that pack was leaving command_file: directives literal and
+// failing to embed the script.
+func TestRunPack_InlinesCommandFile(t *testing.T) {
+	dir := t.TempDir()
+	scriptContent := "#!/bin/sh\nset -eu\necho hello-from-script\n"
+	scriptDir := filepath.Join(dir, "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir scripts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "run.sh"), []byte(scriptContent), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	dipSrc := `workflow A
+  goal: "Pack-time inlining smoke test"
+  start: Run
+  exit: Done
+
+  tool Run
+    timeout: 30s
+    command_file: scripts/run.sh
+
+  agent Done
+    prompt:
+      Done.
+
+  edges
+    Run -> Done
+`
+	entry := filepath.Join(dir, "a.dip")
+	if err := os.WriteFile(entry, []byte(dipSrc), 0o644); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	out := filepath.Join(dir, "a.dipx")
+	var stdout, stderr bytes.Buffer
+	if code := runPack(&stdout, &stderr, []string{"-o", out, entry}); code != exitDipxOK {
+		t.Fatalf("pack exit = %d; stderr=%s", code, stderr.String())
+	}
+	bundled := readBundledDip(t, out, "workflows/a.dip")
+	if strings.Contains(bundled, "command_file:") {
+		t.Fatalf("bundled .dip still has command_file: directive:\n%s", bundled)
+	}
+	if !strings.Contains(bundled, "echo hello-from-script") {
+		t.Fatalf("bundled .dip missing inlined script content:\n%s", bundled)
+	}
+	// Script file should NOT appear in the bundle — only the .dip with the
+	// script inlined into its command: block.
+	for _, name := range listBundleEntries(t, out) {
+		if strings.HasSuffix(name, ".sh") {
+			t.Errorf("bundle unexpectedly contains script file: %s", name)
+		}
+	}
+}
+
+// readBundledDip extracts the named .dip file from the bundle and returns
+// its contents as a string. Fails the test on any read/zip error.
+func readBundledDip(t *testing.T, bundlePath, entryName string) string {
+	t.Helper()
+	r, err := zip.OpenReader(bundlePath)
+	if err != nil {
+		t.Fatalf("open bundle: %v", err)
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		if f.Name != entryName {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s: %v", entryName, err)
+		}
+		defer rc.Close()
+		body, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("read %s: %v", entryName, err)
+		}
+		return string(body)
+	}
+	t.Fatalf("entry %s not found in bundle", entryName)
+	return ""
+}
+
+// listBundleEntries returns the names of every zip entry in bundlePath.
+func listBundleEntries(t *testing.T, bundlePath string) []string {
+	t.Helper()
+	r, err := zip.OpenReader(bundlePath)
+	if err != nil {
+		t.Fatalf("open bundle: %v", err)
+	}
+	defer r.Close()
+	names := make([]string, 0, len(r.File))
+	for _, f := range r.File {
+		names = append(names, f.Name)
+	}
+	return names
 }

--- a/cmd/dippin/cmd_pack_test.go
+++ b/cmd/dippin/cmd_pack_test.go
@@ -240,6 +240,44 @@ func TestRunPack_InlinesCommandFile(t *testing.T) {
 	}
 }
 
+// TestRunPack_RejectsSubgraphRefEscape confirms that prepShadowSourceTree's
+// ensureUnderRoot check rejects a workflow whose subgraph reference escapes
+// the entry's directory. Without the check, writeShadowFile would compute
+// a relative path with ".." segments and write outside the temp shadow dir.
+func TestRunPack_RejectsSubgraphRefEscape(t *testing.T) {
+	dir := t.TempDir()
+	entry := filepath.Join(dir, "entry.dip")
+	src := `workflow E
+  goal: "escape-attempt"
+  start: S
+  exit: D
+
+  subgraph S
+    label: "escape"
+    ref: ../escaped.dip
+
+  agent D
+    prompt:
+      done
+
+  edges
+    S -> D
+`
+	if err := os.WriteFile(entry, []byte(src), 0o644); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	out := filepath.Join(dir, "e.dipx")
+	var stdout, stderr bytes.Buffer
+	code := runPack(&stdout, &stderr, []string{"-o", out, entry})
+	if code == exitDipxOK {
+		t.Fatalf("expected pack to fail on subgraph ref escape; stderr=%s", stderr.String())
+	}
+	combined := stderr.String() + stdout.String()
+	if !strings.Contains(combined, "escapes source root") {
+		t.Errorf("expected 'escapes source root' in error; got: %s", combined)
+	}
+}
+
 // readBundledDip extracts the named .dip file from the bundle and returns
 // its contents as a string. Fails the test on any read/zip error.
 func readBundledDip(t *testing.T, bundlePath, entryName string) string {

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -49,7 +49,7 @@ workflow <Name>
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `tool_access` (`none` disables LLM tools; DIP139 warns on unknown), `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
 | `human` | `mode` (freeform\|choice\|interview\|yes_no) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
-| `tool` | `command` | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes) |
+| `tool` | `command` (or `command_file`) | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes), `command_file` (path to external script, relative to .dip dir) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
 | `subgraph` | `ref` | `params` |
@@ -310,7 +310,8 @@ Invalid values fall back to no-tools at runtime (fail-closed) and are flagged by
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `command` | multiline | Shell command. Supports pipes, here-docs, case/esac. |
+| `command` | multiline | Shell command. Supports pipes, here-docs, case/esac. Required unless `command_file` is set. |
+| `command_file` | string | Path (relative to the `.dip` source directory) to an external script whose contents replace inline `command:`. Mutually exclusive with `command`. See "Tool Command File" below. |
 | `timeout` | duration | **Required** (DIP111). e.g. `30s`, `5m` |
 | `outputs` | CSV | Possible stdout values for condition checks |
 | `marker_grep` | string | Regex matched against stdout; sets `ctx.tool_marker`. Tracker validates at runtime. |
@@ -320,6 +321,23 @@ Invalid values fall back to no-tools at runtime (fail-closed) and are flagged by
 | `writes` | CSV | Context keys written |
 
 Do NOT use `${ctx.*}` in commands — they expand to empty at parse time (DIP124). Output is captured as `ctx.tool_stdout` and `ctx.tool_stderr`.
+
+**Tool Command File (`command_file:`)** — *added v0.33.0.*
+
+Reference an external file for a tool node's command instead of inlining a heredoc:
+
+```dip
+tool Setup
+  command_file: scripts/setup.sh
+```
+
+Path resolution: relative to the `.dip` source directory. Absolute paths rejected. Symlinks rejected. Parent-tree escape (`../../etc/passwd`) rejected. 4 MiB size cap.
+
+Mutually exclusive with `command:` — specifying both is a parse error.
+
+Loading: CLI entry points (`dippin lint`, `dippin pack`, `dippin validate`, `dippin doctor`) load the file contents into the IR after parse. The LSP and the playground skip loading; they show the path unresolved. Tracker reads `.dipx` bundles where content is already inlined, so the runtime sees no difference from inline `command:`.
+
+Non-goals (deferred): `prompt_file:` / `system_prompt_file:` directives ([#65](https://github.com/2389-research/dippin-lang/issues/65)), configurable size cap ([#66](https://github.com/2389-research/dippin-lang/issues/66)), full-chain symlink resolution ([#67](https://github.com/2389-research/dippin-lang/issues/67)), glob expansion ([#68](https://github.com/2389-research/dippin-lang/issues/68)), DOT round-trip preservation of the directive form ([#69](https://github.com/2389-research/dippin-lang/issues/69)), graceful LSP/WASM not-loaded signal ([#70](https://github.com/2389-research/dippin-lang/issues/70)). See issue [#52](https://github.com/2389-research/dippin-lang/issues/52).
 
 ### parallel / fan_in — concurrent execution
 

--- a/cmd/dippin/pack_shadow.go
+++ b/cmd/dippin/pack_shadow.go
@@ -6,11 +6,27 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/2389-research/dippin-lang/formatter"
 	"github.com/2389-research/dippin-lang/ir"
 	"github.com/2389-research/dippin-lang/parser"
 )
+
+// ensureUnderRoot rejects any absolute path that resolves outside rootDir.
+// Guards the shadow-tree writer against a malicious subgraph ref like
+// `subgraph: ../../../escape.dip`, which would otherwise cause
+// writeShadowFile to write outside the temp shadow dir (since
+// filepath.Join(shadowDir, "../../../escape.dip") escapes). dipx.Pack does
+// its own escape check, but it runs AFTER we've built the shadow tree —
+// too late to prevent the out-of-tree write.
+func ensureUnderRoot(absPath, rootDir string) error {
+	rel, err := filepath.Rel(rootDir, absPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("pack-inline: ref escapes source root: %s", absPath)
+	}
+	return nil
+}
 
 // prepShadowSourceTree walks the entry workflow and every transitively-
 // reachable subgraph .dip, resolves any command_file: directives by reading
@@ -108,7 +124,7 @@ func inlineOne(srcAbs, rootDir, shadowDir string) ([]string, error) {
 	if err := writeShadowFile(srcAbs, rootDir, shadowDir, wf); err != nil {
 		return nil, err
 	}
-	return collectRefPaths(wf, filepath.Dir(srcAbs))
+	return collectRefPaths(wf, filepath.Dir(srcAbs), rootDir)
 }
 
 // clearCommandFileDirectives walks every tool node in wf and clears its
@@ -142,10 +158,10 @@ func writeShadowFile(srcAbs, rootDir, shadowDir string, wf *ir.Workflow) error {
 
 // collectRefPaths returns absolute disk paths for every subgraph ref in wf,
 // resolved against srcDir (the directory of the workflow that declared them).
-// Returns an error if any ref escapes the source root would only matter for
-// dipx.Pack's later walk — we leave that validation to dipx and just enqueue
-// the reachable refs here.
-func collectRefPaths(wf *ir.Workflow, srcDir string) ([]string, error) {
+// Each resolved target is validated to be under rootDir — refs that escape
+// fail fast here (before BFS enqueues them) so the parent workflow's context
+// is in the error message.
+func collectRefPaths(wf *ir.Workflow, srcDir, rootDir string) ([]string, error) {
 	var out []string
 	for _, n := range wf.Nodes {
 		ref := refFromNodeForShadow(n)
@@ -154,6 +170,9 @@ func collectRefPaths(wf *ir.Workflow, srcDir string) ([]string, error) {
 		}
 		target, err := filepath.Abs(filepath.Join(srcDir, ref))
 		if err != nil {
+			return nil, err
+		}
+		if err := ensureUnderRoot(target, rootDir); err != nil {
 			return nil, err
 		}
 		out = append(out, target)

--- a/cmd/dippin/pack_shadow.go
+++ b/cmd/dippin/pack_shadow.go
@@ -1,0 +1,176 @@
+// ABOUTME: Shadow-tree preprocessing for `dippin pack` — inlines command_file:
+// ABOUTME: directives at pack time so bundles are self-contained.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/2389-research/dippin-lang/formatter"
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/parser"
+)
+
+// prepShadowSourceTree walks the entry workflow and every transitively-
+// reachable subgraph .dip, resolves any command_file: directives by reading
+// the referenced scripts from disk, then writes the inlined .dip sources
+// into a fresh temp directory preserving the original relative layout.
+//
+// Returns the shadow path of the entry workflow and a cleanup func the
+// caller must invoke (even on error from downstream Pack). The shadow
+// tree is what dipx.Pack should walk: scripts referenced by command_file:
+// are now embedded in the .dip text so the resulting bundle is self-
+// contained and does not need the external script files to exist when
+// the bundle is later opened.
+//
+// Architecture note: this preprocessing lives in the CLI layer because
+// dipx must not import formatter or parser/resolve (CLAUDE.md loader-
+// tier rule). dipx still walks the shadow tree using its own parser
+// path; we only adjust the .dip text before handing it off.
+func prepShadowSourceTree(entry string) (string, func(), error) {
+	entryAbs, err := filepath.Abs(entry)
+	if err != nil {
+		return "", noop, err
+	}
+	rootDir := filepath.Dir(entryAbs)
+	shadow, cleanup, err := makeShadowDir()
+	if err != nil {
+		return "", noop, err
+	}
+	if err := walkAndInline(entryAbs, rootDir, shadow); err != nil {
+		cleanup()
+		return "", noop, err
+	}
+	rel, err := filepath.Rel(rootDir, entryAbs)
+	if err != nil {
+		cleanup()
+		return "", noop, err
+	}
+	return filepath.Join(shadow, rel), cleanup, nil
+}
+
+// noop is the cleanup returned when prep fails before any temp dir was made.
+func noop() {}
+
+// makeShadowDir creates a fresh temp dir for the shadow source tree and
+// returns a cleanup func that removes it.
+func makeShadowDir() (string, func(), error) {
+	dir, err := os.MkdirTemp("", "dippin-pack-shadow-*")
+	if err != nil {
+		return "", noop, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	return dir, cleanup, nil
+}
+
+// walkAndInline performs a BFS over the entry workflow's subgraph ref graph,
+// rooted at entryAbs. Each visited .dip is parsed, command_file: directives
+// are resolved against the source file's directory, every tool node has its
+// CommandFile field cleared (so the formatter emits inline command: blocks),
+// the result is formatted, and written to the shadow tree at the same
+// relative path as the original source.
+func walkAndInline(entryAbs, rootDir, shadowDir string) error {
+	visited := map[string]struct{}{}
+	queue := []string{entryAbs}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if _, ok := visited[cur]; ok {
+			continue
+		}
+		visited[cur] = struct{}{}
+		refs, err := inlineOne(cur, rootDir, shadowDir)
+		if err != nil {
+			return err
+		}
+		queue = append(queue, refs...)
+	}
+	return nil
+}
+
+// inlineOne reads, parses, inlines, formats, and writes a single .dip into
+// the shadow tree. Returns absolute paths to any subgraph refs the workflow
+// declares so the caller can enqueue them for further processing.
+func inlineOne(srcAbs, rootDir, shadowDir string) ([]string, error) {
+	data, err := os.ReadFile(srcAbs)
+	if err != nil {
+		return nil, fmt.Errorf("pack-inline: read %s: %w", srcAbs, err)
+	}
+	wf, err := parser.NewParser(string(data), srcAbs).Parse()
+	if err != nil {
+		return nil, fmt.Errorf("pack-inline: parse %s: %w", srcAbs, err)
+	}
+	if err := parser.ResolveFileDirectives(wf, filepath.Dir(srcAbs)); err != nil {
+		return nil, fmt.Errorf("pack-inline: %w", err)
+	}
+	clearCommandFileDirectives(wf)
+	if err := writeShadowFile(srcAbs, rootDir, shadowDir, wf); err != nil {
+		return nil, err
+	}
+	return collectRefPaths(wf, filepath.Dir(srcAbs))
+}
+
+// clearCommandFileDirectives walks every tool node in wf and clears its
+// CommandFile field. The formatter emits command_file: when CommandFile is
+// set (preserving directive form on round-trip); we clear it after resolving
+// so the formatter emits the inlined command: text instead.
+func clearCommandFileDirectives(wf *ir.Workflow) {
+	for _, n := range wf.Nodes {
+		tc, ok := n.Config.(ir.ToolConfig)
+		if !ok || tc.CommandFile == "" {
+			continue
+		}
+		tc.CommandFile = ""
+		n.Config = tc
+	}
+}
+
+// writeShadowFile mirrors srcAbs's path under shadowDir (relative to rootDir)
+// and writes the formatted workflow text to the resulting location.
+func writeShadowFile(srcAbs, rootDir, shadowDir string, wf *ir.Workflow) error {
+	rel, err := filepath.Rel(rootDir, srcAbs)
+	if err != nil {
+		return err
+	}
+	dst := filepath.Join(shadowDir, rel)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, []byte(formatter.Format(wf)), 0o644)
+}
+
+// collectRefPaths returns absolute disk paths for every subgraph ref in wf,
+// resolved against srcDir (the directory of the workflow that declared them).
+// Returns an error if any ref escapes the source root would only matter for
+// dipx.Pack's later walk — we leave that validation to dipx and just enqueue
+// the reachable refs here.
+func collectRefPaths(wf *ir.Workflow, srcDir string) ([]string, error) {
+	var out []string
+	for _, n := range wf.Nodes {
+		ref := refFromNodeForShadow(n)
+		if ref == "" {
+			continue
+		}
+		target, err := filepath.Abs(filepath.Join(srcDir, ref))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, target)
+	}
+	return out, nil
+}
+
+// refFromNodeForShadow mirrors dipx/helpers.go::refFromNode. Duplicated here
+// because dipx exports the type-switch logic only through Pack's internal
+// walker. Keep the two in sync: the set of ref-bearing node kinds must match
+// so dipx.Pack's subgraph walk sees the same set we shadow.
+func refFromNodeForShadow(n *ir.Node) string {
+	switch cfg := n.Config.(type) {
+	case ir.SubgraphConfig:
+		return cfg.Ref
+	case ir.ManagerLoopConfig:
+		return cfg.SubgraphRef
+	}
+	return ""
+}

--- a/docs/GRAMMAR.ebnf
+++ b/docs/GRAMMAR.ebnf
@@ -107,6 +107,7 @@ tool_node       = "tool" IDENTIFIER NEWLINE
                   INDENT { tool_field | common_field } OUTDENT ;
 
 tool_field      = "command" ":" field_value
+                | "command_file" ":" field_value
                 | "timeout" ":" DURATION
                 | "outputs" ":" identifier_list ;
 

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -47,7 +47,7 @@ workflow <Name>
 |------|----------------|-----------------|
 | `agent` | `prompt` | `model`, `provider`, `backend`, `working_dir`, `tool_access` (`none` disables LLM tools; DIP139 warns on unknown), `auto_status`, `goal_gate`, `reasoning_effort`, `fidelity`, `max_turns`, `system_prompt` |
 | `human` | `mode` (freeform\|choice\|interview\|yes_no) | `default`, `timeout` (duration, e.g. 5m), `timeout_action` (string: fail\|default) |
-| `tool` | `command` | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes) |
+| `tool` | `command` (or `command_file`) | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes), `command_file` (path to external script, relative to .dip dir) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
 | `subgraph` | `ref` | `params` |

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -261,7 +261,8 @@ Tool nodes execute shell commands and capture their output.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `command` | Multiline | — | Shell command(s) to execute. Supports full shell syntax including pipes, conditionals, and multi-line scripts. The command's stdout is captured as `ctx.tool_stdout` and stderr as `ctx.tool_stderr`. |
+| `command` | Multiline | Required (unless `command_file`) | Shell command(s) to execute. Supports full shell syntax including pipes, conditionals, and multi-line scripts. The command's stdout is captured as `ctx.tool_stdout` and stderr as `ctx.tool_stderr`. |
+| `command_file` | String | — | Path (relative to the `.dip` source directory) to an external file whose contents replace inline `command:`. Mutually exclusive with `command`. Loaded at CLI entry points (`dippin lint`, `pack`, `validate`); LSP and playground see the path unresolved. Security: absolute paths rejected, parent-tree escape rejected, symlinks rejected, 4 MiB size cap. |
 | `timeout` | Duration | — | Maximum execution time (e.g., `"30s"`, `"2m"`, `"1m30s"`). If the command exceeds this duration, it is killed. **Recommended** — the linter warns (DIP111) if omitted. |
 | `outputs` | CSV | — | Declared possible stdout values (comma-separated). Used by `dippin coverage` to check whether outgoing edge conditions cover all tool outputs. Advisory — not enforced at runtime. |
 | `marker_grep` | String | — | Regex matched line-by-line against captured stdout. The last match populates `ctx.tool_marker`. Tracker validates and applies the regex at runtime. |

--- a/docs/superpowers/specs/2026-05-27-issue-52-command-file-design.md
+++ b/docs/superpowers/specs/2026-05-27-issue-52-command-file-design.md
@@ -25,12 +25,12 @@ tool Setup
 
 These are tracked as numbered follow-up issues, filed before merge (§ Release coordination):
 
-1. **`prompt_file:` and `system_prompt_file:` directives.** The cited production pain (tracker's `build_product.dip` heredoc bloat) is entirely shell scripts in tool nodes. Prompt variants ship when a workflow with the analogous prompt-bloat pain surfaces.
-2. **Configurable size cap.** v1 hardcodes 4MB. When someone has a legitimate larger file, file an issue with the use case and pick a real default; don't pre-emptively configure.
-3. **Symlink full-chain resolution.** v1 uses `os.Lstat` to reject symlinks at the directive's path. Full `EvalSymlinks` resolution (catching symlinks deeper in the resolved path) is deferred.
-4. **Glob support** (`command_file: scripts/*.sh`). Composition semantics undefined; no current need.
-5. **DOT round-trip preservation of `command_file:`.** DOT export emits inlined `command` only; pack-then-unpack loses the directive form. Spec documents the trade-off explicitly. Tracker reads from `.dipx` bundles where content is already inlined; no current consumer needs the path.
-6. **Graceful LSP/WASM "file directive seen; not loaded in this context" message.** Authors using the playground or LSP see `cfg.Command == ""` for tool nodes with `command_file:` set. v1 lets this silently work for lint (which doesn't dereference `Command`); a future polish surfaces a clearer signal.
+1. **`prompt_file:` and `system_prompt_file:` directives.** The cited production pain (tracker's `build_product.dip` heredoc bloat) is entirely shell scripts in tool nodes. Prompt variants ship when a workflow with the analogous prompt-bloat pain surfaces. ([#65](https://github.com/2389-research/dippin-lang/issues/65))
+2. **Configurable size cap.** v1 hardcodes 4MB. When someone has a legitimate larger file, file an issue with the use case and pick a real default; don't pre-emptively configure. ([#66](https://github.com/2389-research/dippin-lang/issues/66))
+3. **Symlink full-chain resolution.** v1 uses `os.Lstat` to reject symlinks at the directive's path. Full `EvalSymlinks` resolution (catching symlinks deeper in the resolved path) is deferred. ([#67](https://github.com/2389-research/dippin-lang/issues/67))
+4. **Glob support** (`command_file: scripts/*.sh`). Composition semantics undefined; no current need. ([#68](https://github.com/2389-research/dippin-lang/issues/68))
+5. **DOT round-trip preservation of `command_file:`.** DOT export emits inlined `command` only; pack-then-unpack loses the directive form. Spec documents the trade-off explicitly. Tracker reads from `.dipx` bundles where content is already inlined; no current consumer needs the path. ([#69](https://github.com/2389-research/dippin-lang/issues/69))
+6. **Graceful LSP/WASM "file directive seen; not loaded in this context" message.** Authors using the playground or LSP see `cfg.Command == ""` for tool nodes with `command_file:` set. v1 lets this silently work for lint (which doesn't dereference `Command`); a future polish surfaces a clearer signal. ([#70](https://github.com/2389-research/dippin-lang/issues/70))
 
 ## Dippin-side design
 
@@ -318,12 +318,12 @@ Auto-handled (no change needed): tree-sitter grammar, Zed highlights, site `high
 
 (Mirrors the #41 "task #0" pattern that broke the DIP28 anti-pattern of unfilled "follow-up if needed" promises.)
 
-1. **Add `prompt_file:` and `system_prompt_file:` directives.** When workflow authors hit prompt-bloat analogous to the shell-script pain, ship the symmetric directives. Estimated v0.34 or v0.35.
-2. **Configurable size cap for `*_file:` directives.** v1 hardcodes 4MB. If a legitimate use case exceeds it, expose a workflow-level or CLI-level config.
-3. **Symlink full-chain resolution via `EvalSymlinks`.** v1 only rejects symlinks at the directive's path. A deeper symlink (in a parent directory that resolves elsewhere) could still escape. Tighten if the threat model requires.
-4. **Glob support for `command_file:` patterns.** `command_file: scripts/*.sh` expansion with defined composition semantics.
-5. **Preserve `command_file:` path through DOT round-trip.** Required if tracker (or any other consumer) wants source-path attribution in debugging output. Currently no consumer needs this.
-6. **Graceful LSP/WASM "file directive seen; not loaded in this context" signal.** v1 lets these contexts silently render the unresolved IR. A future polish surfaces a clearer note in the LSP diagnostic stream and the playground UI.
+1. **Add `prompt_file:` and `system_prompt_file:` directives.** When workflow authors hit prompt-bloat analogous to the shell-script pain, ship the symmetric directives. Estimated v0.34 or v0.35. ([#65](https://github.com/2389-research/dippin-lang/issues/65))
+2. **Configurable size cap for `*_file:` directives.** v1 hardcodes 4MB. If a legitimate use case exceeds it, expose a workflow-level or CLI-level config. ([#66](https://github.com/2389-research/dippin-lang/issues/66))
+3. **Symlink full-chain resolution via `EvalSymlinks`.** v1 only rejects symlinks at the directive's path. A deeper symlink (in a parent directory that resolves elsewhere) could still escape. Tighten if the threat model requires. ([#67](https://github.com/2389-research/dippin-lang/issues/67))
+4. **Glob support for `command_file:` patterns.** `command_file: scripts/*.sh` expansion with defined composition semantics. ([#68](https://github.com/2389-research/dippin-lang/issues/68))
+5. **Preserve `command_file:` path through DOT round-trip.** Required if tracker (or any other consumer) wants source-path attribution in debugging output. Currently no consumer needs this. ([#69](https://github.com/2389-research/dippin-lang/issues/69))
+6. **Graceful LSP/WASM "file directive seen; not loaded in this context" signal.** v1 lets these contexts silently render the unresolved IR. A future polish surfaces a clearer note in the LSP diagnostic stream and the playground UI. ([#70](https://github.com/2389-research/dippin-lang/issues/70))
 
 ## Complexity budgets
 

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -145,7 +145,7 @@
           }
         },
         {
-          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|marker_grep|route_required|output_limit|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|tool_access|class|reads|writes)\\s*(:)",
+          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|marker_grep|command_file|route_required|output_limit|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|tool_access|class|reads|writes)\\s*(:)",
           "captures": {
             "1": { "name": "entity.name.tag.field.dippin" },
             "2": { "name": "punctuation.separator.key-value.dippin" }

--- a/examples/external_files.dip
+++ b/examples/external_files.dip
@@ -1,0 +1,16 @@
+workflow ExternalFiles
+  goal: "Demonstrate command_file: directive (issue #52)"
+  start: Setup
+  exit: Verify
+
+  tool Setup
+    timeout: 30s
+    command_file: external_files/setup.sh
+
+  agent Verify
+    model: claude-sonnet-4-6
+    prompt: "Confirm setup ran successfully. STATUS: success or STATUS: fail."
+    auto_status: true
+
+  edges
+    Setup -> Verify

--- a/examples/external_files/setup.sh
+++ b/examples/external_files/setup.sh
@@ -1,0 +1,4 @@
+set -eu
+echo "Running external setup script..."
+mkdir -p .ai/scratch
+echo "ready" > .ai/scratch/setup.done

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -510,7 +510,9 @@ func writeToolFields(wr *writer, n *ir.Node, cfg ir.ToolConfig) {
 		wr.line("timeout: %s", formatDuration(cfg.Timeout))
 	}
 	writeIOFields(wr, n)
-	if cfg.Command != "" {
+	if cfg.CommandFile != "" {
+		wr.line("command_file: %s", quoteValue(cfg.CommandFile))
+	} else if cfg.Command != "" {
 		wr.multilineBlock("command", cfg.Command)
 	}
 }

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -1993,3 +1993,48 @@ func TestFormat_AgentToolAccessWhitespaceOnly(t *testing.T) {
 		t.Errorf("whitespace-only tool_access should not appear in formatted output:\n%s", out)
 	}
 }
+
+func TestFormat_ToolCommandFile(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: A
+
+  tool A
+    command_file: scripts/setup.sh
+`
+	p := parser.NewParser(src, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	out := Format(w)
+	if !strings.Contains(out, "command_file: scripts/setup.sh") {
+		t.Errorf("formatted output missing command_file directive:\n%s", out)
+	}
+	// And it should NOT also emit a multi-line command: block
+	if strings.Contains(out, "command:") {
+		t.Errorf("formatted output should not contain inline command: when file form used:\n%s", out)
+	}
+}
+
+func TestFormat_ToolCommandInline(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: A
+
+  tool A
+    command: echo hi
+`
+	p := parser.NewParser(src, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	out := Format(w)
+	if !strings.Contains(out, "command:") {
+		t.Errorf("formatted output missing inline command:\n%s", out)
+	}
+	if strings.Contains(out, "command_file:") {
+		t.Errorf("formatted output should not contain command_file when inline used:\n%s", out)
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -128,6 +128,7 @@ func (HumanConfig) nodeConfig() {}
 // ToolConfig holds configuration for shell command nodes.
 type ToolConfig struct {
 	Command       string // Shell command (multiline OK)
+	CommandFile   string // Source path when Command was loaded from command_file:; empty if inline. Populated by parser.ResolveFileDirectives.
 	Timeout       time.Duration
 	Outputs       []string // Declared possible stdout values for coverage analysis
 	MarkerGrep    string   // Regex matched line-by-line against stdout; populates ctx.tool_marker

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -53,6 +53,7 @@ func fieldCompletions() []protocol.CompletionItem {
 		{"fidelity:", "Fidelity level"},
 		{"tool_access:", "LLM tool catalog gate on agent (none = no tools; omit = full)"},
 		{"marker_grep:", "Regex matched against tool stdout; sets ctx.tool_marker"},
+		{"command_file:", "External script reference for tool node (path relative to .dip dir)"},
 		{"route_required:", "Require _TRACKER_ROUTE= sentinel line from tool stdout"},
 		{"output_limit:", "Per-node stdout byte cap (non-negative int; 0 = engine default)"},
 	}

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -425,6 +425,16 @@ func TestFieldCompletionsIncludesToolAccess(t *testing.T) {
 	t.Error("missing completion for 'tool_access:' (v0.32.0 safety primitive)")
 }
 
+func TestFieldCompletionsIncludesCommandFile(t *testing.T) {
+	items := fieldCompletions()
+	for _, it := range items {
+		if it.Label == "command_file:" {
+			return
+		}
+	}
+	t.Error("missing completion for 'command_file:' (v0.33.0 directive)")
+}
+
 func TestConvertDiagnostic(t *testing.T) {
 	d := validator.Diagnostic{
 		Code:     "DIP001",

--- a/migrate/parity.go
+++ b/migrate/parity.go
@@ -281,6 +281,9 @@ func compareToolCommandAndTimeout(id string, ac, bc ir.ToolConfig) []Difference 
 	if !promptsEqual(ac.Command, bc.Command) {
 		diffs = append(diffs, fieldDiff(id, "command", fmt.Sprintf("node %q command differs", id)))
 	}
+	if ac.CommandFile != bc.CommandFile {
+		diffs = append(diffs, fieldDiff(id, "command_file", fmt.Sprintf("node %q command_file: %q vs %q", id, ac.CommandFile, bc.CommandFile)))
+	}
 	if ac.Timeout != bc.Timeout {
 		diffs = append(diffs, fieldDiff(id, "timeout", fmt.Sprintf("node %q timeout: %s vs %s", id, ac.Timeout, bc.Timeout)))
 	}

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -407,7 +407,7 @@ func applyHumanInterviewField(cfg *ir.HumanConfig, key, val string) bool {
 // applyToolField applies tool-specific configuration fields.
 func (p *Parser) applyToolField(cfg *ir.ToolConfig, key, val string, loc ir.SourceLocation) {
 	if applyToolStringField(cfg, key, val) {
-		p.checkCommandFileConflict(cfg, loc)
+		p.checkCommandFileConflict(cfg, key, loc)
 		return
 	}
 	if p.applyToolBoolField(cfg, key, val, loc) {
@@ -421,8 +421,13 @@ func (p *Parser) applyToolField(cfg *ir.ToolConfig, key, val string, loc ir.Sour
 
 // checkCommandFileConflict emits a diagnostic if both command: and command_file:
 // are set on the same tool node. Per spec, this is a parser-time error (not a
-// DIP code) because the conflict is syntactic.
-func (p *Parser) checkCommandFileConflict(cfg *ir.ToolConfig, loc ir.SourceLocation) {
+// DIP code) because the conflict is syntactic. Gated on the assigning key being
+// command or command_file so subsequent unrelated tool string-field writes
+// (outputs, marker_grep, etc.) don't re-emit the same diagnostic.
+func (p *Parser) checkCommandFileConflict(cfg *ir.ToolConfig, key string, loc ir.SourceLocation) {
+	if key != "command" && key != "command_file" {
+		return
+	}
 	if cfg.Command != "" && cfg.CommandFile != "" {
 		p.diagnostics = append(p.diagnostics, fmt.Sprintf(
 			"tool node has both `command` and `command_file` set; choose one at %d:%d",

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -407,6 +407,7 @@ func applyHumanInterviewField(cfg *ir.HumanConfig, key, val string) bool {
 // applyToolField applies tool-specific configuration fields.
 func (p *Parser) applyToolField(cfg *ir.ToolConfig, key, val string, loc ir.SourceLocation) {
 	if applyToolStringField(cfg, key, val) {
+		p.checkCommandFileConflict(cfg, loc)
 		return
 	}
 	if p.applyToolBoolField(cfg, key, val, loc) {
@@ -418,11 +419,24 @@ func (p *Parser) applyToolField(cfg *ir.ToolConfig, key, val string, loc ir.Sour
 	p.emitUnknownFieldHint("tool", key, loc)
 }
 
+// checkCommandFileConflict emits a diagnostic if both command: and command_file:
+// are set on the same tool node. Per spec, this is a parser-time error (not a
+// DIP code) because the conflict is syntactic.
+func (p *Parser) checkCommandFileConflict(cfg *ir.ToolConfig, loc ir.SourceLocation) {
+	if cfg.Command != "" && cfg.CommandFile != "" {
+		p.diagnostics = append(p.diagnostics, fmt.Sprintf(
+			"tool node has both `command` and `command_file` set; choose one at %d:%d",
+			loc.Line, loc.Column))
+	}
+}
+
 // applyToolStringField handles string-valued tool fields. Returns true if handled.
 func applyToolStringField(cfg *ir.ToolConfig, key, val string) bool {
 	switch key {
 	case "command":
 		cfg.Command = val
+	case "command_file":
+		cfg.CommandFile = val
 	case "outputs":
 		cfg.Outputs = splitComma(val)
 	case "marker_grep":

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2155,3 +2155,98 @@ func TestParseAgent_ToolAccess(t *testing.T) {
 		})
 	}
 }
+
+func TestParseTool_CommandFile(t *testing.T) {
+	cases := []struct {
+		name             string
+		src              string
+		wantFile         string
+		wantCommand      string
+		wantDiagContains string // substring expected in any parser diagnostic; "" = no diagnostic expected
+	}{
+		{
+			name: "command_file only",
+			src: `workflow X
+  start: A
+  exit: A
+
+  tool A
+    command_file: scripts/setup.sh
+`,
+			wantFile:    "scripts/setup.sh",
+			wantCommand: "",
+		},
+		{
+			name: "command only (unchanged behavior)",
+			src: `workflow X
+  start: A
+  exit: A
+
+  tool A
+    command: echo hi
+`,
+			wantFile:    "",
+			wantCommand: "echo hi",
+		},
+		{
+			name: "both set (command first)",
+			src: `workflow X
+  start: A
+  exit: A
+
+  tool A
+    command: echo hi
+    command_file: scripts/setup.sh
+`,
+			wantDiagContains: "both `command` and `command_file`",
+		},
+		{
+			name: "both set (command_file first)",
+			src: `workflow X
+  start: A
+  exit: A
+
+  tool A
+    command_file: scripts/setup.sh
+    command: echo hi
+`,
+			wantDiagContains: "both `command` and `command_file`",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.src, "test.dip")
+			w, _ := p.Parse() // some cases expect diagnostics; don't fail on parse error
+			if tc.wantDiagContains != "" {
+				found := false
+				for _, d := range p.diagnostics {
+					if strings.Contains(d, tc.wantDiagContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected diagnostic containing %q; got %v", tc.wantDiagContains, p.diagnostics)
+				}
+				return
+			}
+			if w == nil {
+				t.Fatalf("unexpected nil workflow")
+			}
+			node := w.Node("A")
+			if node == nil {
+				t.Fatalf("node A not found")
+			}
+			cfg, ok := node.Config.(ir.ToolConfig)
+			if !ok {
+				t.Fatalf("expected ToolConfig, got %T", node.Config)
+			}
+			if cfg.CommandFile != tc.wantFile {
+				t.Errorf("CommandFile = %q, want %q", cfg.CommandFile, tc.wantFile)
+			}
+			if cfg.Command != tc.wantCommand {
+				t.Errorf("Command = %q, want %q", cfg.Command, tc.wantCommand)
+			}
+		})
+	}
+}

--- a/parser/resolve.go
+++ b/parser/resolve.go
@@ -1,0 +1,104 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+const maxDirectiveFileSize = 4 << 20 // 4 MiB
+
+// ResolveFileDirectives loads file contents for every tool node with
+// CommandFile set, populating Command from the file's bytes. Paths are
+// resolved relative to baseDir (typically the directory of the .dip
+// source file). Returns the first error encountered.
+//
+// Parser entry points (NewParser/Parse) do NOT call this — they stay pure.
+// CLI entry points call it after parsing. LSP and WASM contexts skip it;
+// the IR retains the CommandFile-set / Command-empty state, which is the
+// correct unresolved view for those consumers.
+func ResolveFileDirectives(w *ir.Workflow, baseDir string) error {
+	for _, n := range w.Nodes {
+		if err := resolveNodeDirective(n, baseDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveNodeDirective resolves a single node's CommandFile, if any.
+// Returns nil if the node has no tool config, no CommandFile, or already
+// has an inline Command populated (inline wins — Task 2's parser check
+// should prevent both being set, but be defensive).
+func resolveNodeDirective(n *ir.Node, baseDir string) error {
+	tc, ok := n.Config.(ir.ToolConfig)
+	if !ok || tc.CommandFile == "" || tc.Command != "" {
+		return nil
+	}
+	contents, err := loadDirectiveFile(baseDir, tc.CommandFile)
+	if err != nil {
+		return fmt.Errorf("node %q command_file: %w", n.ID, err)
+	}
+	tc.Command = string(contents)
+	n.Config = tc
+	return nil
+}
+
+// loadDirectiveFile resolves p relative to baseDir, applies path security
+// checks, and reads the file. Error messages reference the user-written
+// path (p), never the resolved absolute path, to avoid leaking directory
+// structure into diagnostics.
+func loadDirectiveFile(baseDir, p string) ([]byte, error) {
+	resolved, err := safeResolve(baseDir, p)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("path %q: %w", p, err)
+	}
+	if err := checkFileInfo(p, info); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(resolved)
+}
+
+// safeResolve joins baseDir/p and ensures the result stays under baseDir.
+// Rejects absolute paths and any path that escapes via `..`.
+func safeResolve(baseDir, p string) (string, error) {
+	if filepath.IsAbs(p) {
+		return "", fmt.Errorf("absolute paths not allowed: %q", p)
+	}
+	resolved := filepath.Join(baseDir, p)
+	rel, err := filepath.Rel(baseDir, resolved)
+	if err != nil || hasParentRef(rel) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("path %q resolves outside source directory", p)
+	}
+	return resolved, nil
+}
+
+// checkFileInfo enforces symlink and size policies on the resolved file.
+func checkFileInfo(p string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("symlinks not allowed: %q", p)
+	}
+	if info.Size() > maxDirectiveFileSize {
+		return fmt.Errorf("file %q exceeds %d byte limit (size %d)", p, maxDirectiveFileSize, info.Size())
+	}
+	return nil
+}
+
+// hasParentRef returns true if rel contains a `..` path segment.
+// Used as defensive belt after filepath.Rel; should not fire on a
+// non-symlink filesystem since Rel canonicalizes already.
+func hasParentRef(rel string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(rel), "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/parser/resolve.go
+++ b/parser/resolve.go
@@ -1,7 +1,9 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,20 +52,49 @@ func resolveNodeDirective(n *ir.Node, baseDir string) error {
 // loadDirectiveFile resolves p relative to baseDir, applies path security
 // checks, and reads the file. Error messages reference the user-written
 // path (p), never the resolved absolute path, to avoid leaking directory
-// structure into diagnostics.
+// structure into diagnostics. In particular, *fs.PathError values from
+// os.Lstat / os.ReadFile carry the resolved absolute path in their
+// stringification, so we never wrap them with %w — instead we branch on
+// the error kind and emit a user-path-only message.
 func loadDirectiveFile(baseDir, p string) ([]byte, error) {
 	resolved, err := safeResolve(baseDir, p)
 	if err != nil {
 		return nil, err
 	}
-	info, err := os.Lstat(resolved)
+	info, err := statDirectiveFile(p, resolved)
 	if err != nil {
-		return nil, fmt.Errorf("path %q: %w", p, err)
+		return nil, err
 	}
 	if err := checkFileInfo(p, info); err != nil {
 		return nil, err
 	}
-	return os.ReadFile(resolved)
+	return readDirectiveFile(p, resolved)
+}
+
+// statDirectiveFile lstats the resolved path, rewriting any error so it
+// only mentions the user-written path p (never the absolute resolved one).
+func statDirectiveFile(p, resolved string) (os.FileInfo, error) {
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("file %q not found", p)
+		}
+		return nil, fmt.Errorf("cannot stat file %q: not accessible", p)
+	}
+	return info, nil
+}
+
+// readDirectiveFile reads the resolved path, rewriting any error so it
+// only mentions the user-written path p (never the absolute resolved one).
+func readDirectiveFile(p, resolved string) ([]byte, error) {
+	contents, err := os.ReadFile(resolved)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("file %q not found", p)
+		}
+		return nil, fmt.Errorf("cannot read file %q: not accessible", p)
+	}
+	return contents, nil
 }
 
 // safeResolve joins baseDir/p and ensures the result stays under baseDir.

--- a/parser/resolve_test.go
+++ b/parser/resolve_test.go
@@ -1,0 +1,155 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+func TestResolveFileDirectives_LoadsContent(t *testing.T) {
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "setup.sh",
+			}},
+		},
+	}
+	baseDir := "testdata/command_file"
+	if err := ResolveFileDirectives(w, baseDir); err != nil {
+		t.Fatalf("ResolveFileDirectives: %v", err)
+	}
+	cfg := w.Nodes[0].Config.(ir.ToolConfig)
+	if !strings.Contains(cfg.Command, "fixture: ResolveFileDirectives test") {
+		t.Errorf("Command not populated from file; got %q", cfg.Command)
+	}
+	if cfg.CommandFile != "setup.sh" {
+		t.Errorf("CommandFile = %q, want %q", cfg.CommandFile, "setup.sh")
+	}
+}
+
+func TestResolveFileDirectives_SkipsInline(t *testing.T) {
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				Command: "inline content",
+			}},
+		},
+	}
+	if err := ResolveFileDirectives(w, "testdata/command_file"); err != nil {
+		t.Fatalf("ResolveFileDirectives: %v", err)
+	}
+	cfg := w.Nodes[0].Config.(ir.ToolConfig)
+	if cfg.Command != "inline content" {
+		t.Errorf("inline Command modified: %q", cfg.Command)
+	}
+}
+
+func TestResolveFileDirectives_RejectsAbsolutePath(t *testing.T) {
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "/etc/passwd",
+			}},
+		},
+	}
+	err := ResolveFileDirectives(w, "testdata/command_file")
+	if err == nil || !strings.Contains(err.Error(), "absolute paths not allowed") {
+		t.Errorf("expected absolute-path rejection; got %v", err)
+	}
+	// Error must reference the user-written path
+	if !strings.Contains(err.Error(), "/etc/passwd") {
+		t.Errorf("error should reference user-written path /etc/passwd; got %v", err)
+	}
+}
+
+func TestResolveFileDirectives_RejectsParentEscape(t *testing.T) {
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "../../../etc/passwd",
+			}},
+		},
+	}
+	err := ResolveFileDirectives(w, "testdata/command_file")
+	if err == nil || !strings.Contains(err.Error(), "resolves outside source directory") {
+		t.Errorf("expected parent-escape rejection; got %v", err)
+	}
+}
+
+func TestResolveFileDirectives_RejectsPostCleanEscape(t *testing.T) {
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "legit/../../../etc/passwd",
+			}},
+		},
+	}
+	err := ResolveFileDirectives(w, "testdata/command_file")
+	if err == nil || !strings.Contains(err.Error(), "resolves outside source directory") {
+		t.Errorf("expected post-Clean escape rejection; got %v", err)
+	}
+}
+
+func TestResolveFileDirectives_RejectsSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	external := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(external, []byte("external"), 0o644); err != nil {
+		t.Fatalf("write external: %v", err)
+	}
+	linkPath := filepath.Join(tmp, "link.sh")
+	if err := os.Symlink(external, linkPath); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "link.sh",
+			}},
+		},
+	}
+	err := ResolveFileDirectives(w, tmp)
+	if err == nil || !strings.Contains(err.Error(), "symlinks not allowed") {
+		t.Errorf("expected symlink rejection; got %v", err)
+	}
+}
+
+func TestResolveFileDirectives_RejectsOversize(t *testing.T) {
+	tmp := t.TempDir()
+	bigPath := filepath.Join(tmp, "big.sh")
+	// Write 4 MiB + 1 byte
+	big := make([]byte, (4<<20)+1)
+	if err := os.WriteFile(bigPath, big, 0o644); err != nil {
+		t.Fatalf("write big: %v", err)
+	}
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "big.sh",
+			}},
+		},
+	}
+	err := ResolveFileDirectives(w, tmp)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected oversize rejection; got %v", err)
+	}
+}
+
+func TestResolveFileDirectives_MissingFile(t *testing.T) {
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "nonexistent.sh",
+			}},
+		},
+	}
+	err := ResolveFileDirectives(w, "testdata/command_file")
+	if err == nil {
+		t.Errorf("expected missing-file error; got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent.sh") {
+		t.Errorf("error should reference user-written path; got %v", err)
+	}
+}

--- a/parser/resolve_test.go
+++ b/parser/resolve_test.go
@@ -138,6 +138,13 @@ func TestResolveFileDirectives_RejectsOversize(t *testing.T) {
 }
 
 func TestResolveFileDirectives_MissingFile(t *testing.T) {
+	// Use an absolute baseDir so we can detect leaks of the resolved
+	// absolute path in error messages. The CLI typically resolves to
+	// absolute paths before invoking ResolveFileDirectives.
+	absBase, err := filepath.Abs("testdata/command_file")
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
 	w := &ir.Workflow{
 		Nodes: []*ir.Node{
 			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
@@ -145,11 +152,16 @@ func TestResolveFileDirectives_MissingFile(t *testing.T) {
 			}},
 		},
 	}
-	err := ResolveFileDirectives(w, "testdata/command_file")
+	err = ResolveFileDirectives(w, absBase)
 	if err == nil {
-		t.Errorf("expected missing-file error; got nil")
+		t.Fatalf("expected missing-file error; got nil")
 	}
+	// Error must reference the user-written path
 	if !strings.Contains(err.Error(), "nonexistent.sh") {
 		t.Errorf("error should reference user-written path; got %v", err)
+	}
+	// Error must NOT contain the resolved absolute path (information leak).
+	if strings.Contains(err.Error(), absBase) {
+		t.Errorf("error leaked resolved absolute path %q in message: %v", absBase, err)
 	}
 }

--- a/parser/testdata/command_file/setup.sh
+++ b/parser/testdata/command_file/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -eu
+echo "fixture: ResolveFileDirectives test"

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,21 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.33.0] — RELEASE_DATE
+
+New `command_file:` directive on tool nodes replaces inline `command:` heredocs with external file references. Solves the heredoc-bloat pattern seen in long tracker workflows. Dippin-only release — no tracker coordination required (tracker reads inlined `Command` from `.dipx` bundles unchanged).
+
+### Added
+- `command_file: <path>` directive on tool nodes. Path is relative to the `.dip` source directory.
+- `parser.ResolveFileDirectives(w, baseDir)` — separate-pass file loader called by CLI entry points. Parser itself stays pure.
+- Path security in the resolver: absolute-path reject, parent-tree-escape reject, symlink reject (via `Lstat`), 4 MiB size cap. Error messages reference user-written paths, not resolved absolute paths.
+- Parser-time error when both `command:` and `command_file:` are set on the same tool node.
+- `examples/external_files.dip` + `examples/external_files/setup.sh` demonstrate the directive.
+
+### Notes
+- LSP and `cmd/wasm` (playground) skip the resolver. They see `cfg.CommandFile != "" && cfg.Command == ""`, which is the correct unresolved-IR view.
+- DOT round-trip is lossy for the directive form — pack-then-unpack rewrites `command_file:` to inline `command:`. Tracker reads from `.dipx` bundles where content is already inlined; no current consumer needs the path preserved through DOT. Deferred to a follow-up issue ([#69](https://github.com/2389-research/dippin-lang/issues/69)).
+
 ## [v0.32.0] — 2026-05-27
 
 New agent-node safety primitive: `tool_access: none` strips an LLM's tool catalog. Joint release with tracker `v0.31.0` — the dippin field is meaningless without tracker enforcement, so they ship together (see [#41](https://github.com/2389-research/dippin-lang/issues/41) for context, including the v0.28.2 runaway-agent incident this bounds).

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -133,7 +133,8 @@ Invalid values fall back to no-tools at runtime (fail-closed) and are flagged by
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `command` | multiline | Shell command. Supports pipes, here-docs, case/esac. |
+| `command` | multiline | Shell command. Supports pipes, here-docs, case/esac. Required unless `command_file` is set. |
+| `command_file` | string | Path (relative to the `.dip` source directory) to an external script whose contents replace inline `command:`. Mutually exclusive with `command`. See "Tool Command File" below. |
 | `timeout` | duration | **Required** (DIP111). e.g. `30s`, `5m` |
 | `outputs` | CSV | Possible stdout values for condition checks |
 | `marker_grep` | string | Regex matched against stdout; sets `ctx.tool_marker`. Tracker validates at runtime. |
@@ -143,6 +144,23 @@ Invalid values fall back to no-tools at runtime (fail-closed) and are flagged by
 | `writes` | CSV | Context keys written |
 
 Do NOT use `${ctx.*}` in commands — they expand to empty at parse time (DIP124). Output is captured as `ctx.tool_stdout` and `ctx.tool_stderr`.
+
+**Tool Command File (`command_file:`)** — *added v0.33.0.*
+
+Reference an external file for a tool node's command instead of inlining a heredoc:
+
+```dip
+tool Setup
+  command_file: scripts/setup.sh
+```
+
+Path resolution: relative to the `.dip` source directory. Absolute paths rejected. Symlinks rejected. Parent-tree escape (`../../etc/passwd`) rejected. 4 MiB size cap.
+
+Mutually exclusive with `command:` — specifying both is a parse error.
+
+Loading: CLI entry points (`dippin lint`, `dippin pack`, `dippin validate`, `dippin doctor`) load the file contents into the IR after parse. The LSP and the playground skip loading; they show the path unresolved. Tracker reads `.dipx` bundles where content is already inlined, so the runtime sees no difference from inline `command:`.
+
+Non-goals (deferred): `prompt_file:` / `system_prompt_file:` directives ([#65](https://github.com/2389-research/dippin-lang/issues/65)), configurable size cap ([#66](https://github.com/2389-research/dippin-lang/issues/66)), full-chain symlink resolution ([#67](https://github.com/2389-research/dippin-lang/issues/67)), glob expansion ([#68](https://github.com/2389-research/dippin-lang/issues/68)), DOT round-trip preservation of the directive form ([#69](https://github.com/2389-research/dippin-lang/issues/69)), graceful LSP/WASM not-loaded signal ([#70](https://github.com/2389-research/dippin-lang/issues/70)). See issue [#52](https://github.com/2389-research/dippin-lang/issues/52).
 
 ### parallel / fan_in — concurrent execution
 


### PR DESCRIPTION
## Summary

Closes [#52](https://github.com/2389-research/dippin-lang/issues/52).

Adds `command_file:` directive on tool nodes — replaces inline `command:` heredocs with external file references. Solves real heredoc-bloat pain (tracker's `build_product.dip` is 1212 lines, ~200 of which are heredoc-write helpers for downstream `source`).

```dip
tool Setup
  command_file: scripts/setup.sh
```

**Dippin-internal** — no tracker coordination needed. Tracker reads `.dipx` bundles where content is already inlined.

## Architecture

Parser stays pure. A separate `parser.ResolveFileDirectives(w, baseDir)` pass runs at CLI entry points (`dippin lint`, `pack`, `validate`, `doctor`). LSP (`lsp/document.go`) and WASM playground (`cmd/wasm/main.go`) skip the resolver and see the unresolved IR view (`CommandFile != "" && Command == ""`) without errors.

**Path security in resolver** (4 layers):
- Absolute paths rejected
- Parent-tree escape rejected (`filepath.Rel` + defensive `..`-segment scan)
- Symlinks rejected (`os.Lstat`) — closes CI-untrusted-PR symlink-to-/etc/passwd exposure
- 4 MiB size cap

**Error messages** reference the user-written path only, never the resolved absolute path. Avoids leaking CI directory structure into PR review comments.

## What's in the PR

11 implementation commits on top of [the spec + plan](https://github.com/2389-research/dippin-lang/tree/main/docs/superpowers) (already on main):

- **IR** — `ToolConfig.CommandFile string` (single new field).
- **Parser** — one case + mutual-exclusion parser-time error (no DIP code; syntactic mistake).
- **Resolver** — new `parser/resolve.go` with `ResolveFileDirectives` + 4-layer path security. Parser stays pure.
- **CLI integration** — `parseAndResolveDip` helper called from both parse entry points in `cmd/dippin/cli.go`. `cmd_fmt.go` intentionally not changed (bare-parser path preserves directive across `dippin fmt`).
- **Resolver leak fix** — `os.Lstat` / `os.ReadFile` errors stripped of absolute path; `errors.Is(err, fs.ErrNotExist)` branch emits user-path-only message.
- **Formatter** — `cfg.CommandFile != ""` branch first; preserves directive form across `dippin fmt`.
- **Migrate parity** — `CommandFile` added to `compareToolCommandAndTimeout`.
- **Example** — `examples/external_files.dip` + `examples/external_files/setup.sh`, lint-clean (DIP111 timeout added).
- **Docs** — `docs/nodes.md`, `docs/llm-reference.md`, `docs/GRAMMAR.ebnf`, `site/static/skill.md`, `CHANGELOG.md` v0.33.0 stub with `RELEASE_DATE` placeholder. No `docs/validation.md` change (no new DIP code).
- **Integration coverage** — LSP completion + regression test + VSCode TextMate grammar entry. Tree-sitter, Zed, highlight.js, WASM playground auto-handle via generic field-name patterns (verified during squad review).

## Deferred (6 follow-up issues filed before merge, mirrors #41 task-#0 pattern)

[#65](https://github.com/2389-research/dippin-lang/issues/65) prompt_file/system_prompt_file · [#66](https://github.com/2389-research/dippin-lang/issues/66) configurable size cap · [#67](https://github.com/2389-research/dippin-lang/issues/67) EvalSymlinks full chain · [#68](https://github.com/2389-research/dippin-lang/issues/68) glob support · [#69](https://github.com/2389-research/dippin-lang/issues/69) DOT round-trip preservation · [#70](https://github.com/2389-research/dippin-lang/issues/70) LSP/WASM unresolved-IR signal

## Design journey

Initial proposal absorbed the same kinds of rings the v0.32 spec went through four times. Three-persona squad review (YAGNI/pragmatism, parser+security, future-maintainer + integration) cut scope aggressively:

- **3 directives → 1.** Cited pain is shell scripts (tool nodes), not prompts. Prompt variants deferred.
- **IR fields: 3 → 1.** Parser stays pure (correctness win for LSP/WASM); `CommandFile` is primary representation, not metadata.
- **Path security: 4 stacked layers → 4 distinct checks** with one productive addition (`Lstat` symlink reject).
- **DIP140 lint code: dropped.** Parser-time error matches the syntactic-mistake category.
- **Editor/site surfaces: most auto-handle.** Only VSCode TextMate + LSP completion needed explicit updates.

The simplification was the design. Same lesson as #41.

## Test plan
- [ ] `just check` passes (Go suite + complexity + validate-examples)
- [ ] `examples/external_files.dip` lints clean and exercises the resolver end-to-end
- [ ] Parser tests cover valid file form, valid inline form, both-set error (either ordering)
- [ ] Resolver tests cover content load, absolute reject, parent-escape reject, post-Clean escape, symlink reject, oversize reject, missing file, user-path-only error messages
- [ ] Formatter round-trips both directive and inline forms
- [ ] LSP regression test covers the new completion entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782504338&installation_id=131176874&pr_number=71&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F71&signature=67cb90ad9d140c75958bce757ebea7a9b3972eb559fb8035efdfe002200458ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add `command_file:` directive for tool nodes and CLI-side resolution that inlines external scripts for packaging and CLI analysis; LSP/playground continue to show unresolved paths.
  * Formatter now emits `command_file:` when used and pack tooling inlines referenced files.

* **Documentation**
  * Spec, grammar, examples, and changelog updated; new example workflow demonstrates external-file usage.

* **Tests**
  * Parser, resolver, formatter, lsp, and pack tests added for `command_file:` behavior and security checks.

* **Bug Fixes**
  * CI temp-file handling corrected so relative paths resolve during round-trip checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->