### PR TITLE
fix: reject full-chain symlink escapes in file directives (#67)

### DIFF
--- a/parser/resolve.go
+++ b/parser/resolve.go
@@ -160,11 +160,11 @@ func safeResolve(baseDir, p string) (string, error) {
 // defeats both. Resolving the parent — not the leaf — leaves the separate
 // leaf-symlink rejection in checkFileInfo intact. (#67)
 func checkContainment(baseDir, resolved, p string) error {
-	realBase, err := filepath.EvalSymlinks(baseDir)
+	realBase, err := realPath(baseDir)
 	if err != nil {
 		return pathErr(p, err, "stat")
 	}
-	realParent, err := filepath.EvalSymlinks(filepath.Dir(resolved))
+	realParent, err := realPath(filepath.Dir(resolved))
 	if err != nil {
 		return pathErr(p, err, "stat")
 	}
@@ -172,6 +172,20 @@ func checkContainment(baseDir, resolved, p string) error {
 		return fmt.Errorf("path %q resolves outside source directory", p)
 	}
 	return nil
+}
+
+// realPath resolves path's symlink chain and returns it absolute and cleaned.
+// Both the base and the parent must be absolute before escapesBase compares
+// them: with a relative baseDir, a symlink whose target is absolute yields a
+// relative base but an absolute parent, and filepath.Rel errors on that pair —
+// which would otherwise be misread as an escape and reject a valid in-dir file
+// (e.g. `dippin validate workflow.dip`, baseDir "."). (#67)
+func realPath(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(resolved)
 }
 
 // escapesBase reports whether target lies outside base via a `..` ancestor

--- a/parser/resolve.go
+++ b/parser/resolve.go
@@ -94,6 +94,9 @@ func loadDirectiveFile(baseDir, p string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := checkContainment(baseDir, resolved, p); err != nil {
+		return nil, err
+	}
 	info, err := statDirectiveFile(p, resolved)
 	if err != nil {
 		return nil, err
@@ -109,10 +112,7 @@ func loadDirectiveFile(baseDir, p string) ([]byte, error) {
 func statDirectiveFile(p, resolved string) (os.FileInfo, error) {
 	info, err := os.Lstat(resolved)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("file %q not found", p)
-		}
-		return nil, fmt.Errorf("cannot stat file %q: not accessible", p)
+		return nil, pathErr(p, err, "stat")
 	}
 	return info, nil
 }
@@ -122,26 +122,64 @@ func statDirectiveFile(p, resolved string) (os.FileInfo, error) {
 func readDirectiveFile(p, resolved string) ([]byte, error) {
 	contents, err := os.ReadFile(resolved)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("file %q not found", p)
-		}
-		return nil, fmt.Errorf("cannot read file %q: not accessible", p)
+		return nil, pathErr(p, err, "read")
 	}
 	return contents, nil
 }
 
+// pathErr maps a filesystem error to a user-path-only diagnostic. *fs.PathError
+// values from the os package carry the resolved absolute path in their
+// stringification, so we branch on the error kind and emit a message that names
+// only the user-written path p (verb is the failed operation, e.g. "stat").
+func pathErr(p string, err error, verb string) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("file %q not found", p)
+	}
+	return fmt.Errorf("cannot %s file %q: not accessible", verb, p)
+}
+
 // safeResolve joins baseDir/p and ensures the result stays under baseDir.
