### PR TITLE
feat: DIP140 — lint params keys that re-enable tools under tool_access (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistr
 
 ## Lint Rules
 
-48 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP139 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
+49 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP140 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
 
 ## Testing
 

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -187,10 +187,10 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-39 diagnostic codes across two categories:
+49 diagnostic codes across two categories:
 
 - **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP133** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation
+- **DIP101–DIP140** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety
 
 ---
 
@@ -530,7 +530,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP009) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001-DIP139) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001-DIP140) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |
@@ -651,6 +651,7 @@ The primary loop for authoring .dip files:
 | DIP132 | Invalid JSON in response_schema | Fix the JSON syntax |
 | DIP133 | Params key shadows field | Rename the params key |
 | DIP139 | Invalid `tool_access` value | Use `tool_access: none` or omit the field; runtime fail-closes on unknown values |
+| DIP140 | `params` re-enables tools that `tool_access` strips | Remove the `params` key (`allowed_tools`, `disallowed_tools`, `tool_choice`, `permission_mode`); `tool_access` governs the catalog |
 
 ## Best Practices
 

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -185,7 +185,7 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-39 diagnostic codes across two categories:
+49 diagnostic codes across two categories:
 
 - **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP133** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation
+- **DIP101–DIP140** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -353,7 +353,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP009) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001-DIP139) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001-DIP140) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |
@@ -474,6 +474,7 @@ The primary loop for authoring .dip files:
 | DIP132 | Invalid JSON in response_schema | Fix the JSON syntax |
 | DIP133 | Params key shadows field | Rename the params key |
 | DIP139 | Invalid `tool_access` value | Use `tool_access: none` or omit the field; runtime fail-closes on unknown values |
+| DIP140 | `params` re-enables tools that `tool_access` strips | Remove the `params` key (`allowed_tools`, `disallowed_tools`, `tool_choice`, `permission_mode`); `tool_access` governs the catalog |
 
 ## Best Practices
 

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -404,5 +404,12 @@ func nodeValidationExplanations() map[string]Explanation {
 			Fix:     "Use `tool_access: none` to disable LLM tools, or omit the field for the full catalog. Invalid values fall back to no-tools at runtime (fail-closed) — the diagnostic surfaces the typo so author intent matches runtime behavior.",
 			Example: "agent ReportFinalStatus\n  prompt: \"Summarize\"\n  tool_access: nono   // DIP139: typo — runtime disables tools (fail-closed)",
 		},
+		DIP140: {
+			Code:    DIP140,
+			Summary: "params re-enables tools that tool_access strips",
+			Trigger: "An agent sets tool_access (any non-empty value) and also sets a params key that would re-grant tools: allowed_tools, disallowed_tools, tool_choice, or permission_mode. When tool_access is set, tracker ignores these params keys (fail-closed), so the override is silently neutralized — a likely bypass attempt or dead config.",
+			Fix:     "Remove the params key; tool_access governs the tool catalog. To grant tools instead, omit tool_access.",
+			Example: "agent Summarize\n  prompt: \"Summarize\"\n  tool_access: none\n  params:\n    allowed_tools: Bash   // DIP140: tracker strips this — tool_access wins",
+		},
 	}
 }

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -5,7 +5,7 @@ import (
 	"github.com/2389-research/dippin-lang/simulate"
 )
 
-// Lint runs all semantic quality checks (DIP101–DIP139) on the workflow
+// Lint runs all semantic quality checks (DIP101–DIP140) on the workflow
 // and returns all diagnostics found. These are warnings, not errors —
 // the workflow can still execute, but the findings indicate likely bugs
 // or quality issues.
