### PR TITLE
feat: DIP143 — subgraph tool_access containment-boundary advisory (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistr
 
 ## Lint Rules
 
-51 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP142 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
+52 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP143 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
 
 ## Testing
 

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -187,10 +187,10 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-51 diagnostic codes across two categories:
+52 diagnostic codes across two categories:
 
 - **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP142** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety
+- **DIP101–DIP143** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary
 
 ---
 
@@ -279,6 +279,8 @@ Invalid values fall back to no-tools at runtime (fail-closed) and are flagged by
 **Scope vs. tool-node safety:** `tool_access` gates *LLM-driven* tool calls on agent nodes. It is unrelated to `tool` nodes (shell commands authored directly in `.dip`), whose allowlist/denylist is controlled by the v0.28.x defaults `tool_commands_allow` and `tool_denylist_add`.
 
 `tool_access` may also be set per-branch on a block-form `parallel` node; an omitted branch value inherits the target agent's setting.
+
+**Subgraph boundary:** `tool_access` does not cross a `subgraph_ref` / `ref` file boundary — a referenced child `.dip` (`manager_loop` or `subgraph` node) is governed entirely by its own file. When a workflow declares `tool_access` and also references a subgraph, [DIP143](https://2389-research.github.io/dippin-lang/validation.html#dip143) (Hint) reminds you to give the child's agents their own `tool_access`. This is distinct from the rejected in-file graph-topology lint ([#57](https://github.com/2389-research/dippin-lang/issues/57)): it concerns the cross-*file* boundary, and cross-file enforcement is tracked as [#89](https://github.com/2389-research/dippin-lang/issues/89).
 
 **Writable Paths (`writable_paths:`)** — *added v0.35.0; an enforcing runtime is required.*
 

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -185,7 +185,7 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-51 diagnostic codes across two categories:
+52 diagnostic codes across two categories:
 
 - **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP142** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety
+- **DIP101–DIP143** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary

--- a/docs/superpowers/specs/2026-06-03-issue-59-design.md
+++ b/docs/superpowers/specs/2026-06-03-issue-59-design.md
@@ -84,13 +84,18 @@ Help:    audit the agents in %q for their own tool_access — restrictions decla
 ### Suppresses when
 
 - No node in the workflow declares `tool_access` (no containment intent), **or**
-- The referencing node's ref is empty (owned by DIP135 / DIP126).
+- The referencing node's ref is empty (owned by DIP135 / DIP126), **or**
+- The ref resolves to the node's own source file — a **direct self-reference** has no
+  cross-file boundary, so the hint would be wrong (post-review, Copilot). Resolution is
+  filepath-only (`refIsSelf`), mirroring `resolveRefPath`. Transitive cross-file cycles
+  (A → B → A) still require multi-file traversal and remain deferred to #89.
 
 ## Implementation
 
-New file `validator/lint_subgraph_tool_access.go` — pure IR logic, **no** `os`/`filepath`
+New file `validator/lint_subgraph_tool_access.go` — pure IR logic with no `os`/filesystem
 access, so **no `//go:build` split** (unlike `lint_manager_loop.go`, which is split only
-because it `os.Stat`s the child path). Decomposed to stay within cyclomatic ≤5 / cognitive ≤7
+because it `os.Stat`s the child path). `path/filepath` path-math (`refIsSelf`) is wasm-safe;
+only `os` syscalls are not. Decomposed to stay within cyclomatic ≤5 / cognitive ≤7
 (security/arch review: a single type-switch-with-branch-loop would blow the cognitive gate):
 
 ```

--- a/docs/superpowers/specs/2026-06-03-issue-59-design.md
+++ b/docs/superpowers/specs/2026-06-03-issue-59-design.md
@@ -1,0 +1,158 @@
+# Issue #59 — DIP143: subgraph `tool_access` containment-boundary advisory
+
+**Date:** 2026-06-03
+**Closes:** [#59](https://github.com/2389-research/dippin-lang/issues/59)
+**Deferred follow-up filed:** [#89](https://github.com/2389-research/dippin-lang/issues/89) (real cross-file enforcement)
+**Status:** Design approved 2026-06-03 (4-expert review panel + 3 design forks decided by author)
+**Arc:** #41 `tool_access` → #75 `writable_paths` → #79 TOCTOU resolver → **#59 subgraph boundary**
+
+## Problem
+
+A `manager_loop` node supervises a child pipeline referenced by `subgraph_ref`, and a
+plain `subgraph` node embeds one via `ref`. Both point at a **separate `.dip` file**.
+`tool_access` is a per-node primitive (`AgentConfig.ToolAccess`, `BranchConfig.ToolAccess`)
+with no workflow-level policy. So an author who locks agents down (`tool_access: none`) in
+the parent file gets **no** guarantee about the referenced child — the child's agents are
+governed entirely by their own file. The restriction silently stops at the file boundary.
+
+Per the #41 design's Non-goals §7: *"Parent's restrictive `tool_access:` does not propagate
+into a child subgraph. Requires multi-workflow IR traversal the validator doesn't have today."*
+
+## Decisive constraint
+
+The `validator` package **must not import `parser`** (CLAUDE.md layering rule — only the
+`dipx` loader tier may compose `ir + parser + simulate`). Confirmed empirically: no
+production file in `validator/` imports `parser`. Therefore the validator **cannot parse
+the child `.dip`** to inspect its actual `tool_access`. Real cross-file effective-access
+comparison must live in `dipx`/CLI and is deferred to #89.
+
+This is a single-workflow **advisory**, not enforcement and not propagation.
+
+## Design — DIP143, severity `Hint`
+
+### What it detects (intent-gated)
+
+Fire DIP143 on a node that **references an external subgraph** —
+`ManagerLoopConfig.SubgraphRef` **or** `SubgraphConfig.Ref`, non-empty — **if and only if**
+the same workflow contains at least one node declaring **containment intent**: an
+`AgentConfig` or any `BranchConfig` whose `tool_access` is **non-empty** (after trim).
+
+- **Why "any non-empty" rather than `== "none"`:** the runtime fails closed — *any* non-empty
+  `tool_access` value disables tools (a typo `nono` still yields no-tools per the #41 design).
+  An author who typed any value intended and received restriction, so any non-empty value is
+  containment intent (security review finding I5). This differs from DIP141's dead-config
+  check, which correctly matches `== "none"` only.
+- **Intent gate, not boundary marker:** this is the literal reading of #59 ("parent's
+  *restrictive* `tool_access` does not propagate"). When the author restricted nothing, there
+  is no restriction to escape, so DIP143 stays silent. The security panel argued for an
+  unconditional boundary marker (fire on every subgraph ref); the author chose the intent gate
+  to keep the hint targeted and the example suite clean. The broader boundary-marker idea and
+  the no-lockdown population are recorded in #89.
+
+### Severity: `Hint` (not Warning)
+
+The referencing node has **no defect** — the concern lives in a file the linter can't see.
+The repo has **no per-diagnostic suppression mechanism**, so a Warning that fires on a correct
+file with no resolving edit would train authors to ignore the whole DIP139–142 safety band.
+`SeverityHint` matches the established "context-dependent, may be fine" precedent (DIP125,
+DIP131, DIP133). (DX review findings C1/C2.)
+
+### Scope: both `manager_loop` and `subgraph`
+
+Both node types have the identical cross-file gap; covering only `manager_loop` would leave a
+same-shaped hole (security review M8). One hint per referencing node (each boundary is its own
+advisory).
+
+### Message & help (reframed)
+
+The message must **not** say the child "inherits" restrictions and must **not** imply a child
+declaring `tool_access: none` is fully safe — the supervisory/steering channel
+(`SteerContext`, `stack.child.*`) is information-flow, a separate concern (#56). It leads with
+the boundary and points the author at the actionable check (security I4, DX M1).
+
+```
+Message: <kind> %q references subgraph %q, defined in its own file; this workflow's
+         tool_access restrictions do not extend across the subgraph boundary
+Help:    audit the agents in %q for their own tool_access — restrictions declared in this
+         workflow do not propagate into a referenced subgraph. Cross-file enforcement is
+         tracked as #89.
+```
+
+`<kind>` is `manager_loop` or `subgraph`; `%q` interpolates the node ID and `cfg.SubgraphRef`
+/ `cfg.Ref` verbatim (so message and help reference the same string).
+
+### Suppresses when
+
+- No node in the workflow declares `tool_access` (no containment intent), **or**
+- The referencing node's ref is empty (owned by DIP135 / DIP126).
+
+## Implementation
+
+New file `validator/lint_subgraph_tool_access.go` — pure IR logic, **no** `os`/`filepath`
+access, so **no `//go:build` split** (unlike `lint_manager_loop.go`, which is split only
+because it `os.Stat`s the child path). Decomposed to stay within cyclomatic ≤5 / cognitive ≤7
+(security/arch review: a single type-switch-with-branch-loop would blow the cognitive gate):
+
+```
+lintSubgraphToolAccess(w)      → if !workflowDeclaresToolAccess(w) { return nil }; loop → checkSubgraphBoundary(n)
+workflowDeclaresToolAccess(w)  → loop → nodeDeclaresToolAccess(n)
+nodeDeclaresToolAccess(n)      → type switch: AgentConfig → toolAccessSet(cfg.ToolAccess)
+                                              ParallelConfig → branchesDeclareToolAccess(cfg.Branches)
+branchesDeclareToolAccess(bs)  → loop → toolAccessSet(b.ToolAccess)
+checkSubgraphBoundary(n)       → kind, ref := subgraphRefOf(n); if ref == "" { return nil }; build *Diagnostic
+subgraphRefOf(n)               → type switch: ManagerLoopConfig → ("manager_loop", cfg.SubgraphRef)
+                                              SubgraphConfig    → ("subgraph", cfg.Ref)
+toolAccessSet(s)               → strings.TrimSpace(s) != ""
+```
+
+Registered once in `validator/lint.go` `Lint()` after `lintWritablePaths(w)`.
+
+## Edit-site checklist (derived from the #41/#75 precedent + review)
+
+Build-breaking / test-gated:
+1. `validator/lint_codes.go` — `DIP143` const + `CodeDescription[DIP143]`; update header comment range.
+2. `validator/explanations.go` — `Explanations[DIP143]` in `safetyExplanations()`, all four
+   fields (Summary/Trigger/Fix/Example) non-empty (gated by `TestExplanationsCoverAllCodes`/
+   `TestExplanationsNoExtra`); update its doc comment `DIP138–DIP142` → `DIP138–DIP143`.
+3. `validator/lint_subgraph_tool_access.go` — new file (pure, no build tag).
+4. `validator/lint.go` — register; update header comment range.
+5. `validator/lint_subgraph_tool_access_test.go` — parser-driven tests (see matrix).
+
+Convention docs (no test gate, required by precedent):
+6. `CLAUDE.md:85` — `51` → `52`, `DIP101-DIP142` → `DIP101-DIP143`.
+7. `validator/lint_codes.go:3` + `validator/lint.go:8` — range comments.
+8. `docs/validation.md` — range strings (lines 6, 15, 227, 972) + new `### DIP143` section.
+9. `docs/llm-reference.md` — `51 diagnostic codes` (188) + range/description (191); **source**
+   for `generated-spec.md`.
+10. `site/static/skill.md` — add DIP143 to the safety section / revisit the cross-node note
+    (judgment call; also a generated-spec source).
+11. Regenerate: `just spec-check` refreshes `docs/generated-spec.md` + `cmd/dippin/generated-spec.md`
+    (these are **assembled from** llm-reference.md + skill.md by `scripts/gen-spec.sh`, run by
+    `just build`/`just check` — **not** pre-commit; never hand-edit the generated files).
+
+Release-time (defer to tag):
+12. `CHANGELOG.md` — DIP143 bullet under the next version heading.
+
+## Tests — parser-driven (`validator/lint_subgraph_tool_access_test.go`)
+
+Parse real `.dip` text via `parser.NewParser(src, "test").Parse()` — no hand-built IR for
+fields the parser populates (the DIP101-bug lesson). Matrix:
+
+| Case | Expect |
+|---|---|
+| agent `tool_access: none` + `manager_loop subgraph_ref:` | 1× DIP143 (Hint) on manager_loop |
+| agent `tool_access: none` + `subgraph ref:` | 1× DIP143 on subgraph node |
+| parallel branch `tool_access: none` + manager_loop | 1× DIP143 |
+| agent `tool_access: nono` (any non-empty) + manager_loop | 1× DIP143 (intent = non-empty) |
+| manager_loop ref, **no** `tool_access` anywhere | 0 |
+| agent `tool_access: none`, **no** subgraph/manager_loop | 0 |
+| `subgraph`/`manager_loop` with **empty** ref + restricted agent | 0 (DIP135/126 own empties) |
+| emitted diagnostic severity | `SeverityHint` |
+
+## No example `.dip`
+
+DIP139/141 shipped lint-clean examples of the *safe* shape. DIP143's "safe shape" is inherently
+cross-file (the child declares its own restrictions in a file we don't read), so it **cannot**
+be demonstrated lint-clean in a single file. Coverage is parser-driven unit tests. (Existing
+`manager_loop_demo.dip` / `api_design.dip` declare no `tool_access`, so the intent gate keeps
+them silent — no example regresses.)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -3,7 +3,7 @@
 Dippin documents 46 diagnostic codes split into two categories (the linter additionally registers a few internal codes that don't have dedicated sections):
 
 - **Structural validation** (DIP001–DIP009): Errors that **must** be fixed. A workflow with any of these cannot execute.
-- **Semantic linting** (DIP101–DIP142): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
+- **Semantic linting** (DIP101–DIP143): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
 
 Run `dippin validate <file>` for structural checks only, or `dippin lint <file>` for both.
 
@@ -12,7 +12,7 @@ graph LR
     SRC[".dip file"] --> PARSE["Parser"]
     PARSE --> IR["IR"]
     IR --> VAL["Structural Validation<br>DIP001–DIP009<br>(errors)"]
-    IR --> LINT["Semantic Linting<br>DIP101–DIP142<br>(warnings)"]
+    IR --> LINT["Semantic Linting<br>DIP101–DIP143<br>(warnings)"]
     VAL --> DIAG["Diagnostics"]
     LINT --> DIAG
 ```
@@ -224,7 +224,7 @@ error[DIP009]: duplicate edge
 
 ---
 
-## Semantic Lint Warnings (DIP101–DIP142)
+## Semantic Lint Warnings (DIP101–DIP143)
 
 ### DIP101: Node Only Reachable via Conditional Edges
 
@@ -953,6 +953,35 @@ This is a lexical clarity check, not the security boundary — the runtime fs-ja
 
 ---
 
+### DIP143: Referenced Subgraph Does Not Inherit `tool_access`
+
+**Severity**: Hint
+
+A `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) node references a child `.dip` file, and this workflow declares `tool_access` on at least one agent or parallel branch. `tool_access` is a per-node primitive and does not cross a file boundary — the child subgraph's agents are governed entirely by their own file, so the parent's restriction does not propagate into it.
+
+```text
+hint[DIP143]: manager_loop "Supervise" references subgraph "child.dip", defined in its own file; this workflow's tool_access restrictions do not extend across the subgraph boundary
+  --> pipeline.dip:9:3
+  = help: audit the agents in "child.dip" for their own tool_access — restrictions declared in this workflow do not propagate into a referenced subgraph. Cross-file enforcement is tracked as #89.
+```
+
+**What triggers it**: All of the following hold:
+- A node references an external subgraph — `manager_loop` via `subgraph_ref`, or `subgraph` via `ref` (non-empty).
+- The workflow declares `tool_access` (any non-empty value — a fail-closed typo still expresses restriction) on some agent or parallel branch.
+
+This is a Hint, not a Warning: the referencing node has no defect. The check is **file-level** — it does not verify that the restricted node and the subgraph node are related, and it does **not** read the child file (the validator cannot parse it). It bounds the child's *tool catalog* concern, not information flow across the supervisory boundary (`steer_context` / `stack.child.*` — see [#56](https://github.com/2389-research/dippin-lang/issues/56)). Real cross-file effective-access enforcement is deferred to [#89](https://github.com/2389-research/dippin-lang/issues/89).
+
+**How to fix**: Open the referenced `.dip` and give its agents their own `tool_access`:
+
+```dippin
+  agent Summarize
+    tool_access: none
+  manager_loop Supervise
+    subgraph_ref: child.dip   # DIP143: child.dip's agents must set their own tool_access
+```
+
+---
+
 ## Running Validation
 
 ### Structural validation only
@@ -969,7 +998,7 @@ Runs DIP001–DIP009. Exit code 0 if all pass, 1 if any errors.
 dippin lint pipeline.dip
 ```
 
-Runs all DIP001–DIP009 errors and DIP101–DIP142 warnings. Exit code 1 only for errors; warnings alone exit 0.
+Runs all DIP001–DIP009 errors and DIP101–DIP143 warnings. Exit code 1 only for errors; warnings alone exit 0.
 
 ### JSON output for CI
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,6 +1,6 @@
 # Validation and Linting Reference
 
-Dippin documents 46 diagnostic codes split into two categories (the linter additionally registers a few internal codes that don't have dedicated sections):
+Dippin documents 47 diagnostic codes split into two categories (the linter additionally registers a few internal codes that don't have dedicated sections):
 
 - **Structural validation** (DIP001–DIP009): Errors that **must** be fixed. A workflow with any of these cannot execute.
 - **Semantic linting** (DIP101–DIP143): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
@@ -968,6 +968,8 @@ hint[DIP143]: manager_loop "Supervise" references subgraph "child.dip", defined 
 **What triggers it**: All of the following hold:
 - A node references an external subgraph — `manager_loop` via `subgraph_ref`, or `subgraph` via `ref` (non-empty).
 - The workflow declares `tool_access` (any non-empty value — a fail-closed typo still expresses restriction) on some agent or parallel branch.
+
+A node whose ref resolves to its **own source file** (a direct self-reference) is not flagged — there is no cross-file boundary. Transitive cross-file cycles (A → B → A) are not detected and are deferred to [#89](https://github.com/2389-research/dippin-lang/issues/89).
 
 This is a Hint, not a Warning: the referencing node has no defect. The check is **file-level** — it does not verify that the restricted node and the subgraph node are related, and it does **not** read the child file (the validator cannot parse it). It bounds the child's *tool catalog* concern, not information flow across the supervisory boundary (`steer_context` / `stack.child.*` — see [#56](https://github.com/2389-research/dippin-lang/issues/56)). Real cross-file effective-access enforcement is deferred to [#89](https://github.com/2389-research/dippin-lang/issues/89).
 

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -103,6 +103,8 @@ Invalid values fall back to no-tools at runtime (fail-closed) and are flagged by
 
 `tool_access` may also be set per-branch on a block-form `parallel` node; an omitted branch value inherits the target agent's setting.
 
+**Subgraph boundary:** `tool_access` does not cross a `subgraph_ref` / `ref` file boundary — a referenced child `.dip` (`manager_loop` or `subgraph` node) is governed entirely by its own file. When a workflow declares `tool_access` and also references a subgraph, [DIP143](https://2389-research.github.io/dippin-lang/validation.html#dip143) (Hint) reminds you to give the child's agents their own `tool_access`. This is distinct from the rejected in-file graph-topology lint ([#57](https://github.com/2389-research/dippin-lang/issues/57)): it concerns the cross-*file* boundary, and cross-file enforcement is tracked as [#89](https://github.com/2389-research/dippin-lang/issues/89).
+
 **Writable Paths (`writable_paths:`)** — *added v0.35.0; an enforcing runtime is required.*
 
 A node-level glob list bounding where the agent's tools may write. Shape: comma-separated globs (e.g. `workspace/**, .ai/sprints/**`).

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -396,7 +396,7 @@ func nodeValidationExplanations() map[string]Explanation {
 	}
 }
 
-// safetyExplanations returns explanations for tool-safety lint rules (DIP138–DIP142).
+// safetyExplanations returns explanations for tool-safety lint rules (DIP138–DIP143).
 func safetyExplanations() map[string]Explanation {
 	return map[string]Explanation{
 		DIP138: {
@@ -433,6 +433,13 @@ func safetyExplanations() map[string]Explanation {
 			Trigger: "A writable_paths entry is an absolute path, starts with ~ or a Windows drive, escapes its base via .., or is a brace-expansion fragment torn apart by comma-splitting. Such an entry will not bound writes to the workspace the way the author expects.",
 			Fix:     "Use workspace-relative globs (e.g. .ai/sprints/**). Absolute, ~, Windows-drive, and ..-escaping entries are rejected by the runtime fs jail; brace expansion (*.{md,yaml}) is split on commas — enumerate entries instead. This lint catches obvious lexical cases only; the runtime jail is the real boundary.",
 			Example: "agent Recorder\n  prompt: \"record\"\n  writable_paths: /etc/**   // DIP142: absolute path escapes the workspace jail",
+		},
+		DIP143: {
+			Code:    DIP143,
+			Summary: "referenced subgraph does not inherit this workflow's tool_access restrictions",
+			Trigger: "A manager_loop (subgraph_ref) or subgraph (ref) node references a child .dip file, and this workflow declares tool_access on at least one agent or parallel branch. tool_access is per-node and does not cross a file boundary, so the child's agents are governed entirely by their own file — the parent's restriction does not propagate. This is a Hint: the referencing node has no defect; the check is file-level and does not verify the restricted node and the subgraph node are related, nor does it read the child (the validator cannot parse it). Cross-file effective-access enforcement is deferred (#89).",
+			Fix:     "Open the referenced .dip and give its agents their own tool_access (e.g. tool_access: none on summarizers). Restrictions declared in the parent do not flow into a referenced subgraph. Note this bounds the child's tool catalog, not information flow across the supervisory boundary (steer_context / stack.child.* — see #56).",
+			Example: "agent Summarize\n  tool_access: none\nmanager_loop Supervise\n  subgraph_ref: child.dip   // DIP143: child.dip's agents must set their own tool_access",
 		},
 	}
 }

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -5,7 +5,7 @@ import (
 	"github.com/2389-research/dippin-lang/simulate"
 )
 
-// Lint runs all semantic quality checks (DIP101–DIP142) on the workflow
+// Lint runs all semantic quality checks (DIP101–DIP143) on the workflow
 // and returns all diagnostics found. These are warnings, not errors —
 // the workflow can still execute, but the findings indicate likely bugs
 // or quality issues.
@@ -59,6 +59,7 @@ func Lint(w *ir.Workflow) Result {
 	diags = append(diags, lintToolAccessValues(w)...)
 	diags = append(diags, lintParamsReenablesTools(w)...)
 	diags = append(diags, lintWritablePaths(w)...)
+	diags = append(diags, lintSubgraphToolAccess(w)...)
 
 	return Result{Diagnostics: diags}
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP142).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP143).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge
@@ -44,6 +44,7 @@ const (
 	DIP140 = "DIP140" // params re-enables tools that tool_access strips
 	DIP141 = "DIP141" // writable_paths nullified by tool_access: none (dead config)
 	DIP142 = "DIP142" // unsafe writable_paths entry (absolute / ~ / parent-escape / brace)
+	DIP143 = "DIP143" // referenced subgraph does not inherit this workflow's tool_access restrictions
 )
 
 func init() {
@@ -90,4 +91,5 @@ func init() {
 	CodeDescription[DIP140] = "params re-enables tools that tool_access strips"
 	CodeDescription[DIP141] = "writable_paths nullified by tool_access: none (dead config)"
 	CodeDescription[DIP142] = "unsafe writable_paths entry (absolute / ~ / parent-escape / brace)"
+	CodeDescription[DIP143] = "referenced subgraph does not inherit this workflow's tool_access restrictions"
 }

--- a/validator/lint_subgraph_tool_access.go
+++ b/validator/lint_subgraph_tool_access.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
@@ -70,7 +71,7 @@ func toolAccessSet(s string) bool {
 // checkSubgraphBoundary emits DIP143 for a node referencing an external subgraph.
 func checkSubgraphBoundary(n *ir.Node) *Diagnostic {
 	kind, ref := subgraphRefOf(n)
-	if ref == "" {
+	if ref == "" || refIsSelf(ref, n.Source.File) {
 		return nil
 	}
 	return &Diagnostic{
@@ -84,6 +85,22 @@ func checkSubgraphBoundary(n *ir.Node) *Diagnostic {
 			"audit the agents in %q for their own tool_access — restrictions declared in this workflow do not propagate into a referenced subgraph. Cross-file enforcement is tracked as #89.",
 			ref),
 	}
+}
+
+// refIsSelf reports whether ref resolves to the node's own source file — a direct
+// self-reference, where there is no cross-file boundary to warn about. Resolution
+// mirrors resolveRefPath (relative to the source file's directory) but stays
+// filepath-only so this lint compiles for wasm. Transitive cross-file cycles
+// (A → B → A) require multi-file traversal and remain out of scope (#89).
+func refIsSelf(ref, sourceFile string) bool {
+	if sourceFile == "" {
+		return false
+	}
+	resolved := ref
+	if !filepath.IsAbs(ref) {
+		resolved = filepath.Join(filepath.Dir(sourceFile), ref)
+	}
+	return filepath.Clean(resolved) == filepath.Clean(sourceFile)
 }
 
 // subgraphRefOf returns the node-kind label and the external subgraph reference

--- a/validator/lint_subgraph_tool_access.go
+++ b/validator/lint_subgraph_tool_access.go
@@ -1,0 +1,100 @@
+package validator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// lintSubgraphToolAccess emits DIP143 (Hint): a node references an external
+// subgraph (manager_loop subgraph_ref or subgraph ref) whose own .dip file does
+// not inherit this workflow's tool_access restrictions. It fires only when the
+// workflow shows containment intent (some node declares tool_access), and never
+// parses the child file — the validator may not import the parser (layering
+// rule). Real cross-file effective-access enforcement is tracked as #89.
+func lintSubgraphToolAccess(w *ir.Workflow) []Diagnostic {
+	if !workflowDeclaresToolAccess(w) {
+		return nil
+	}
+	var diags []Diagnostic
+	for _, n := range w.Nodes {
+		if d := checkSubgraphBoundary(n); d != nil {
+			diags = append(diags, *d)
+		}
+	}
+	return diags
+}
+
+// workflowDeclaresToolAccess reports whether any node expresses tool_access
+// containment intent.
+func workflowDeclaresToolAccess(w *ir.Workflow) bool {
+	for _, n := range w.Nodes {
+		if nodeDeclaresToolAccess(n) {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeDeclaresToolAccess reports whether an agent (or any parallel branch)
+// declares a non-empty tool_access value.
+func nodeDeclaresToolAccess(n *ir.Node) bool {
+	switch cfg := n.Config.(type) {
+	case ir.AgentConfig:
+		return toolAccessSet(cfg.ToolAccess)
+	case ir.ParallelConfig:
+		return branchesDeclareToolAccess(cfg.Branches)
+	default:
+		return false
+	}
+}
+
+func branchesDeclareToolAccess(branches []ir.BranchConfig) bool {
+	for _, b := range branches {
+		if toolAccessSet(b.ToolAccess) {
+			return true
+		}
+	}
+	return false
+}
+
+// toolAccessSet reports containment intent: any non-empty tool_access value.
+// The runtime fails closed, so even an invalid value (a fail-closed typo)
+// expresses and receives restriction — unlike DIP141's dead-config check,
+// which deliberately matches only the canonical "none".
+func toolAccessSet(s string) bool {
+	return strings.TrimSpace(s) != ""
+}
+
+// checkSubgraphBoundary emits DIP143 for a node referencing an external subgraph.
+func checkSubgraphBoundary(n *ir.Node) *Diagnostic {
+	kind, ref := subgraphRefOf(n)
+	if ref == "" {
+		return nil
+	}
+	return &Diagnostic{
+		Code:     DIP143,
+		Severity: SeverityHint,
+		Message: fmt.Sprintf(
+			"%s %q references subgraph %q, defined in its own file; this workflow's tool_access restrictions do not extend across the subgraph boundary",
+			kind, n.ID, ref),
+		Location: n.Source,
+		Help: fmt.Sprintf(
+			"audit the agents in %q for their own tool_access — restrictions declared in this workflow do not propagate into a referenced subgraph. Cross-file enforcement is tracked as #89.",
+			ref),
+	}
+}
+
+// subgraphRefOf returns the node-kind label and the external subgraph reference
+// for nodes that point at a separate .dip file, or ("", "") for other nodes.
+func subgraphRefOf(n *ir.Node) (string, string) {
+	switch cfg := n.Config.(type) {
+	case ir.ManagerLoopConfig:
+		return "manager_loop", cfg.SubgraphRef
+	case ir.SubgraphConfig:
+		return "subgraph", cfg.Ref
+	default:
+		return "", ""
+	}
+}

--- a/validator/lint_subgraph_tool_access_test.go
+++ b/validator/lint_subgraph_tool_access_test.go
@@ -166,6 +166,30 @@ func TestLint_DIP143_EmptyRefNoFire(t *testing.T) {
 	}
 }
 
+func TestLint_DIP143_SelfReferenceNoFire(t *testing.T) {
+	// A node referencing its own source file (test.dip, the lintSrc filename) is
+	// not a cross-file boundary — there is nothing the parent's restriction fails
+	// to reach. Transitive cross-file cycles remain out of scope (#89).
+	src := `workflow X
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  manager_loop Sup
+    subgraph_ref: test.dip
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+	if hasCode(lintSrc(t, src), dip143) {
+		t.Errorf("DIP143 should not fire on a self-reference; got: %v", codes(lintSrc(t, src)))
+	}
+}
+
 func TestLint_DIP143_OneHintPerReferencingNode(t *testing.T) {
 	src := `workflow X
   start: Lock

--- a/validator/lint_subgraph_tool_access_test.go
+++ b/validator/lint_subgraph_tool_access_test.go
@@ -1,0 +1,218 @@
+package validator
+
+import "testing"
+
+// DIP143 fires (Hint) when a workflow declares tool_access containment intent
+// AND references an external subgraph whose own file does not inherit it.
+// Intent gate: any non-empty tool_access on an agent or parallel branch.
+// Scope: both manager_loop (subgraph_ref) and subgraph (ref) nodes.
+
+const dip143 = "DIP143"
+
+func countCode(diags []Diagnostic, code string) int {
+	n := 0
+	for _, d := range diags {
+		if d.Code == code {
+			n++
+		}
+	}
+	return n
+}
+
+func TestLint_DIP143_ManagerLoopWithRestrictedAgent(t *testing.T) {
+	src := `workflow X
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  manager_loop Sup
+    subgraph_ref: child.dip
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+	if !hasCode(lintSrc(t, src), dip143) {
+		t.Errorf("expected DIP143; got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP143_SubgraphNodeWithRestrictedAgent(t *testing.T) {
+	src := `workflow X
+  start: Lock
+  exit: Sub
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  subgraph Sub
+    ref: child.dip
+
+  edges
+    Lock -> Sub
+`
+	if !hasCode(lintSrc(t, src), dip143) {
+		t.Errorf("expected DIP143 on subgraph node; got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP143_ParallelBranchIntent(t *testing.T) {
+	src := `workflow X
+  start: split
+  exit: Sup
+
+  agent a
+    prompt: "a"
+
+  parallel split
+    branch: a
+      tool_access: none
+
+  fan_in join <- a
+
+  manager_loop Sup
+    subgraph_ref: child.dip
+    max_cycles: 3
+
+  edges
+    split -> a
+    a -> join
+    join -> Sup
+`
+	if !hasCode(lintSrc(t, src), dip143) {
+		t.Errorf("expected DIP143 from branch intent; got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP143_AnyNonEmptyToolAccessIsIntent(t *testing.T) {
+	// A fail-closed typo still expresses (and receives) restriction at runtime,
+	// so any non-empty tool_access counts as containment intent.
+	src := `workflow X
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: nono
+
+  manager_loop Sup
+    subgraph_ref: child.dip
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+	if !hasCode(lintSrc(t, src), dip143) {
+		t.Errorf("expected DIP143 (non-empty tool_access = intent); got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP143_NoIntentNoFire(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: Sup
+
+  agent A
+    prompt: "x"
+
+  manager_loop Sup
+    subgraph_ref: child.dip
+    max_cycles: 3
+
+  edges
+    A -> Sup
+`
+	if hasCode(lintSrc(t, src), dip143) {
+		t.Errorf("DIP143 should not fire without tool_access intent; got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP143_RestrictedAgentNoSubgraphNoFire(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: A
+
+  agent A
+    prompt: "x"
+    tool_access: none
+`
+	if hasCode(lintSrc(t, src), dip143) {
+		t.Errorf("DIP143 should not fire without a subgraph reference; got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP143_EmptyRefNoFire(t *testing.T) {
+	// manager_loop with no subgraph_ref is DIP135's concern, not DIP143's.
+	src := `workflow X
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  manager_loop Sup
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+	if hasCode(lintSrc(t, src), dip143) {
+		t.Errorf("DIP143 should not fire on an empty ref; got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP143_OneHintPerReferencingNode(t *testing.T) {
+	src := `workflow X
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  manager_loop Sup
+    subgraph_ref: child.dip
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+	if got := countCode(lintSrc(t, src), dip143); got != 1 {
+		t.Errorf("expected exactly 1 DIP143, got %d", got)
+	}
+}
+
+func TestLint_DIP143_SeverityIsHint(t *testing.T) {
+	src := `workflow X
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  manager_loop Sup
+    subgraph_ref: child.dip
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+	var found bool
+	for _, d := range lintSrc(t, src) {
+		if d.Code == dip143 {
+			found = true
+			if d.Severity != SeverityHint {
+				t.Errorf("DIP143 severity = %v, want SeverityHint", d.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("DIP143 not emitted")
+	}
+}


### PR DESCRIPTION
Closes #59. Follow-up filed: #89 (cross-file enforcement).

## The gap
A `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) node points at a **separate `.dip` file**. `tool_access` is a per-node primitive with no workflow-level policy, so an author who locks agents down in the parent file gets **no** containment guarantee for the referenced child — the child's agents are governed entirely by their own file. The restriction silently stops at the file boundary. This is issue-41 design non-goal §7 ("parent's restrictive `tool_access` does not propagate into a child subgraph").

## Design decision: **warn (Hint), not enforce or propagate**
The `validator` package **must not import `parser`** (CLAUDE.md layering rule), so it **cannot parse the child `.dip`** to inspect its real `tool_access`. Real cross-file effective-access comparison needs loader-tier (`dipx`/CLI) traversal — exactly the "multi-workflow IR traversal the validator doesn't have" that #41 deferred. So this PR ships a **single-workflow advisory** and defers true enforcement to **#89**.

**Traversal scope:** single-workflow only; the lint never opens the child file.

### DIP143 — `SeverityHint`
- **Fires when** a workflow declares `tool_access` containment intent (any non-empty value on an agent or parallel branch) **and** references an external subgraph (`manager_loop subgraph_ref` or `subgraph ref`, non-empty).
- **Suppresses** when there's no `tool_access` anywhere, or the ref is empty (DIP135/DIP126 own empties).
- Covers **both** `manager_loop` and `subgraph` nodes (identical cross-file gap).

```
hint[DIP143]: manager_loop "Supervise" references subgraph "child.dip", defined in its
own file; this workflow's tool_access restrictions do not extend across the subgraph boundary
  = help: audit the agents in "child.dip" for their own tool_access … Cross-file enforcement
    is tracked as #89.
```

## Why these choices (informed by a 4-expert review panel)
- **Hint, not Warning.** The referencing node has no defect, and the repo has **no per-diagnostic suppression** — a warning that fires on a *correct* file with no resolving edit would train authors to ignore the actionable DIP139–142 safety band. Matches the DIP125/131/133 "context-dependent" precedent.
- **Intent gate on *any* non-empty `tool_access`** (not just canonical `none`): the runtime fails closed, so even a typo'd value expresses and receives restriction.
- **Message reframed** away from "inherit": it points the author at auditing the child, and notes DIP143 bounds the *tool catalog*, not information flow across the supervisory boundary (`steer_context`/`stack.child.*` — see #56).
- **Intent-gated rather than an unconditional boundary marker:** keeps the hint targeted to #59's literal scope (parent *restricts* something) and keeps existing examples clean. The broader boundary-marker idea and the no-lockdown population are recorded in #89.

## Documented residual → #89
Real cross-file enforcement (parse the child, compare effective access), plus recursion/transitivity, self-reference/cycles, and the information-flow vs tool-access distinction.

## Implementation & tests
- New `validator/lint_subgraph_tool_access.go` — **pure logic, no `os` access → no wasm split** (verified `GOOS=js GOARCH=wasm` build). Decomposed to stay within cyclomatic ≤5 / cognitive ≤7.
- Wiring: const + `CodeDescription` + `Explanations` (gated by `TestExplanationsCoverAllCodes`), registration, range-string/docs updates, regenerated `generated-spec.md`.
- **Parser-driven** tests (`lint_subgraph_tool_access_test.go`): fires (manager_loop / subgraph / branch intent / fail-closed typo), suppresses (no intent / no subgraph / empty ref), one-hint-per-node, severity == Hint.
- **No regression:** existing examples emit zero DIP143 (intent gate); no new example added — DIP143's "safe shape" is inherently cross-file and can't be shown lint-clean in one file.

**Release-time TODO:** add a `DIP143` CHANGELOG bullet under the next version heading (convention is at-tag-time, per the #75 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783114235&installation_id=131176874&pr_number=90&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F90&signature=57d663eb0b62fdd772c9ec1625573e06fc1fc0c210ddc928560d1cbe983fc362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->