-// Rejects absolute paths and any path that escapes via `..`.
+// Rejects absolute paths and any path that escapes via `..`. This is a purely
+// lexical check; symlink-based escapes are caught separately by
+// checkContainment.
 func safeResolve(baseDir, p string) (string, error) {
 	if filepath.IsAbs(p) {
 		return "", fmt.Errorf("absolute paths not allowed: %q", p)
 	}
 	resolved := filepath.Join(baseDir, p)
-	rel, err := filepath.Rel(baseDir, resolved)
-	if err != nil || hasParentRef(rel) || filepath.IsAbs(rel) {
+	if escapesBase(baseDir, resolved) {
 		return "", fmt.Errorf("path %q resolves outside source directory", p)
 	}
 	return resolved, nil
+}
+
+// checkContainment resolves the symlink chain of the file's parent directory
+// and rejects the path if its real location escapes baseDir. safeResolve only
+// does lexical containment and checkFileInfo's Lstat only inspects the leaf, so
+// a symlinked *parent* directory (e.g. baseDir/sub -> /etc, then sub/passwd)
+// defeats both. Resolving the parent — not the leaf — leaves the separate
+// leaf-symlink rejection in checkFileInfo intact. (#67)
+func checkContainment(baseDir, resolved, p string) error {
+	realBase, err := filepath.EvalSymlinks(baseDir)
+	if err != nil {
+		return pathErr(p, err, "stat")
+	}
+	realParent, err := filepath.EvalSymlinks(filepath.Dir(resolved))
+	if err != nil {
+		return pathErr(p, err, "stat")
+	}
+	if escapesBase(realBase, realParent) {
+		return fmt.Errorf("path %q resolves outside source directory", p)
+	}
+	return nil
+}
+
+// escapesBase reports whether target lies outside base via a `..` ancestor
+// reference or an unrelated root. Shared by the lexical (safeResolve) and
+// full-chain (checkContainment) containment checks.
+func escapesBase(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	return err != nil || hasParentRef(rel) || filepath.IsAbs(rel)
 }
 
 // checkFileInfo enforces symlink and size policies on the resolved file.

--- a/parser/resolve_test.go
+++ b/parser/resolve_test.go
@@ -116,6 +116,63 @@ func TestResolveFileDirectives_RejectsSymlink(t *testing.T) {
 	}
 }
 
+func TestResolveFileDirectives_RejectsSymlinkedParentDir(t *testing.T) {
+	// The leaf file is a real (non-symlink) file, so the leaf-only Lstat
+	// check passes. The escape is via a symlinked *parent directory* that
+	// points outside baseDir — lexical filepath.Rel never resolves it, so
+	// only full-chain EvalSymlinks containment catches this. (#67)
+	tmp := t.TempDir()
+	external := t.TempDir() // sibling dir, outside tmp
+	if err := os.WriteFile(filepath.Join(external, "secret.txt"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(tmp, "sub")); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "sub/secret.txt",
+			}},
+		},
+	}
+	err := ResolveFileDirectives(w, tmp)
+	if err == nil || !strings.Contains(err.Error(), "resolves outside source directory") {
+		t.Errorf("expected symlinked-parent escape rejection; got %v", err)
+	}
+}
+
+func TestResolveFileDirectives_AllowsSymlinkedParentDirInsideBase(t *testing.T) {
+	// A symlinked parent directory that resolves to a location *inside*
+	// baseDir must still load — the containment check rejects escapes, not
+	// all symlinks. Guards against over-blocking legitimate internal links.
+	tmp := t.TempDir()
+	realSub := filepath.Join(tmp, "real_sub")
+	if err := os.Mkdir(realSub, 0o755); err != nil {
+		t.Fatalf("mkdir real_sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realSub, "data.sh"), []byte("echo hi"), 0o644); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	if err := os.Symlink(realSub, filepath.Join(tmp, "link")); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "link/data.sh",
+			}},
+		},
+	}
+	if err := ResolveFileDirectives(w, tmp); err != nil {
+		t.Fatalf("expected internal symlinked dir to load; got %v", err)
+	}
+	cfg := w.Nodes[0].Config.(ir.ToolConfig)
+	if cfg.Command != "echo hi" {
+		t.Errorf("Command not loaded through internal symlink; got %q", cfg.Command)
+	}
+}
+
 func TestResolveFileDirectives_RejectsOversize(t *testing.T) {
 	tmp := t.TempDir()
 	bigPath := filepath.Join(tmp, "big.sh")

--- a/parser/resolve_test.go
+++ b/parser/resolve_test.go
@@ -142,6 +142,48 @@ func TestResolveFileDirectives_RejectsSymlinkedParentDir(t *testing.T) {
 	}
 }
 