@@ -57,6 +57,7 @@ func Lint(w *ir.Workflow) Result {
 	diags = append(diags, lintResponseSchemaJSON(w)...)
 	diags = append(diags, lintAgentParamsShadow(w)...)
 	diags = append(diags, lintToolAccessValues(w)...)
+	diags = append(diags, lintParamsReenablesTools(w)...)
 
 	return Result{Diagnostics: diags}
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP139).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP140).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge
@@ -41,6 +41,7 @@ const (
 	DIP137 = "DIP137" // unbounded manager_loop: no stop_condition and no max_cycles
 	DIP138 = "DIP138" // tool node routes on stdout but declares no marker_grep / outputs (reserved)
 	DIP139 = "DIP139" // invalid tool_access value on agent node
+	DIP140 = "DIP140" // params re-enables tools that tool_access strips
 )
 
 func init() {
@@ -84,4 +85,5 @@ func init() {
 	CodeDescription[DIP137] = "unbounded manager_loop: no stop_condition and no max_cycles"
 	CodeDescription[DIP138] = "tool node routes on stdout but declares no marker_grep / outputs"
 	CodeDescription[DIP139] = "invalid tool_access value on agent node"
+	CodeDescription[DIP140] = "params re-enables tools that tool_access strips"
 }

--- a/validator/lint_params_bypass_test.go
+++ b/validator/lint_params_bypass_test.go
@@ -1,0 +1,114 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// --- DIP140: params re-enables tools that tool_access strips ---
+
+func TestLint_DIP140_ParamsReenablesToolsUnderToolAccess(t *testing.T) {
+	for _, key := range []string{"allowed_tools", "disallowed_tools", "tool_choice", "permission_mode"} {
+		t.Run(key, func(t *testing.T) {
+			w := &ir.Workflow{
+				Name:  "dip140",
+				Start: "A",
+				Exit:  "A",
+				Nodes: []*ir.Node{
+					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+						Prompt:     "Summarize.",
+						ToolAccess: "none",
+						Params:     map[string]string{key: "Bash"},
+					}},
+				},
+			}
+			res := Lint(w)
+			if !hasCode(res.Diagnostics, DIP140) {
+				t.Errorf("expected DIP140 for params key %q under tool_access; got: %v", key, codes(res.Diagnostics))
+			}
+		})
+	}
+}
+
+func TestLint_DIP140_Severity(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "dip140_sev",
+		Start: "A",
+		Exit:  "A",
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+				Prompt:     "Summarize.",
+				ToolAccess: "none",
+				Params:     map[string]string{"allowed_tools": "Bash"},
+			}},
+		},
+	}
+	res := Lint(w)
+	for _, d := range res.Diagnostics {
+		if d.Code == DIP140 && d.Severity != SeverityWarning {
+			t.Errorf("DIP140 should be warning, got %s", d.Severity)
+		}
+	}
+}
+
+func TestLint_DIP140_NoToolAccess_NoFire(t *testing.T) {
+	// Without tool_access set, allowed_tools is a legitimate backend:
+	// claude-code knob — tracker honors it, so no bypass and no warning.
+	w := &ir.Workflow{
+		Name:  "dip140_no_access",
+		Start: "A",
+		Exit:  "A",
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+				Prompt: "Work.",
+				Params: map[string]string{"allowed_tools": "Bash"},
+			}},
+		},
+	}
+	res := Lint(w)
+	if hasCode(res.Diagnostics, DIP140) {
+		t.Errorf("DIP140 should not fire without tool_access; got: %v", codes(res.Diagnostics))
+	}
+}
+
+func TestLint_DIP140_NonToolParams_NoFire(t *testing.T) {
+	// tool_access set, but params has no tool-re-enabling key.
+	w := &ir.Workflow{
+		Name:  "dip140_other_params",
+		Start: "A",
+		Exit:  "A",
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+				Prompt:     "Summarize.",
+				ToolAccess: "none",
+				Params:     map[string]string{"temperature": "0.2"},
+			}},
+		},
+	}
+	res := Lint(w)
+	if hasCode(res.Diagnostics, DIP140) {
+		t.Errorf("DIP140 should not fire for non-tool params; got: %v", codes(res.Diagnostics))
+	}
+}
+
+// --- DIP133 now also covers params: { tool_access: ... } (shadow of the
+// first-class tool_access field) ---
+
+func TestLint_DIP133_ToolAccessShadow(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "dip133_tool_access_shadow",
+		Start: "A",
+		Exit:  "A",
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+				Prompt: "Hello.",
+				Params: map[string]string{"tool_access": "none"},
+			}},
+		},
+	}
+	res := Lint(w)
+	if !hasCode(res.Diagnostics, DIP133) {
+		t.Errorf("expected DIP133 for params tool_access shadow; got: %v", codes(res.Diagnostics))
+	}
+}

