### PR TITLE
docs: add Git Workflow policy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,15 @@ Everything flows through `ir.Workflow`. Packages import `ir` but not each other 
 
 Key gotcha: The parser stores edge conditions as `Condition.Raw` (plain text). `Condition.Parsed` (AST) is only populated by `simulate.EnsureConditionsParsed()`. Any code reading `Condition.Parsed` must ensure it's been called first — `Lint()` does this automatically.
 
+## Git Workflow
+
+- **Never commit or push to `main`.** All work happens on a unique feature branch (e.g. `fix/<issue>-<slug>`, `feat/<slug>`). Branch first, then commit.
+- **Never push directly to `main`.** Changes reach `main` only through a reviewed Pull Request. `main` is delivered to the tracker team via tags (see Versioning), so it must stay green and intentional.
+- **Work off an isolated worktree per unit of work**, not the shared checkout — so an in-progress branch never collides with other work. Use `git worktree add` (or the `superpowers:using-git-worktrees` skill).
+- **Parallel subagents each get their own worktree.** When dispatching subagents to work on independent/parallel branches of work simultaneously, give each its own git worktree (`isolation: "worktree"` for the Agent tool / `opts.isolation: "worktree"` in workflows) so concurrent edits can't conflict. Sequential subagents editing the same branch share the one worktree.
+- Leave `.claude/settings.local.json` uncommitted.
+- Commit messages end with the trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
 ## Versioning
 
 Tag semver releases after batches of meaningful changes. The tracker team **always pins to a specific dippin version, never `@latest`** — so merged work on `main` is invisible to them until it's tagged. Cutting a tag is what delivers a feature to tracker; they then bump their pin to adopt it. Update CHANGELOG.md when tagging.


### PR DESCRIPTION
## Summary
Documents the git workflow conventions in `CLAUDE.md`:

- Never commit or push to `main` — branch first (`fix/…`, `feat/…`).
- `main` changes only via reviewed PR (it's delivered to the tracker team via tags).
- One isolated git worktree per unit of work.
- Parallel subagents each get their own worktree (`isolation: "worktree"`); sequential subagents on the same branch share one.
- Leave `.claude/settings.local.json` uncommitted; standard commit-message trailer.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782663262&installation_id=131176874&pr_number=81&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F81&signature=226be69528e5c9eae5278f7919e4360c17a185be2520fbc7bf608d2087837891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines with Git workflow rules, branch isolation practices, and commit message formatting standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/dippin-lang/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->