+func TestResolveFileDirectives_AllowsInternalSymlinkUnderRelativeBase(t *testing.T) {
+	// Regression: when baseDir is RELATIVE (e.g. `dippin validate
+	// workflow.dip` → baseDir "."), an internal symlink whose target is
+	// absolute makes EvalSymlinks(parent) absolute while EvalSymlinks(base)
+	// stays relative. filepath.Rel(relative, absolute) errors, which must
+	// NOT be read as an escape. Both sides are normalized to absolute. (#67)
+	tmp := t.TempDir()
+	realSub := filepath.Join(tmp, "real_sub")
+	if err := os.Mkdir(realSub, 0o755); err != nil {
+		t.Fatalf("mkdir real_sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realSub, "data.sh"), []byte("echo hi"), 0o644); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	// os.Symlink with an absolute target → the link resolves to an absolute path.
+	if err := os.Symlink(realSub, filepath.Join(tmp, "link")); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	relBase, err := filepath.Rel(cwd, tmp)
+	if err != nil {
+		t.Fatalf("rel base: %v", err)
+	}
+	w := &ir.Workflow{
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeTool, Config: ir.ToolConfig{
+				CommandFile: "link/data.sh",
+			}},
+		},
+	}
+	if err := ResolveFileDirectives(w, relBase); err != nil {
+		t.Fatalf("expected internal symlink under relative base to load; got %v", err)
+	}
+	cfg := w.Nodes[0].Config.(ir.ToolConfig)
+	if cfg.Command != "echo hi" {
+		t.Errorf("Command not loaded under relative base; got %q", cfg.Command)
+	}
+}
+
 func TestResolveFileDirectives_AllowsSymlinkedParentDirInsideBase(t *testing.T) {
 	// A symlinked parent directory that resolves to a location *inside*
 	// baseDir must still load — the containment check rejects escapes, not


### PR DESCRIPTION
Closes #67.

## Problem

The file-directive path-security resolver (`parser/resolve.go`) had a path-traversal gap. It enforced containment with:
1. **Lexical** parent-escape detection (`filepath.Rel`) in `safeResolve` — never resolves symlinks.
2. A **leaf-only** symlink check (`os.Lstat` on the resolved path) in `checkFileInfo`.

A symlinked **parent directory** defeats both — e.g. `baseDir/sub -> /etc`, then `command_file: sub/passwd`:
- The leaf (`passwd`) is a real file, so `Lstat` sees no symlink.
- Lexical `Rel(baseDir, baseDir/sub/passwd)` = `sub/passwd` — no `..`, so it passes.

Result: `dippin validate` / `dippin pack` would read files outside the `.dip` source directory.

## Fix

Add `checkContainment`: resolve the file's **parent directory** through `filepath.EvalSymlinks` and reject if its real location escapes the real `baseDir`. Resolving the parent (not the leaf) leaves the existing leaf-symlink rejection intact, so error messages and behavior for direct leaf symlinks are unchanged.

Refactored out two shared helpers to stay within the repo's complexity caps (cyclomatic ≤5 / cognitive ≤7):
- `escapesBase` — the `Rel`-based containment predicate, now shared by the lexical and full-chain checks.
- `pathErr` — the user-path-only error mapping (no resolved-absolute-path leak), shared by stat/read/containment.

## Tests (TDD — test written and watched fail first)

- `RejectsSymlinkedParentDir` — the escape is now rejected (`resolves outside source directory`).
- `AllowsSymlinkedParentDirInsideBase` — guard: symlinked dirs that stay **inside** `baseDir` still load (no over-blocking).
- All existing resolver tests (leaf-symlink rejection, parent escape, oversize, missing-file, agent slots) still pass.

`just check` green: 0 lint issues, complexity OK, race tests pass, examples validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782592674&installation_id=131176874&pr_number=77&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F77&signature=7fe24c7f31d0f92637d8bd7c7461ae618a4b491facec5383ad9cd8356bf67edf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Symlink handling tightened: containment is now checked earlier in the resolution flow to prevent path escapes.
  * Error reporting consolidated so filesystem failures are shown as user-path-only diagnostics for clearer, less noisy messages.

* **Tests**
  * Added tests covering symlink edge cases involving parent directories, relative bases, and internal symlinks to verify containment behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->