--- a/validator/lint_response.go
+++ b/validator/lint_response.go
@@ -21,7 +21,7 @@ var agentFirstClassFields = map[string]bool{
 	"reasoning_effort": true, "fidelity": true,
 	"auto_status": true, "goal_gate": true,
 	"cache_tools": true, "compaction": true,
-	"compaction_threshold": true,
+	"compaction_threshold": true, "tool_access": true,
 }
 
 func lintResponseFormat(w *ir.Workflow) []Diagnostic {

--- a/validator/lint_tool_access.go
+++ b/validator/lint_tool_access.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
@@ -37,6 +38,54 @@ func lintToolAccessValues(w *ir.Workflow) []Diagnostic {
 			Message:  fmt.Sprintf("node %q has tool_access %q which is not recognized", n.ID, cfg.ToolAccess),
 			Location: n.Source,
 			Help:     "valid value: none (omit the field for the full catalog). Invalid values fall back to no-tools at runtime — fix the typo or remove the field.",
+		})
+	}
+	return diags
+}
+
+// toolReenablingParamsKeys lists Params keys that re-grant LLM tools. When an
+// agent sets tool_access, tracker strips these (fail-closed); the lint surfaces
+// the neutralized override at author time. Source: v0.32.0 issue-41 design
+// § Params bypass defense.
+var toolReenablingParamsKeys = map[string]bool{
+	"allowed_tools":    true,
+	"disallowed_tools": true,
+	"tool_choice":      true,
+	"permission_mode":  true,
+}
+
+// lintParamsReenablesTools fires DIP140 when an agent declares tool_access
+// (non-empty) yet also sets a Params key that would re-enable tools. Tracker
+// ignores such keys when tool_access is set, so the override is silently
+// neutralized — a likely bypass attempt or dead config.
+func lintParamsReenablesTools(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, n := range w.Nodes {
+		cfg, ok := n.Config.(ir.AgentConfig)
+		if !ok || strings.TrimSpace(cfg.ToolAccess) == "" || len(cfg.Params) == 0 {
+			continue
+		}
+		diags = append(diags, checkParamsReenable(n, cfg.Params)...)
+	}
+	return diags
+}
+
+func checkParamsReenable(n *ir.Node, params map[string]string) []Diagnostic {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		if toolReenablingParamsKeys[k] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	var diags []Diagnostic
+	for _, k := range keys {
+		diags = append(diags, Diagnostic{
+			Code:     DIP140,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("node %q params key %q re-enables tools that tool_access strips — tracker ignores it", n.ID, k),
+			Location: n.Source,
+			Help:     "remove the params key; tool_access governs the tool catalog. To grant tools instead, omit tool_access.",
 		})
 	}
 	return diags


### PR DESCRIPTION
Closes #60.

## Problem

`tool_access: none` (v0.32.0) strips an agent's LLM tool catalog, but the untyped `params:` surface is an escape hatch: an author can write

```
agent Summarize
  prompt: "Summarize"
  tool_access: none
  params:
    allowed_tools: Bash      # attempts to re-grant tools
```

The v0.32.0 issue-41 design defends against this **on the tracker side** — when `tool_access` is set, tracker ignores `allowed_tools`, `disallowed_tools`, `tool_choice`, `permission_mode` (fail-closed). But that runtime defense is invisible at author time: the author gets no signal that their override was silently neutralized. This is the dippin-side companion lint the design deferred.

## Change

**New `DIP140` (Warning)** — fires when an agent declares `tool_access` (any non-empty value) **and** sets a `params` key that would re-enable tools. Message names the offending key and explains tracker ignores it.

- Does **not** fire without `tool_access` set — `allowed_tools` is then a legitimate `backend: claude-code` knob tracker honors.
- Does **not** fire for non-tool params keys.

**Also closes a related gap.** The design states "DIP133 catches the redundant `params: { tool_access: ... }` case" — but `tool_access` was missing from `agentFirstClassFields`, so it never did. Added it; the shadow case now warns as documented.

## Design notes

- New code (not an extension of DIP133): DIP133's trigger is "params key shadows a *typed first-class field*." The four tool-re-enabling keys aren't first-class fields, and the semantics differ ("neutralized bypass" vs "redundant shadow"), so they warrant distinct codes.
- Severity **Warning** (vs DIP133's Hint): a neutralized tool-grant under a safety primitive is louder than a style shadow.

## Tests (TDD — written and watched fail first)

- `DIP140` fires for each of `allowed_tools` / `disallowed_tools` / `tool_choice` / `permission_mode`.
- Correct Warning severity.
- No fire without `tool_access`; no fire for non-tool params.
- `DIP133` now fires for `params: { tool_access: ... }`.

`just check` green: 0 lint issues, complexity OK (cyclomatic ≤5 / cognitive ≤7), race tests pass, examples validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782593099&installation_id=131176874&pr_number=78&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F78&signature=f19271bdcc85142281af0e379eaa7ba2acd1127a64bdab26931af31c1632c649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new lint warning (DIP140) that flags when params keys re-enable tools despite an agent’s tool_access setting.
  * Lint now reports diagnostics up through DIP140.

* **Documentation**
  * Updated CLI/docs and reference pages to include DIP140 and the expanded diagnostic range.

* **Tests**
  * Added tests covering DIP140 behavior and related diagnostic interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->