### PR TITLE
docs: CHANGELOG v0.35.0 (writable_paths, paired with tracker v0.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.35.0] — 2026-06-02
+
+### Added
+- `writable_paths:` — a comma-separated glob list on agent nodes and parallel branches that bounds where an agent's tools may write (e.g. `writable_paths: workspace/**, .ai/sprints/**`) ([#75](https://github.com/2389-research/dippin-lang/issues/75)). Absent = unbounded; a per-branch empty value inherits the target agent's (never resets to unbounded). dippin **carries + lints**; tracker **enforces** an fs-level write jail on the `native` backend (covering `Write`/`Edit`/`ApplyPatch`, **`Bash` and any process Bash spawns**), resolved against an immutable session root. Distinct from the advisory `writes:` field (context keys). Carried through parse → IR → format → DOT export → migrate.
+- `DIP141` — `writable_paths` nullified by `tool_access: none` (dead config; nothing left to bound).
+- `DIP142` — unsafe `writable_paths` entry (absolute / `~` / Windows-drive / `..`-escape / brace mis-split). Author-clarity lint; the runtime fs-jail is the real boundary.
+- `examples/agent_writable_paths.dip` demonstrating the five motivating failure/recovery-recorder shapes.
+
+### Tracker pairing (requires tracker `>= v0.35.0`)
+- Enforcement ships in tracker [v0.35.0](https://github.com/2389-research/tracker/releases/tag/v0.35.0) ([tracker#275](https://github.com/2389-research/tracker/pull/275)): native fs-jail incl. Bash children, runtime symlink-chain resolution, immutable session-root anchor (`working_dir`/`Params` cannot relocate it), `Params`/`working_dir` bypass defense, and a single-turn red-team suite.
+- **Fail-closed.** A present-but-empty or comma-only `writable_paths:` is rejected by `dippin validate`/`pack` (parse error). A malformed or **tracker-unrecognized** value → tracker denies all writes or refuses to start, never unbounded. On `claude-code`/`acp`, tracker **refuses to start** when `writable_paths` is set (native-only enforcement) — never a prompt-level pretend-jail.
+- **Version-skew is a safety requirement, not a suggestion:** a tracker `< v0.35.0` does not enforce `writable_paths` and would run those agents **unbounded**. Pin `requires tracker >= v0.35.0`; never `@latest`.
+
+### Notes
+- The primitive bounds write *location*, not network (`curl`/`cargo fetch`), reads/exfil-by-read, or *content* within an allowed path (a `workspace/**` grant can still poison `workspace/Cargo.toml`). Chain laundering is tracked in [#56](https://github.com/2389-research/dippin-lang/issues/56).
+- Sequenced follow-ups: [#55](https://github.com/2389-research/dippin-lang/issues/55) (tool-name allowlists — now an orthogonal axis), [#53](https://github.com/2389-research/dippin-lang/issues/53) (defaults cascade).
+- Design spec: `docs/superpowers/specs/2026-05-29-issue-75-writable-paths-design.md`.
+
 ## [v0.34.0] — 2026-05-28
 
 ### Added

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,24 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.35.0] — 2026-06-02
+
+### Added
+- `writable_paths:` — a comma-separated glob list on agent nodes and parallel branches that bounds where an agent's tools may write (e.g. `writable_paths: workspace/**, .ai/sprints/**`) ([#75](https://github.com/2389-research/dippin-lang/issues/75)). Absent = unbounded; a per-branch empty value inherits the target agent's (never resets to unbounded). dippin **carries + lints**; tracker **enforces** an fs-level write jail on the `native` backend (covering `Write`/`Edit`/`ApplyPatch`, **`Bash` and any process Bash spawns**), resolved against an immutable session root. Distinct from the advisory `writes:` field (context keys). Carried through parse → IR → format → DOT export → migrate.
+- `DIP141` — `writable_paths` nullified by `tool_access: none` (dead config; nothing left to bound).
+- `DIP142` — unsafe `writable_paths` entry (absolute / `~` / Windows-drive / `..`-escape / brace mis-split). Author-clarity lint; the runtime fs-jail is the real boundary.
+- `examples/agent_writable_paths.dip` demonstrating the five motivating failure/recovery-recorder shapes.
+
+### Tracker pairing (requires tracker `>= v0.35.0`)
+- Enforcement ships in tracker [v0.35.0](https://github.com/2389-research/tracker/releases/tag/v0.35.0) ([tracker#275](https://github.com/2389-research/tracker/pull/275)): native fs-jail incl. Bash children, runtime symlink-chain resolution, immutable session-root anchor (`working_dir`/`Params` cannot relocate it), `Params`/`working_dir` bypass defense, and a single-turn red-team suite.
+- **Fail-closed.** A present-but-empty or comma-only `writable_paths:` is rejected by `dippin validate`/`pack` (parse error). A malformed or **tracker-unrecognized** value → tracker denies all writes or refuses to start, never unbounded. On `claude-code`/`acp`, tracker **refuses to start** when `writable_paths` is set (native-only enforcement) — never a prompt-level pretend-jail.
+- **Version-skew is a safety requirement, not a suggestion:** a tracker `< v0.35.0` does not enforce `writable_paths` and would run those agents **unbounded**. Pin `requires tracker >= v0.35.0`; never `@latest`.
+
+### Notes
+- The primitive bounds write *location*, not network (`curl`/`cargo fetch`), reads/exfil-by-read, or *content* within an allowed path (a `workspace/**` grant can still poison `workspace/Cargo.toml`). Chain laundering is tracked in [#56](https://github.com/2389-research/dippin-lang/issues/56).
+- Sequenced follow-ups: [#55](https://github.com/2389-research/dippin-lang/issues/55) (tool-name allowlists — now an orthogonal axis), [#53](https://github.com/2389-research/dippin-lang/issues/53) (defaults cascade).
+- Design spec: `docs/superpowers/specs/2026-05-29-issue-75-writable-paths-design.md`.
+
 ## [v0.34.0] — 2026-05-28
 
 ### Added


### PR DESCRIPTION
Release prep for **dippin v0.35.0** — the `writable_paths` primitive (#75).

The feature code already merged via #83; this adds the CHANGELOG `v0.35.0` entry (the only remaining release artifact — `skill.md`/`docs` already pin `requires tracker >= v0.35.0`).

**Joint release is now unblocked:**
- ✅ tracker enforcement merged ([tracker#275](https://github.com/2389-research/tracker/pull/275)) and **tagged tracker v0.35.0**.
- ✅ dippin `writable_paths` on `main` (#83).
- ➡️ Merge this, then tag **dippin v0.35.0** → GoReleaser publishes binaries + Homebrew. Tracker then bumps its go.mod pin from the `792e6e6` pseudo-version to `dippin v0.35.0`.

CHANGELOG entry records the field, DIP141/DIP142, the example, the tracker pairing, and the fail-closed / version-skew safety requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783025776&installation_id=131176874&pr_number=84&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F84&signature=a20282644fb241539409a6532797137b897aac3aa55f9ebe88e09b35021979b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for v0.35.0 release, documenting new `writable_paths:` configuration to restrict where agent tools can write to the filesystem, including tracker version requirements and fail-closed enforcement behavior for invalid or missing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->