### PR TITLE
docs: CHANGELOG v0.36.0 — DIP143 + TOCTOU resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.36.0] — 2026-06-03
+
+Dippin-side only — no paired runtime release required.
+
+### Added
+- `DIP143` (Hint) — a `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) node references a child `.dip` that does not inherit the parent workflow's `tool_access` restrictions ([#59](https://github.com/2389-research/dippin-lang/issues/59)). Fires only when the workflow declares `tool_access` intent (any non-empty value on an agent or parallel branch) **and** references an external subgraph, reminding the author to give the child's agents their own `tool_access`. `tool_access` is per-node and does not cross a file boundary. A direct self-reference (a node whose ref resolves to its own source file) is not flagged. The lint never parses the child file (the validator may not import the parser); real cross-file effective-access enforcement, plus transitive cross-file cycles, are deferred to [#89](https://github.com/2389-research/dippin-lang/issues/89).
+
+### Hardened
+- The `@file` directive resolver is hardened against a leaf TOCTOU race ([#79](https://github.com/2389-research/dippin-lang/issues/79)). The path was validated and then read via a separate `os.ReadFile`, so a concurrent symlink/rename swap of the final component could redirect the read outside `baseDir`, bypassing the [#67](https://github.com/2389-research/dippin-lang/issues/67)/[#77](https://github.com/2389-research/dippin-lang/issues/77) containment under a race. Now a single open-once path — `os.OpenFile(O_RDONLY|O_NOFOLLOW)` → `f.Stat()` (fstat the fd) → containment check → `io.ReadAll` — operates entirely on one fd, closing the check-to-read race. On Unix, `O_NOFOLLOW` makes leaf-symlink rejection atomic (`ELOOP`); the resolved path is never leaked in the error. The residual parent-directory swap race is documented as out of scope.
+
+### Docs
+- Clarified that `tool_access` is node-scoped — it constrains the executor of a single node and does not taint downstream nodes — resolving [#57](https://github.com/2389-research/dippin-lang/issues/57) via documentation rather than a graph-topology lint ([#87](https://github.com/2389-research/dippin-lang/pull/87)).
+
+### Changed
+- Internal: removed the consumer product name "tracker" from dippin sources — dippin is consumer-agnostic ([#85](https://github.com/2389-research/dippin-lang/pull/85)).
+
 ## [v0.35.0] — 2026-06-02
 
 ### Added

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,22 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.36.0] — 2026-06-03
+
+Dippin-side only — no paired runtime release required.
+
+### Added
+- `DIP143` (Hint) — a `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) node references a child `.dip` that does not inherit the parent workflow's `tool_access` restrictions ([#59](https://github.com/2389-research/dippin-lang/issues/59)). Fires only when the workflow declares `tool_access` intent (any non-empty value on an agent or parallel branch) **and** references an external subgraph, reminding the author to give the child's agents their own `tool_access`. `tool_access` is per-node and does not cross a file boundary. A direct self-reference (a node whose ref resolves to its own source file) is not flagged. The lint never parses the child file (the validator may not import the parser); real cross-file effective-access enforcement, plus transitive cross-file cycles, are deferred to [#89](https://github.com/2389-research/dippin-lang/issues/89).
+
+### Hardened
+- The `@file` directive resolver is hardened against a leaf TOCTOU race ([#79](https://github.com/2389-research/dippin-lang/issues/79)). The path was validated and then read via a separate `os.ReadFile`, so a concurrent symlink/rename swap of the final component could redirect the read outside `baseDir`, bypassing the [#67](https://github.com/2389-research/dippin-lang/issues/67)/[#77](https://github.com/2389-research/dippin-lang/issues/77) containment under a race. Now a single open-once path — `os.OpenFile(O_RDONLY|O_NOFOLLOW)` → `f.Stat()` (fstat the fd) → containment check → `io.ReadAll` — operates entirely on one fd, closing the check-to-read race. On Unix, `O_NOFOLLOW` makes leaf-symlink rejection atomic (`ELOOP`); the resolved path is never leaked in the error. The residual parent-directory swap race is documented as out of scope.
+
+### Docs
+- Clarified that `tool_access` is node-scoped — it constrains the executor of a single node and does not taint downstream nodes — resolving [#57](https://github.com/2389-research/dippin-lang/issues/57) via documentation rather than a graph-topology lint ([#87](https://github.com/2389-research/dippin-lang/pull/87)).
+
+### Changed
+- Internal: removed the consumer product name "tracker" from dippin sources — dippin is consumer-agnostic ([#85](https://github.com/2389-research/dippin-lang/pull/85)).
+
 ## [v0.35.0] — 2026-06-02
 
 ### Added


### PR DESCRIPTION
Release notes for **v0.36.0**, covering the untagged commits on `main` since v0.35.0. Cut this tag after merge to deliver them to consumers (who pin, never `@latest`).

**Dippin-side only — no paired runtime release required** (unlike v0.32.0/v0.35.0).

### In this release
- **`DIP143` (Hint)** — subgraph `tool_access` containment-boundary advisory ([#59](https://github.com/2389-research/dippin-lang/issues/59), PR #90). Cross-file enforcement deferred to #89.
- **`@file` resolver leaf-TOCTOU hardening** — open-once (`O_RDONLY|O_NOFOLLOW`) + fstat + read on one fd ([#79](https://github.com/2389-research/dippin-lang/issues/79), PR #88).
- **Docs:** `tool_access` node-scoped clarification, resolving #57 without a lint (#87).
- **Chore:** "tracker" product-name excision (#85).

Regenerated `site/content/changelog.md` via the pre-commit hook.

Suggested tag (post-merge): `v0.36.0` — minor bump (new lint surface + security hardening, no breaking changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783115844&installation_id=131176874&pr_number=91&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F91&signature=9e6a35104706fbea944e379fbf82ada2949a8a6902aea4300679b01f3089a9c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->