### PR TITLE
feat: graph-level on_failure route + DIP144 failure-route lint (Closes #92, Closes #93)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistr
 
 ## Lint Rules
 
-52 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP143 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
+53 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP144 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
 
 ## Testing
 

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -187,10 +187,10 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-52 diagnostic codes across two categories:
+53 diagnostic codes across two categories:
 
 - **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP143** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary
+- **DIP101–DIP144** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route
 
 ---
 

--- a/docs/edges.md
+++ b/docs/edges.md
@@ -122,6 +122,24 @@ This means conditions always take precedence over labels, and labels over weight
 
 ---
 
+## Failure Handling
+
+When an agent node finishes with outcome `fail` or errors, the runtime resolves a failure route using the following precedence (first match wins):
+
+| Priority | Mechanism | Description |
+|----------|-----------|-------------|
+| 1 | **Explicit fail edge** | An outgoing edge with `when ctx.outcome = fail` (or `failure`) on the node |
+| 2 | **Bounded node retry** | `retry_target` + `max_retries` — node retries before propagating failure |
+| 3 | **Node fallback_target** | The node's own `fallback_target` field — used when retries are exhausted |
+| 4 | **Graph on_failure** | The workflow's `defaults.on_failure` node ID — catch-all for any agent without a more specific route |
+| 5 | **Halt** | No route found — the pipeline stops |
+
+A restart-edge (`restart: true`) tagged with `when ctx.outcome = fail` falls under priority 1 and carries its own `max_restarts` budget rather than `max_retries`.
+
+**Separation of concerns:** dippin validates that the `on_failure` target node exists (DIP003) and is reachable (DIP004); the runtime owns the evaluation ordering shown above. DIP144 warns when an agent node has no failure route at any level of this cascade; any of priorities 1–4 suppresses the warning.
+
+---
+
 ## Condition Expressions
 
 ### Comparison Operators

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -185,7 +185,7 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-52 diagnostic codes across two categories:
+53 diagnostic codes across two categories:
 
 - **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP143** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary
+- **DIP101–DIP144** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -53,7 +53,7 @@ These fields are available on **all** block-style node kinds (agent, human, tool
 | `max_retries` | Integer | No | Maximum retry attempts before giving up. Overrides the workflow default. |
 | `base_delay` | Duration | No | Override the retry policy's default base delay (e.g. `500ms`, `2s`, `1m`). |
 | `retry_target` | String | No | Node ID to jump to when retrying (instead of re-executing the current node). |
-| `fallback_target` | String | No | Node ID to jump to if all retries are exhausted. |
+| `fallback_target` | String | No | Node ID to jump to if all retries are exhausted. A graph-level catch-all can also be declared via `defaults.on_failure` (see [edges.md](edges.md) — Failure Handling). |
 
 ### reads and writes
 

--- a/docs/superpowers/plans/2026-06-04-on-failure-route-dip144.md
+++ b/docs/superpowers/plans/2026-06-04-on-failure-route-dip144.md
@@ -1,0 +1,935 @@
+# on_failure route (#92) + DIP144 lint (#93) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a graph-level `on_failure: <NodeID>` default failure route (carried, validated, formatted, DOT-round-tripped) and a new DIP144 lint warning for agent nodes that have no failure route.
+
+**Architecture:** `on_failure` lands in `ir.WorkflowDefaults.OnFailure`, parsed in the `defaults:` block, validated structurally (reusing DIP003), seeded into DIP004 reachability so catch-all-only recovery nodes aren't falsely flagged, and round-tripped through both the `.dip` formatter and DOT export/migrate. DIP144 flags agent nodes lacking a failure route, suppressed by an explicit fail-outcome edge, `fallback_target`, bounded retry, or graph `on_failure`. dippin carries/validates; the tracker runtime enforces (not gated on tracker readiness).
+
+**Tech Stack:** Go; `just` for all build/test (never raw `go`); pre-commit hook mirrors CI (cyclomatic ≤5 / cognitive ≤7).
+
+**Spec:** `docs/superpowers/specs/2026-06-04-issue-92-93-design.md`
+
+**Worktree (use ABSOLUTE paths; cwd may reset between commands):**
+`/home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route`
+
+**Build order constraint:** `on_failure` (Tasks 1–5) must land before DIP144 (Task 6) so suppressor (d) compiles.
+
+**Test-run convention:** `just test-pkg <pkg>` runs the whole package verbose — find your test name in the output. Use `just test` for the full suite and `just complexity` before each commit-worthy step. Do NOT run raw `go test`.
+
+---
+
+### Task 1: Parse `on_failure` into `WorkflowDefaults.OnFailure`
+
+**Files:**
+- Modify: `ir/ir.go` (WorkflowDefaults struct, ~line 47)
+- Modify: `parser/parse_defaults.go:77-91` (`applyDefaultExtraField`)
+- Modify: `parser/testdata/defaults_complex.dip`
+- Test: `parser/parser_test.go` (`TestParseDefaultsComplex`, ~line 859)
+
+- [ ] **Step 1: Add the failing test assertion**
+
+In `parser/testdata/defaults_complex.dip`, add one line inside the `defaults` block (after `restart_target: A`):
+
+```
+    on_failure: A
+```
+
+In `parser/parser_test.go`, inside `TestParseDefaultsComplex`, add after the `RestartTarget` assertion:
+
+```go
+	if d.OnFailure != "A" {
+		t.Errorf("on_failure = %q, want A", d.OnFailure)
+	}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-pkg parser`
+Expected: compile error — `d.OnFailure undefined (type ir.WorkflowDefaults has no field or method OnFailure)`.
+
+- [ ] **Step 3: Add the IR field**
+
+In `ir/ir.go`, in `WorkflowDefaults`, directly after the `RestartTarget` line:
+
+```go
+	RestartTarget     string        // Where to restart on loop
+	OnFailure         string        // Graph-level default failure route (node ID); runtime catch-all when no node-level fail route applies
+```
+
+- [ ] **Step 4: Add the parser case**
+
+In `parser/parse_defaults.go`, in `applyDefaultExtraField`, add a case to the switch:
+
+```go
+	case "on_resume":
+		d.OnResume = val
+	case "on_failure":
+		d.OnFailure = val
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `just test-pkg parser`
+Expected: PASS (TestParseDefaultsComplex green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+git add ir/ir.go parser/parse_defaults.go parser/testdata/defaults_complex.dip parser/parser_test.go
+git commit -m "feat: parse graph-level on_failure into WorkflowDefaults (#92)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Structural validation of `on_failure` (reuse DIP003)
+
+**Files:**
+- Modify: `validator/validate.go` (`Validate`, ~line 14; add `checkOnFailureTarget`)
+- Modify: `validator/codes.go:7` (DIP003 comment)
+- Test: `validator/validate_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `validator/validate_test.go`:
+
+```go
+func TestOnFailureUnknownNode(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "t", Start: "A", Exit: "A",
+		Defaults: ir.WorkflowDefaults{OnFailure: "Nope"},
+		Nodes:    []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}}},
+	}
+	res := Validate(w)
+	if !hasCode(res.Diagnostics, DIP003) {
+		t.Fatalf("expected DIP003 for unknown on_failure target, got %+v", res.Diagnostics)
+	}
+}
+
+func TestOnFailureKnownNode(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "t", Start: "A", Exit: "A",
+		Defaults: ir.WorkflowDefaults{OnFailure: "A"},
+		Nodes:    []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}}},
+	}
+	res := Validate(w)
+	for _, d := range res.Diagnostics {
+		if d.Code == DIP003 {
+			t.Fatalf("unexpected DIP003 for valid on_failure target: %+v", d)
+		}
+	}
+}
+```
+
+If `hasCode` does not already exist in the test package, add this helper to `validator/validate_test.go`:
+
+```go
+func hasCode(diags []Diagnostic, code string) bool {
+	for _, d := range diags {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}
+```
+
+(First grep `validator/*_test.go` for an existing `hasCode`/`hasDiagnostic` helper and reuse it instead of redefining — redefinition is a compile error.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test-pkg validator`
+Expected: `TestOnFailureUnknownNode` FAILS ("expected DIP003 ... got []").
+
+- [ ] **Step 3: Implement the check**
+
+In `validator/validate.go`, add the call inside `Validate` after `checkEdgeEndpoints(w)`:
+
+```go
+	diags = append(diags, checkEdgeEndpoints(w)...)
+	diags = append(diags, checkOnFailureTarget(w)...)
+```
+
+Add the function (place near `checkEdgeEndpoints`):
+
+```go
+// checkOnFailureTarget verifies DIP003: the graph-level on_failure route, if set,
+// references an existing node. on_failure is a node reference like an edge endpoint,
+// so it reuses the DIP003 code.
+func checkOnFailureTarget(w *ir.Workflow) []Diagnostic {
+	target := w.Defaults.OnFailure
+	if target == "" || w.Node(target) != nil {
+		return nil
+	}
+	d := Diagnostic{
+		Code:     DIP003,
+		Severity: SeverityError,
+		Message:  fmt.Sprintf("on_failure references unknown node %q", target),
+	}
+	if suggestion := closestNodeID(w, target); suggestion != "" {
+		d.Help = fmt.Sprintf("did you mean %q?", suggestion)
+	} else {
+		d.Help = fmt.Sprintf("declare a node with ID %q or fix the on_failure target", target)
+	}
+	return []Diagnostic{d}
+}
+```
+
+- [ ] **Step 4: Update the DIP003 comment for honesty**
+
+In `validator/codes.go`, change line 7:
+
+```go
+	DIP003 = "DIP003" // unknown node reference (edge endpoint or on_failure target)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `just test-pkg validator`
+Expected: both new tests PASS.
+
+- [ ] **Step 6: Check complexity & commit**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+just complexity
+git add validator/validate.go validator/codes.go validator/validate_test.go
+git commit -m "feat: validate on_failure references an existing node via DIP003 (#92)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: DIP004 reachability — seed the `on_failure` target
+
+**Files:**
+- Modify: `validator/validate.go` (`buildAllEdgeAdjacency`, ~line 111)
+- Test: `validator/validate_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+A node reachable ONLY via `on_failure` must not be flagged DIP004:
+
+```go
+func TestOnFailureTargetIsReachable(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "t", Start: "A", Exit: "Done",
+		Defaults: ir.WorkflowDefaults{OnFailure: "Rescue"},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
+			{ID: "Rescue", Kind: ir.NodeHuman, Config: ir.HumanConfig{Mode: "freeform"}},
+			{ID: "Done", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "end"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "A", To: "Done"},
+			{From: "Rescue", To: "Done"},
+		},
+	}
+	res := Validate(w)
+	for _, d := range res.Diagnostics {
+		if d.Code == DIP004 {
+			t.Fatalf("Rescue should be reachable via on_failure, got DIP004: %+v", d)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-pkg validator`
+Expected: FAIL — `Rescue should be reachable via on_failure, got DIP004` (Rescue has no incoming edge).
+
+- [ ] **Step 3: Seed the on_failure edge into reachability**
+
+In `validator/validate.go`, modify `buildAllEdgeAdjacency`:
+
+```go
+// buildAllEdgeAdjacency builds an adjacency map including all edges (including restart).
+// It also includes implicit parallel/fan_in edges and the graph-level on_failure route,
+// so a recovery node reachable only via on_failure is not falsely flagged DIP004.
+func buildAllEdgeAdjacency(w *ir.Workflow) map[string][]string {
+	adj := make(map[string][]string)
+	for _, e := range w.Edges {
+		adj[e.From] = append(adj[e.From], e.To)
+	}
+	addParallelFanInEdges(adj, w)
+	addOnFailureEdge(adj, w)
+	return adj
+}
+
+// addOnFailureEdge adds the graph-level on_failure target as reachable from start.
+// One path suffices for reachability; on_failure is conceptually reachable from any
+// failing node, and start is always reachable.
+func addOnFailureEdge(adj map[string][]string, w *ir.Workflow) {
+	if w.Defaults.OnFailure != "" {
+		adj[w.Start] = append(adj[w.Start], w.Defaults.OnFailure)
+	}
+}
+```
+
+Note: `buildAllEdgeAdjacency` feeds only DIP004 reachability — NOT `buildNonRestartAdjacency` (DIP005 cycles) or `buildForwardAdjacency` (DIP105 success path), so this adds no false cycle and no false success path.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-pkg validator`
+Expected: PASS. Also confirm no DIP005/DIP105 regressions in the package output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+just complexity
+git add validator/validate.go validator/validate_test.go
+git commit -m "fix: seed on_failure target into DIP004 reachability (#92)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Formatter emit + `.dip` round-trip
+
+**Files:**
+- Modify: `formatter/format.go:164-173` (`writeDefaultsRestartFields`)
+- Test: `formatter/format_test.go`
+- Test: `parser/parser_test.go`
+
+- [ ] **Step 1: Write the failing formatter test**
+
+Add to `formatter/format_test.go` (mirror `TestFormatDefaultsRestartTarget`):
+
+```go
+func TestFormatDefaultsOnFailure(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "test",
+		Start: "A",
+		Exit:  "A",
+		Defaults: ir.WorkflowDefaults{
+			OnFailure: "Escalate",
+		},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go."}},
+		},
+	}
+	output := Format(w)
+	assertContains(t, output, "    on_failure: Escalate")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-pkg formatter`
+Expected: FAIL — output does not contain `on_failure: Escalate`.
+
+- [ ] **Step 3: Emit on_failure in the formatter**
+
+In `formatter/format.go`, in `writeDefaultsRestartFields`, add after the `restart_target` block:
+
+```go
+	if d.RestartTarget != "" {
+		wr.line("restart_target: %s", d.RestartTarget)
+	}
+	if d.OnFailure != "" {
+		wr.line("on_failure: %s", d.OnFailure)
+	}
+	writeDefaultsCompactionFields(wr, d)
+```
+
+- [ ] **Step 4: Run formatter test to verify it passes**
+
+Run: `just test-pkg formatter`
+Expected: PASS. Run `just complexity` — `writeDefaultsRestartFields` now has 3 `if`s (cyclomatic 4), within budget.
+
+- [ ] **Step 5: Add the `.dip` round-trip test**
+
+Add to `parser/parser_test.go` (mirror `TestParseDefaultsBudgetRoundTrip`):
+
+```go
+func TestParseDefaultsOnFailureRoundTrip(t *testing.T) {
+	w1 := parseFixture(t, "defaults_complex.dip")
+	if w1.Defaults.OnFailure != "A" {
+		t.Fatalf("precondition: on_failure = %q, want A", w1.Defaults.OnFailure)
+	}
+	formatted := formatter.Format(w1)
+	w2, err := NewParser(formatted, "roundtrip").Parse()
+	if err != nil {
+		t.Fatalf("re-parse error: %v\nformatted:\n%s", err, formatted)
+	}
+	if w2.Defaults.OnFailure != "A" {
+		t.Errorf("round-trip: on_failure = %q, want A", w2.Defaults.OnFailure)
+	}
+}
+```
+
+(`parseFixture` and the `formatter` import already exist in this test file — confirm via the existing `TestParseDefaultsBudgetRoundTrip`.)
+
+- [ ] **Step 6: Run round-trip test to verify it passes**
+
+Run: `just test-pkg parser`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+git add formatter/format.go formatter/format_test.go parser/parser_test.go
+git commit -m "feat: format on_failure default + .dip round-trip (#92)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: DOT export + migrate round-trip
+
+**Files:**
+- Modify: `export/dot.go` (`buildGraphAttrs` ~line 88, `reservedGraphAttrs` ~line 61)
+- Modify: `migrate/migrate.go:114-123` (`graphDefaultsHandlers`)
+- Test: `export/dot_test.go`
+- Test: `migrate/roundtrip_test.go`
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+Add to `migrate/roundtrip_test.go` (mirror `TestRoundTripToolSafetyDefaults`):
+
+```go
+// TestRoundTripOnFailureDefault verifies on_failure round-trips losslessly
+// through parse → ExportDOT → Migrate.
+func TestRoundTripOnFailureDefault(t *testing.T) {
+	src := `workflow OnFailure
+  goal: "round trip"
+  start: A
+  exit: A
+
+  defaults
+    on_failure: A
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A
+`
+	w1, err := dipparser.NewParser(src, "rt.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dot := export.ExportDOT(w1, export.ExportOptions{})
+	w2, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("migrate: %v\nDOT:\n%s", err, dot)
+	}
+	if w2.Defaults.OnFailure != "A" {
+		t.Errorf("on_failure after round-trip = %q, want %q; DOT:\n%s",
+			w2.Defaults.OnFailure, "A", dot)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-pkg migrate`
+Expected: FAIL — `on_failure after round-trip = "" , want "A"` (DOT never emitted it).
+
+- [ ] **Step 3: Emit on_failure in DOT export + reserve the attr name**
+
+In `export/dot.go`, add to `reservedGraphAttrs` (append to the tool-safety line):
+
+```go
+	"tool_commands_allow": true, "tool_denylist_add": true,
+	"on_failure": true,
+```
+
+In `buildGraphAttrs`, add after the tool-safety attribute block (before `addGraphVarsAttrs`):
+
+```go
+	if w.Defaults.OnFailure != "" {
+		attrs = append(attrs, fmt.Sprintf("on_failure=%s", dotQuote(w.Defaults.OnFailure)))
+	}
+```
+
+- [ ] **Step 4: Map on_failure back on migrate**
+
+In `migrate/migrate.go`, add an entry to `graphDefaultsHandlers`:
+
+```go
+	"tool_denylist_add":   func(v string, w *ir.Workflow) { w.Defaults.ToolDenylistAdd = v },
+	"on_failure":          func(v string, w *ir.Workflow) { w.Defaults.OnFailure = v },
+```
+
+- [ ] **Step 5: Run round-trip test to verify it passes**
+
+Run: `just test-pkg migrate`
+Expected: PASS.
+
+- [ ] **Step 6: Add the DOT export assertion**
+
+Add to `export/dot_test.go` (mirror `TestExportToolSafetyDefaults`):
+
+```go
+func TestExportOnFailureDefault(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "t", Start: "A", Exit: "A",
+		Defaults: ir.WorkflowDefaults{OnFailure: "Escalate"},
+		Nodes:    []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+	if !strings.Contains(out, `on_failure="Escalate"`) {
+		t.Errorf("expected on_failure graph attr, got:\n%s", out)
+	}
+}
+```
+
+- [ ] **Step 7: Run export test, complexity, commit**
+
+Run: `just test-pkg export` → PASS.
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+just complexity
+git add export/dot.go export/dot_test.go migrate/migrate.go migrate/roundtrip_test.go
+git commit -m "feat: round-trip on_failure through DOT export/migrate (#92)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: DIP144 lint — agent node without a failure route (#93)
+
+**Files:**
+- Create: `validator/lint_failure_route.go`
+- Create: `validator/lint_failure_route_test.go`
+- Modify: `validator/lint.go` (append chain ~line 62; doc comment line 8)
+- Modify: `validator/lint_codes.go` (const block ~line 47; CodeDescription ~line 94; header comment line 3)
+- Modify: `validator/explanations.go` (`reachabilityExplanations`, ~line 105)
+
+- [ ] **Step 1: Write the failing lint tests**
+
+Create `validator/lint_failure_route_test.go`:
+
+```go
+package validator
+
+import (
+	"testing"
+
+	"github.com/2389-research/dippin-lang/parser"
+)
+
+func lintSrc(t *testing.T, src string) []Diagnostic {
+	t.Helper()
+	w, err := parser.NewParser(src, "t.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return Lint(w).Diagnostics
+}
+
+func TestDIP144FiresOnRoutelessAgent(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  agent A
+    prompt: "go"
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done
+`
+	if !hasCode(lintSrc(t, src), DIP144) {
+		t.Fatal("expected DIP144 on routeless agent A")
+	}
+}
+
+func TestDIP144SuppressedByFailEdge(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  agent A
+    prompt: "go"
+  human Rescue
+    mode: freeform
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done when ctx.outcome = success
+    A -> Rescue when ctx.outcome = fail
+    Rescue -> Done
+`
+	for _, d := range lintSrc(t, src) {
+		if d.Code == DIP144 && d.Message != "" && containsNode(d.Message, "A") {
+			t.Fatalf("DIP144 should be suppressed by fail edge on A: %+v", d)
+		}
+	}
+}
+
+func TestDIP144SuppressedByFallbackTarget(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  agent A
+    prompt: "go"
+    fallback_target: Done
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done
+`
+	if hasCode(lintSrc(t, src), DIP144) {
+		t.Fatal("DIP144 should be suppressed by fallback_target")
+	}
+}
+
+func TestDIP144SuppressedByGraphOnFailure(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  defaults
+    on_failure: Rescue
+  agent A
+    prompt: "go"
+  human Rescue
+    mode: freeform
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done
+    Rescue -> Done
+`
+	if hasCode(lintSrc(t, src), DIP144) {
+		t.Fatal("DIP144 should be suppressed by graph on_failure")
+	}
+}
+
+func TestDIP144FiresWithDIP115OnRoutelessGoalGate(t *testing.T) {
+	src := `workflow W
+  start: G
+  exit: Done
+  agent G
+    prompt: "gate"
+    goal_gate: true
+  agent Done
+    prompt: "end"
+  edges
+    G -> Done
+`
+	diags := lintSrc(t, src)
+	if !hasCode(diags, DIP144) {
+		t.Fatal("expected DIP144 on routeless goal_gate agent")
+	}
+	if !hasCode(diags, DIP115) {
+		t.Fatal("expected DIP115 to still fire alongside DIP144 (independent codes)")
+	}
+}
+
+func TestDIP144NotOnHumanOrToolNodes(t *testing.T) {
+	src := `workflow W
+  start: H
+  exit: Done
+  human H
+    mode: freeform
+  agent Done
+    prompt: "end"
+    fallback_target: Done
+  edges
+    H -> Done
+`
+	for _, d := range lintSrc(t, src) {
+		if d.Code == DIP144 && containsNode(d.Message, "H") {
+			t.Fatalf("DIP144 must not fire on human node H: %+v", d)
+		}
+	}
+}
+```
+
+Add a tiny helper at the bottom of the new test file (or reuse an existing substring helper if present):
+
+```go
+func containsNode(msg, id string) bool {
+	return msg != "" && (msg == id || stringContains(msg, "\""+id+"\""))
+}
+
+func stringContains(s, sub string) bool { return strings.Contains(s, sub) }
+```
+
+…and add `"strings"` to the test imports. (If a `strings`-based substring helper already exists in the package's tests, reuse it and drop these.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test-pkg validator`
+Expected: compile error — `undefined: DIP144` and `undefined: lintAgentFailureRoute` references will surface once added; first failure is `undefined: DIP144`.
+
+- [ ] **Step 3: Add the DIP144 constant + description**
+
+In `validator/lint_codes.go`, in the const block after `DIP143`:
+
+```go
+	DIP143 = "DIP143" // referenced subgraph does not inherit this workflow's tool_access restrictions
+	DIP144 = "DIP144" // agent node has no failure route
+```
+
+And in the `CodeDescription` init after the `DIP143` line:
+
+```go
+	CodeDescription[DIP144] = "agent node has no failure route"
+```
+
+Update the header comment (line 3) from `DIP101–DIP143` to `DIP101–DIP144`.
+
+- [ ] **Step 4: Add the Explanation entry**
+
+In `validator/explanations.go`, inside `reachabilityExplanations()`'s returned map (after the `DIP105` entry):
+
+```go
+		DIP144: {
+			Code:    DIP144,
+			Summary: "agent node has no failure route",
+			Trigger: "An agent node can fail at runtime but has no fail edge, fallback_target, bounded retry, or graph-level on_failure.",
+			Fix:     "Add a `-> <node> when ctx.outcome = fail` edge, set fallback_target, add retry_target with max_retries, or declare a workflow-level on_failure.",
+			Example: "agent Implement\n  prompt: \"build it\"\nImplement -> Test  // DIP144: no route if Implement fails",
+		},
+```
+
+- [ ] **Step 5: Create the lint implementation**
+
+Create `validator/lint_failure_route.go`:
+
+```go
+package validator
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// lintAgentFailureRoute checks DIP144: an agent node that can fail at runtime
+// but has no way to route that failure — no fail edge, no fallback_target, no
+// bounded retry target, and no graph-level on_failure. Such a node is a silent
+// dead-end. Scoped to agent nodes; the exit node and nodes with no outgoing
+// edges are skipped (failure there ends the run, not a routing gap).
+func lintAgentFailureRoute(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, n := range w.Nodes {
+		if needsFailureRoute(w, n) {
+			diags = append(diags, Diagnostic{
+				Code:     DIP144,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("agent node %q has no failure route (no fail edge, no fallback_target, no graph on_failure)", n.ID),
+				Location: n.Source,
+				Help:     "add `-> <node> when ctx.outcome = fail`, set fallback_target:, or declare a workflow-level on_failure:",
+			})
+		}
+	}
+	return diags
+}
+
+// needsFailureRoute reports whether an agent node lacks any failure route.
+func needsFailureRoute(w *ir.Workflow, n *ir.Node) bool {
+	if _, ok := n.Config.(ir.AgentConfig); !ok {
+		return false
+	}
+	if n.ID == w.Exit {
+		return false
+	}
+	outgoing := w.EdgesFrom(n.ID)
+	if len(outgoing) == 0 {
+		return false
+	}
+	return !hasFailureRoute(w, n, outgoing)
+}
+
+// hasFailureRoute reports whether the node has any failure-handling route.
+func hasFailureRoute(w *ir.Workflow, n *ir.Node, outgoing []*ir.Edge) bool {
+	if w.Defaults.OnFailure != "" {
+		return true
+	}
+	if hasBoundedFailureTarget(n.Retry) {
+		return true
+	}
+	return hasFailEdge(outgoing)
+}
+
+// hasBoundedFailureTarget reports whether retry config supplies a recovery target:
+// a fallback_target, or a retry_target bounded by max_retries.
+func hasBoundedFailureTarget(r ir.RetryConfig) bool {
+	if r.FallbackTarget != "" {
+		return true
+	}
+	return r.RetryTarget != "" && r.MaxRetries > 0
+}
+
+// hasFailEdge reports whether any outgoing edge routes on outcome = fail/failure.
+// An unconditional/success edge does NOT count — a hard failure does not traverse it.
+func hasFailEdge(edges []*ir.Edge) bool {
+	for _, e := range edges {
+		cmp, ok := extractEqualityCondition(e)
+		if ok && isOutcomeVar(cmp.Variable) && isFailValue(cmp.Value) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOutcomeVar matches the outcome variable in both namespaced and bare forms.
+func isOutcomeVar(v string) bool { return v == "ctx.outcome" || v == "outcome" }
+
+// isFailValue matches the failure outcome values the engine recognizes.
+func isFailValue(v string) bool { return v == "fail" || v == "failure" }
+```
+
+- [ ] **Step 6: Register the lint**
+
+In `validator/lint.go`, add to the `Lint` append chain (after `lintSubgraphToolAccess(w)`):
+
+```go
+	diags = append(diags, lintSubgraphToolAccess(w)...)
+	diags = append(diags, lintAgentFailureRoute(w)...)
+```
+
+Update the `Lint` doc comment (line 8) from `DIP101–DIP143` to `DIP101–DIP144`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `just test-pkg validator`
+Expected: all DIP144 tests PASS; `TestExplanationsCoverAllCodes` / `TestExplanationsNoExtra` PASS (DIP144 in both maps).
+
+- [ ] **Step 8: Complexity + commit**
+
+Run: `just complexity` (all new helpers ≤5 cyclomatic / ≤7 cognitive).
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+git add validator/lint_failure_route.go validator/lint_failure_route_test.go validator/lint.go validator/lint_codes.go validator/explanations.go
+git commit -m "feat: DIP144 lint — agent node without a failure route (#93)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Example, docs, range bumps, spec regen, wasm
+
+**Files:**
+- Create: `examples/on_failure_route.dip`
+- Modify: docs (`docs/validation.md`, `docs/llm-reference.md`, `docs/edges.md`, `docs/nodes.md`, `docs/syntax.md`)
+- Modify: `CLAUDE.md` (count + range)
+- Regenerate: `docs/generated-spec.md` + `cmd/dippin/generated-spec.md` (via pre-commit/`just spec-check` — do NOT hand-edit)
+
+- [ ] **Step 1: Measure the DIP144 blast radius**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+just build
+for f in examples/*.dip; do n=$(./dippin lint "$f" 2>/dev/null | grep -c DIP144); echo "$n  $f"; done | sort -rn
+```
+
+Record the counts. Decision rule: leave `stress_*`/adversarial fixtures warning; only consider editing a couple of flagship examples (e.g. `orchestrator.dip`, `api_design.dip`) if a one-line `on_failure` is natural. Do NOT mass-edit. Lint warnings do not fail CI.
+
+- [ ] **Step 2: Create the lint-clean demonstrator example**
+
+Create `examples/on_failure_route.dip`:
+
+```
+workflow OnFailureDemo
+  goal: "Demonstrate a graph-level on_failure recovery route"
+  start: Plan
+  exit: Done
+
+  defaults
+    on_failure: Escalate
+
+  agent Plan
+    prompt: "Draft a plan."
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  agent Build
+    prompt: "Execute the plan."
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  human Escalate
+    mode: freeform
+    prompt: "An automated step failed — please intervene."
+
+  agent Done
+    prompt: "Summarize the result."
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  edges
+    Plan -> Build
+    Build -> Done
+    Escalate -> Done
+```
+
+- [ ] **Step 3: Verify the example is structurally valid and DIP144-clean**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+./dippin validate examples/on_failure_route.dip   # expect: validation passed
+./dippin lint examples/on_failure_route.dip        # expect: no DIP144, no DIP108
+```
+
+Expected: `validate` passes (Escalate reachable via the on_failure seed — exercises Task 3 end-to-end); `lint` shows no DIP144 (on_failure suppresses it) and no DIP108 (valid model). If DIP108 fires, swap the model for one verified in `validator/lint_model.go`.
+
+- [ ] **Step 4: Document the attribute, the lint, and precedence**
+
+- `docs/validation.md`: add a `DIP144` row/section alongside DIP101–DIP143; bump the "DIP101–DIP143" range strings and the code count to include DIP144.
+- `docs/llm-reference.md`: bump the "DIP101–DIP143" range and the "52 ... codes" count by one.
+- `docs/edges.md` (Routing Priority cascade, ~line 110): document the 5-level failure precedence (fail edge > bounded retry > fallback_target > on_failure > halt), stating that dippin validates existence/shape and the runtime owns ordering, and that a `restart:true` fail edge carries its own `max_restarts` budget.
+- `docs/nodes.md:55-56`: cross-reference `fallback_target` to the graph-level `on_failure` catch-all.
+- `docs/syntax.md` (defaults table): add an `on_failure` row.
+- `CLAUDE.md:85`: bump the code count and the "DIP101-DIP143" range to DIP144.
+
+- [ ] **Step 5: Regenerate the spec (never hand-edit generated files)**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+just spec-check
+git status --short   # docs/generated-spec.md + cmd/dippin/generated-spec.md may change
+```
+
+- [ ] **Step 6: Verify the wasm build (Netlify preview gate)**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+GOOS=js GOARCH=wasm go build ./cmd/wasm/ ./validator/
+```
+
+Expected: builds cleanly, no output. (This is a build-only verification the justfile's `wasm` recipe also covers via `just wasm`.)
+
+- [ ] **Step 7: Full suite + commit**
+
+Run: `just test` then `just complexity` then `just validate-examples`.
+Expected: all green. (`just check` additionally runs tree-sitter-generate which FAILS in this env with no tree-sitter CLI — treat clean-everything-before-tree-sitter as green; the pre-commit hook is the real gate.)
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+git add examples/on_failure_route.dip docs/ cmd/dippin/generated-spec.md CLAUDE.md
+git commit -m "docs: document on_failure + DIP144, add demonstrator example, bump code range (#92, #93)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Open the PR
+
+- [ ] **Step 1: Push and open the PR**
+
+```bash
+cd /home/clint/code/2389/dippin-lang/.claude/worktrees/feat+92-on-failure-route
+git push -u origin feat/92-on-failure-route
+```
+
+- [ ] **Step 2: Create the PR** with body covering: the `on_failure` attribute + precedence semantics; the DIP144 lint + its suppression set; the DIP003 node-existence validation + DIP004 reachability seeding; the DOT round-trip decision (tool-safety precedent); the DIP102-suppression descope rationale; the examples blast-radius decision; and the cross-repo split (dippin carries/validates, tracker enforces — note the tracker `upstream` follow-up to be filed, blocking-linked to #295, and the `tracker validate` warning-fatality question). Title: `feat: graph-level on_failure route + DIP144 failure-route lint (Closes #92, Closes #93)`.
+
+- [ ] **Step 3: Do NOT tag a release.** Per the maintainer, tagging (~v0.37.0) requires explicit go-ahead.
+```

--- a/docs/superpowers/specs/2026-06-04-issue-92-93-design.md
+++ b/docs/superpowers/specs/2026-06-04-issue-92-93-design.md
@@ -1,0 +1,214 @@
+# Design: graph-level `on_failure` route (#92) + DIP144 failure-route lint (#93)
+
+**Date:** 2026-06-04
+**Issues:** Closes #92, Closes #93 (one PR)
+**Status:** Approved design — ready for implementation plan
+
+## Summary
+
+Two paired changes shipped in one PR:
+
+1. **#92** — a graph-level `on_failure: <NodeID>` default, declaring **one** fallback
+   failure route for the whole workflow instead of wiring `when ctx.outcome = fail`
+   edges or `fallback_target` on every agent node.
+2. **#93** — a new lint **DIP144** (warning): an `agent` node with **no** failure
+   route. `on_failure` is one of its suppressors, which is why they ship together.
+
+dippin **carries + validates** the authoring surface and **lints** for missing
+routes. The tracker runtime **enforces** the routing at execution time (tracker
+engine #295). This PR is dippin-side only; `on_failure` is **inert** until the
+tracker reads it. We do **not** gate dippin behavior (including DIP144 suppression)
+on tracker readiness — dippin ships the feature now; the tracker enforces whenever
+it is ready. A tracker `upstream` follow-up is filed once this lands.
+
+## Scope decisions (ratified)
+
+- **C2 / fail-open:** Implement the full three-way DIP144 suppression now, including
+  `on_failure`. Do **not** gate the suppressor or the release tag on tracker
+  enforcement. Document the carry/validate-vs-enforce split (CHANGELOG/PR note that
+  `on_failure` is inert until the tracker enforces it) — documentation, not behavioral
+  gating.
+- **I2 / DIP102:** **Descope** DIP102 suppression-by-`on_failure`. This deliberately
+  deviates from #92's acceptance-criteria bullet. Rationale: DIP102 detects
+  "routing can get stuck on an *unmatched outcome*" — a different concern than
+  "failure-route presence." `on_failure` only catches *failures*, so blanket-
+  suppressing DIP102 would mask a genuine "succeeded but no edge matched" bug on
+  agent nodes that route on non-`outcome` variables. DIP144 is the purpose-built
+  lint that `on_failure` cleanly suppresses.
+
+## #92 — `on_failure` graph-level default route
+
+### IR
+Add `OnFailure string` to `ir.WorkflowDefaults`, next to `RestartTarget`
+(`ir/ir.go:40-56`). Empty string = unset (matches every sibling string field).
+No other in-repo package needs to read it (verified: nothing reads `RestartTarget`
+either; it is carried metadata for the downstream engine).
+
+### Surface / parser
+`defaults:` block field only (**not** the workflow header). Verified: the header
+parser accepts only `goal`/`start`/`exit`/`requires` + block keywords
+(`parser/parser.go:101-128`); a header `on_failure:` would emit "unexpected
+top-level identifier". Parsed in `parser/parse_defaults.go` via
+`applyDefaultExtraField` (the `restart_target`/`compaction`/`on_resume` switch) —
+one `case "on_failure": d.OnFailure = val`. The issue sketched it at the header,
+but acceptance criteria allow "header/defaults"; defaults-block is consistent with
+every other default-semantics field and lands in `WorkflowDefaults` naturally.
+
+### Structural validation (reuse DIP003)
+New `checkOnFailureTarget(w)` in `validator/validate.go`, wired into `Validate()`.
+Emits **DIP003** `SeverityError` when `Defaults.OnFailure != "" && w.Node(OnFailure)
+== nil`, with the existing `closestNodeID` "did you mean?" suggestion and an
+`on_failure`-specific message (must **not** say "edge").
+
+Honest framing: this is **net-new** defaults-scanning code that *emits* the
+existing DIP003 code — not free reuse. We reuse DIP003 (rather than a new DIP010)
+to avoid churning ~20 hardcoded "DIP001–DIP009" structural-range strings across
+docs/site for zero semantic gain. Update DIP003's const comment
+(`validator/codes.go:7`) and `docs/edges.md` to read "unknown node reference
+(edge endpoint **or `on_failure` target**)".
+
+Known asymmetry: `restart_target`/`retry_target`/`fallback_target` currently get
+**no** node-existence validation. `on_failure` becomes the only validated jump
+target. Acceptable (it's new, no back-compat cost); a follow-up to extend the check
+to the other three is noted but **out of scope** here.
+
+### DIP004 reachability (required fix)
+An `on_failure` recovery node may have **no incoming edge** (the whole point — a
+node reachable only via the catch-all). `buildAllEdgeAdjacency`
+(`validator/validate.go:111-118`) walks only `w.Edges` + parallel/fan_in, so such a
+node is flagged **DIP004** (Error), *blocking validation*. `restart_target` escapes
+this only because authors always also wire a `restart:true` edge.
+
+Fix: seed the `on_failure` target as an **implicit routing edge** into the all-edge
+adjacency used for reachability (mirroring how parallel/fan_in implicit edges are
+added). Add it from `w.Start` (start is reachable, so the target becomes reachable;
+one path suffices). Do **not** add it to the non-restart adjacency
+(`buildNonRestartAdjacency`, used by DIP005 cycle detection) or the forward
+adjacency (DIP105 success-path) — `on_failure` is neither a cycle edge nor a
+success path.
+
+### Formatter round-trip
+Emit in the defaults block next to `restart_target` (`formatter/format.go`
+`writeDefaultsRestartFields`; complexity verified safe — one added `if`).
+`.dip` round-trip test mirroring `TestParseDefaultsBudgetRoundTrip`
+(`parser/parser_test.go:1625`).
+
+### DOT export / migrate round-trip (adopt)
+`on_failure` is a **safety-critical** failure route. The right precedent is the
+tool-safety defaults (`tool_commands_allow`/`tool_denylist_add`), which round-trip
+through DOT *with* a regression test (`migrate/roundtrip_test.go`
+`TestRoundTripToolSafetyDefaults`) — not `restart_target` (an unvalidated loop knob
+that is silently DOT-lossy). Add:
+- `export/dot.go` `buildGraphAttrs`: emit `on_failure=<id>` when set; add
+  `"on_failure": true` to `reservedGraphAttrs` so a like-named var can't collide.
+- `migrate/migrate.go` `graphDefaultsHandlers`: `"on_failure": func(v, w){
+  w.Defaults.OnFailure = v }`.
+- `migrate/roundtrip_test.go` + `export/dot_test.go`: round-trip + export assertions
+  mirroring the tool-safety pair.
+
+### Precedence semantics (documented; tracker enforces)
+For an agent node finishing `outcome = fail` / erroring, most-specific wins:
+1. matching fail edge (`when ctx.outcome = fail|failure`)
+2. bounded node retry (`retry_target` + `max_retries`)
+3. node `fallback_target`
+4. graph `on_failure` (catch-all)
+5. halt (current behavior)
+
+A `goal_gate`'s own `fallback_target` still wins (step 3, ahead of `on_failure`).
+dippin validates *existence/shape only* — the runtime owns the ordering. The docs
+must state this split plainly, and must be unambiguous about retry-vs-fail-edge
+ordering (a `restart:true` fail edge has its own `max_restarts` budget — call this
+out so authors aren't misled). The canonical home is the Routing Priority cascade
+in `docs/edges.md:110-121`.
+
+## #93 — DIP144 lint ("agent node has no failure route")
+
+- **Severity** `warning`. **Scope** `NodeAgent` only (verified: no `codergen`
+  NodeKind; `coder` is only a stylesheet class). New
+  `validator/lint_failure_route.go`, registered in `Lint()`.
+- **Guards (skip, no warning):** the exit node (`n.ID == w.Exit`) and any node with
+  zero outgoing edges (terminal agent — failure ends the run; mirror DIP102's
+  `len(outgoing)==0` continue).
+- **Suppressed** when the node has **any** of:
+  - (a) an outgoing edge whose parsed condition is an equality on `ctx.outcome` or
+    `outcome` with value `fail` or `failure` (reuse `extractEqualityCondition` + the
+    `{fail,failure}` vocabulary; match the prefixed `ctx.outcome` spelling — the
+    parser never normalizes to bare `outcome`).
+  - (b) `Retry.FallbackTarget != ""`.
+  - (c) `Retry.RetryTarget != "" && Retry.MaxRetries > 0` (bounded retry; require the
+    *target*, not a bare `Policy`).
+  - (d) `Defaults.OnFailure != ""`.
+- **Deliberately NOT a suppressor: an unconditional default edge.** A reviewer
+  suggested reusing `hasUnconditionalEdge`/`findExhaustiveSources`, but #93's own
+  case study (`Implement → TestMilestone`, "sole, unconditional edge with no
+  fallback... the engine halted") proves an unconditional/success edge does **not**
+  catch a hard failure. So DIP144 keys on the *explicit fail-outcome edge*, which
+  also correctly catches `{pass,marginal,fail}`-style partitions (they contain a
+  literal `fail` edge) without over-suppressing `{success}`-plus-default routers.
+- **Fires independently of DIP115:** a routeless `goal_gate` agent node gets both.
+  Give DIP144 distinct, broader help text (lists fail edge / `fallback_target` /
+  graph `on_failure`) so it doesn't read as a duplicate of DIP115.
+- **Complexity:** extract `hasFailureRoute(w, n)` and `hasFailEdge(w, nodeID)`
+  helpers from the start to stay ≤5 cyclomatic / ≤7 cognitive.
+
+### Lint plumbing (test-gated)
+- const + `CodeDescription[DIP144]` (`validator/lint_codes.go`).
+- 4-field `Explanations[DIP144]` entry (natural home: the reachability group
+  alongside DIP101/DIP102) — `TestExplanationsCoverAllCodes`/`NoExtra` enforce this.
+- register `lintAgentFailureRoute` in `Lint()`'s append chain (`validator/lint.go`).
+- bump every hardcoded `DIP101–DIP143` range / count string (prose only, no machine
+  contract): `CLAUDE.md`, `validator/lint.go`, `validator/lint_codes.go`,
+  `docs/validation.md`, `docs/llm-reference.md`. Regenerate `docs/generated-spec.md`
+  + `cmd/dippin/generated-spec.md` from source docs via `scripts/gen-spec.sh`
+  (never hand-edit the generated files).
+
+## Examples blast radius (trimmed)
+
+DIP144 will fire on many of the 31 examples (agent nodes up to 33/file). Lint
+warnings do **not** fail CI (`validate-examples` is structural; `TestLintExamples`
+only asserts zero DIP108). So:
+- Measure empirically early (run `dippin lint` on all examples during TDD; report).
+- Add **one new lint-clean example** demonstrating `on_failure` suppressing DIP144
+  (required to prove the feature).
+- Make only a **few flagship** examples (the ones authors copy) lint-clean by adding
+  `on_failure`/fail routes.
+- Leave `stress_*`/adversarial fixtures emitting warnings — that is what they are for.
+
+## Cross-repo follow-up (tracker, separate repo)
+
+File a tracker `upstream` issue, blocking-linked to #295, specifying:
+- Adapter (`pipeline/dippin_adapter.go` `extractWorkflowDefaults`) copies
+  `OnFailure` — an **unresolved node-ID string**; resolve against the engine's node
+  table on the tracker side.
+- Empty `OnFailure` = feature-off; never route to node `""`.
+- Precedence (above) lives entirely in the engine; state it as the engine contract.
+- Answer whether `tracker validate` treats warnings as fatal. If it does, the DIP144
+  version bump could fail consumer CI on existing `.dip` files with no source change
+  — coordinate to keep warnings non-fatal (dippin keeps DIP144 `warning`, not error;
+  no strict flag — YAGNI).
+
+## Out of scope
+
+#94 budget fields (already parse into `WorkflowDefaults`); tracker runtime
+enforcement; any `error`/strict-flag severity for DIP144; node-existence validation
+for `restart_target`/`retry_target`/`fallback_target` (noted follow-up).
+
+## Testing (TDD — failing test first each step)
+
+- parser: `on_failure` → `WorkflowDefaults.OnFailure` (+ add to `defaults_complex.dip`).
+- structural: DIP003 fires on bad `on_failure`; none when valid; "did you mean?".
+- reachability: a node reachable *only* via `on_failure` is NOT flagged DIP004; no
+  false DIP005 cycle.
+- formatter: unit test mirroring `TestFormatDefaultsRestartTarget`; `.dip` round-trip.
+- DOT: export emits `on_failure`; `.dip → DOT → .dip` round-trip preserves it.
+- DIP144: fires on routeless agent; suppressed by each of (a)-(d); not on tool/human
+  nodes; skipped on exit/terminal nodes; fires alongside DIP115 on routeless goal_gate.
+- `TestExplanationsCoverAllCodes`/`NoExtra` for DIP144.
+- `GOOS=js GOARCH=wasm go build ./cmd/wasm/ ./validator/` (Netlify preview gate).
+
+## Build order
+
+1. `on_failure`: IR field → parser → formatter → DOT export/migrate → structural
+   check → reachability fix. (Suppressor (d) needs the field to exist.)
+2. DIP144 lint + plumbing.
+3. Examples + docs + range-string bumps + spec regen.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -121,6 +121,7 @@ The optional `defaults` block sets graph-level configuration that applies to all
 | `restart_target` | String | Node ID to jump to on restart loops |
 | `cache_tools` | Boolean | Whether to cache tool call results |
 | `compaction` | String | Context compaction mode for long pipelines |
+| `on_failure` | String | Graph-level default failure route — node to jump to when an agent has no other failure route (see [edges.md](edges.md) for the full precedence cascade) |
 
 ---
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,6 +1,6 @@
 # Validation and Linting Reference
 
-Dippin documents 48 diagnostic codes split into two categories (the linter additionally registers a few internal codes that don't have dedicated sections):
+Dippin registers 53 diagnostic codes split into two categories; this page documents 48 of them in dedicated sections (the linter registers a few additional internal codes without dedicated sections):
 
 - **Structural validation** (DIP001–DIP009): Errors that **must** be fixed. A workflow with any of these cannot execute.
 - **Semantic linting** (DIP101–DIP144): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -991,9 +991,9 @@ This is a Hint, not a Warning: the referencing node has no defect. The check is 
 An agent node has no declared failure route at any level. If the node fails at runtime, the pipeline has nowhere to go and will halt.
 
 ```
-warning[DIP144]: agent node "Build" has no failure route (no fail edge, no fallback_target, no graph on_failure)
+warning[DIP144]: agent node "Build" has no failure route (no fail edge, no fallback_target, no bounded retry, no graph on_failure)
   --> pipeline.dip:12:3
-  = help: add `-> <node> when ctx.outcome = fail`, set fallback_target:, or declare a workflow-level on_failure:
+  = help: add `-> <node> when ctx.outcome = fail`, set fallback_target:, add retry_target with max_retries, or declare a workflow-level on_failure:
 ```
 
 **What triggers it**: An `agent` node that has none of:

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,9 +1,9 @@
 # Validation and Linting Reference
 
-Dippin documents 47 diagnostic codes split into two categories (the linter additionally registers a few internal codes that don't have dedicated sections):
+Dippin documents 48 diagnostic codes split into two categories (the linter additionally registers a few internal codes that don't have dedicated sections):
 
 - **Structural validation** (DIP001–DIP009): Errors that **must** be fixed. A workflow with any of these cannot execute.
-- **Semantic linting** (DIP101–DIP143): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
+- **Semantic linting** (DIP101–DIP144): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
 
 Run `dippin validate <file>` for structural checks only, or `dippin lint <file>` for both.
 
@@ -12,7 +12,7 @@ graph LR
     SRC[".dip file"] --> PARSE["Parser"]
     PARSE --> IR["IR"]
     IR --> VAL["Structural Validation<br>DIP001–DIP009<br>(errors)"]
-    IR --> LINT["Semantic Linting<br>DIP101–DIP143<br>(warnings)"]
+    IR --> LINT["Semantic Linting<br>DIP101–DIP144<br>(warnings)"]
     VAL --> DIAG["Diagnostics"]
     LINT --> DIAG
 ```
@@ -224,7 +224,7 @@ error[DIP009]: duplicate edge
 
 ---
 
-## Semantic Lint Warnings (DIP101–DIP143)
+## Semantic Lint Warnings (DIP101–DIP144)
 
 ### DIP101: Node Only Reachable via Conditional Edges
 
@@ -984,6 +984,52 @@ This is a Hint, not a Warning: the referencing node has no defect. The check is 
 
 ---
 
+### DIP144: Agent Node Has No Failure Route
+
+**Severity**: Warning
+
+An agent node has no declared failure route at any level. If the node fails at runtime, the pipeline has nowhere to go and will halt.
+
+```
+warning[DIP144]: agent node "Build" has no failure route (no fail edge, no fallback_target, no graph on_failure)
+  --> pipeline.dip:12:3
+  = help: add `-> <node> when ctx.outcome = fail`, set fallback_target:, or declare a workflow-level on_failure:
+```
+
+**What triggers it**: An `agent` node that has none of:
+- An outgoing edge with `when ctx.outcome = fail` (or `failure`)
+- A `fallback_target` field
+- A `retry_target` + `max_retries` bounded retry
+- A `defaults.on_failure` declared on the workflow
+
+**Does not fire on**: `human`, `tool`, `parallel`, `fan_in`, `conditional`, `subgraph`, or `manager_loop` nodes.
+
+**How to fix**: Add any one of the four suppression routes:
+
+```dippin
+  # Option 1: explicit fail edge
+  edges
+    Build -> Escalate when ctx.outcome = fail
+
+  # Option 2: node fallback_target
+  agent Build
+    fallback_target: Escalate
+
+  # Option 3: bounded retry
+  agent Build
+    retry_target: Build
+    max_retries: 3
+    fallback_target: Escalate
+
+  # Option 4: graph-level catch-all
+  defaults
+    on_failure: Escalate
+```
+
+See [edges.md](edges.md) — Failure Handling for the full five-level precedence cascade.
+
+---
+
 ## Running Validation
 
 ### Structural validation only
@@ -1000,7 +1046,7 @@ Runs DIP001–DIP009. Exit code 0 if all pass, 1 if any errors.
 dippin lint pipeline.dip
 ```
 
-Runs all DIP001–DIP009 errors and DIP101–DIP143 warnings. Exit code 1 only for errors; warnings alone exit 0.
+Runs all DIP001–DIP009 errors and DIP101–DIP144 warnings. Exit code 1 only for errors; warnings alone exit 0.
 
 ### JSON output for CI
 

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -288,6 +288,7 @@ func TestDiagnose_GradeCDWorkflow(t *testing.T) {
 	// Score in 60-79 range via warnings (4-6 warnings).
 	w := &ir.Workflow{
 		Name: "test", Start: "A", Exit: "G",
+		Defaults: ir.WorkflowDefaults{OnFailure: "G"}, // suppresses DIP144 so score stays in C/D range
 		Nodes: []*ir.Node{
 			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: ""}},
 			{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: ""}},

--- a/examples/on_failure_route.dip
+++ b/examples/on_failure_route.dip
@@ -1,0 +1,31 @@
+workflow OnFailureDemo
+  goal: "Demonstrate a graph-level on_failure recovery route"
+  start: Plan
+  exit: Done
+
+  defaults
+    on_failure: Escalate
+
+  agent Plan
+    prompt: "Draft a plan."
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  agent Build
+    prompt: "Execute the plan."
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  human Escalate
+    mode: freeform
+    prompt: "An automated step failed — please intervene."
+
+  agent Done
+    prompt: "Summarize the result."
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  edges
+    Plan -> Build
+    Build -> Done
+    Escalate -> Done

--- a/export/dot.go
+++ b/export/dot.go
@@ -64,6 +64,7 @@ var reservedGraphAttrs = map[string]bool{
 	"max_retries": true, "default_max_retry": true, "max_restarts": true,
 	"max_total_tokens": true, "max_cost_cents": true, "max_wall_time": true,
 	"tool_commands_allow": true, "tool_denylist_add": true,
+	"on_failure": true,
 }
 
 // writeDOTHeader writes the digraph opening and global attributes.
@@ -97,6 +98,9 @@ func buildGraphAttrs(w *ir.Workflow, rankDir string) []string {
 	}
 	if w.Defaults.ToolDenylistAdd != "" {
 		attrs = append(attrs, fmt.Sprintf("tool_denylist_add=%s", dotQuote(w.Defaults.ToolDenylistAdd)))
+	}
+	if w.Defaults.OnFailure != "" {
+		attrs = append(attrs, fmt.Sprintf("on_failure=%s", dotQuote(w.Defaults.OnFailure)))
 	}
 
 	// Add workflow vars (excluding reserved graph attributes)

--- a/export/dot_test.go
+++ b/export/dot_test.go
@@ -1442,6 +1442,18 @@ func TestExportToolSafetyVarsCollision(t *testing.T) {
 	}
 }
 
+func TestExportOnFailureDefault(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "t", Start: "A", Exit: "A",
+		Defaults: ir.WorkflowDefaults{OnFailure: "Escalate"},
+		Nodes:    []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+	if !strings.Contains(out, `on_failure="Escalate"`) {
+		t.Errorf("expected on_failure graph attr, got:\n%s", out)
+	}
+}
+
 func TestExportDOTToolRoutingFields(t *testing.T) {
 	wf := &ir.Workflow{
 		Name:  "tool_routing_test",

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -169,6 +169,9 @@ func writeDefaultsRestartFields(wr *writer, d ir.WorkflowDefaults) {
 	if d.RestartTarget != "" {
 		wr.line("restart_target: %s", d.RestartTarget)
 	}
+	if d.OnFailure != "" {
+		wr.line("on_failure: %s", d.OnFailure)
+	}
 	writeDefaultsCompactionFields(wr, d)
 }
 

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -1022,6 +1022,22 @@ func TestFormatDefaultsRestartTarget(t *testing.T) {
 	assertContains(t, output, "    restart_target: Begin")
 }
 
+func TestFormatDefaultsOnFailure(t *testing.T) {
+	w := &ir.Workflow{
+		Name:  "test",
+		Start: "A",
+		Exit:  "A",
+		Defaults: ir.WorkflowDefaults{
+			OnFailure: "Escalate",
+		},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go."}},
+		},
+	}
+	output := Format(w)
+	assertContains(t, output, "    on_failure: Escalate")
+}
+
 func TestFormatSubgraphNoParams(t *testing.T) {
 	w := &ir.Workflow{
 		Name:  "sub",

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -45,6 +45,7 @@ type WorkflowDefaults struct {
 	Fidelity          string        // Default fidelity level
 	MaxRestarts       int           // Max loop restarts (default 5)
 	RestartTarget     string        // Where to restart on loop
+	OnFailure         string        // Default failure route (node to jump to on failure)
 	CacheTools        bool          // Cache tool results
 	Compaction        string        // Context compaction mode
 	OnResume          string        // Fidelity behavior on resume: "preserve" or "degrade"

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -120,6 +120,7 @@ var graphDefaultsHandlers = map[string]func(string, *ir.Workflow){
 	"provider":            func(v string, w *ir.Workflow) { w.Defaults.Provider = v },
 	"tool_commands_allow": func(v string, w *ir.Workflow) { w.Defaults.ToolCommandsAllow = v },
 	"tool_denylist_add":   func(v string, w *ir.Workflow) { w.Defaults.ToolDenylistAdd = v },
+	"on_failure":          func(v string, w *ir.Workflow) { w.Defaults.OnFailure = v },
 }
 
 // extractGraphDefaults populates workflow-level fields from DOT graph attributes.

--- a/migrate/roundtrip_test.go
+++ b/migrate/roundtrip_test.go
@@ -183,6 +183,38 @@ func TestRoundtripPreservesToolOutputs(t *testing.T) {
 	}
 }
 
+// TestRoundTripOnFailureDefault verifies on_failure round-trips losslessly
+// through parse → ExportDOT → Migrate.
+func TestRoundTripOnFailureDefault(t *testing.T) {
+	src := `workflow OnFailure
+  goal: "round trip"
+  start: A
+  exit: A
+
+  defaults
+    on_failure: A
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A
+`
+	w1, err := dipparser.NewParser(src, "rt.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dot := export.ExportDOT(w1, export.ExportOptions{})
+	w2, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("migrate: %v\nDOT:\n%s", err, dot)
+	}
+	if w2.Defaults.OnFailure != "A" {
+		t.Errorf("on_failure after round-trip = %q, want %q; DOT:\n%s",
+			w2.Defaults.OnFailure, "A", dot)
+	}
+}
+
 // TestRoundTripToolSafetyDefaults verifies that tool-safety defaults
 // round-trip losslessly through parse → ExportDOT → Migrate.
 func TestRoundTripToolSafetyDefaults(t *testing.T) {

--- a/parser/parse_defaults.go
+++ b/parser/parse_defaults.go
@@ -73,7 +73,8 @@ func applyDefaultCoreField(d *ir.WorkflowDefaults, key, val string) bool {
 	return true
 }
 
-// applyDefaultExtraField handles fidelity, compaction, on_resume, restart_target, and on_failure defaults.
+// applyDefaultExtraField handles fidelity, compaction, and on_resume defaults,
+// delegating restart_target and on_failure to applyDefaultRoutingField.
 func applyDefaultExtraField(d *ir.WorkflowDefaults, key, val string) bool {
 	switch key {
 	case "fidelity":

--- a/parser/parse_defaults.go
+++ b/parser/parse_defaults.go
@@ -73,17 +73,28 @@ func applyDefaultCoreField(d *ir.WorkflowDefaults, key, val string) bool {
 	return true
 }
 
-// applyDefaultExtraField handles fidelity, restart_target, compaction, on_resume defaults.
+// applyDefaultExtraField handles fidelity, compaction, on_resume, restart_target, and on_failure defaults.
 func applyDefaultExtraField(d *ir.WorkflowDefaults, key, val string) bool {
 	switch key {
 	case "fidelity":
 		d.Fidelity = val
-	case "restart_target":
-		d.RestartTarget = val
 	case "compaction":
 		d.Compaction = val
 	case "on_resume":
 		d.OnResume = val
+	default:
+		return applyDefaultRoutingField(d, key, val)
+	}
+	return true
+}
+
+// applyDefaultRoutingField handles restart_target and on_failure defaults.
+func applyDefaultRoutingField(d *ir.WorkflowDefaults, key, val string) bool {
+	switch key {
+	case "restart_target":
+		d.RestartTarget = val
+	case "on_failure":
+		d.OnFailure = val
 	default:
 		return false
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1644,6 +1644,21 @@ func TestParseDefaultsBudgetRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseDefaultsOnFailureRoundTrip(t *testing.T) {
+	w1 := parseFixture(t, "defaults_complex.dip")
+	if w1.Defaults.OnFailure != "A" {
+		t.Fatalf("precondition: on_failure = %q, want A", w1.Defaults.OnFailure)
+	}
+	formatted := formatter.Format(w1)
+	w2, err := NewParser(formatted, "roundtrip").Parse()
+	if err != nil {
+		t.Fatalf("re-parse error: %v\nformatted:\n%s", err, formatted)
+	}
+	if w2.Defaults.OnFailure != "A" {
+		t.Errorf("round-trip: on_failure = %q, want A", w2.Defaults.OnFailure)
+	}
+}
+
 func TestParseManagerLoopNode(t *testing.T) {
 	src := `workflow W
   start: M

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -880,6 +880,9 @@ func TestParseDefaultsComplex(t *testing.T) {
 	if d.RestartTarget != "A" {
 		t.Errorf("restart_target = %q, want A", d.RestartTarget)
 	}
+	if d.OnFailure != "A" {
+		t.Errorf("on_failure = %q, want A", d.OnFailure)
+	}
 }
 
 func TestParseHumanAndAgentFields(t *testing.T) {

--- a/parser/testdata/defaults_complex.dip
+++ b/parser/testdata/defaults_complex.dip
@@ -11,6 +11,7 @@ workflow DefaultsComplex
     cache_tools: true
     retry_policy: standard
     restart_target: A
+    on_failure: A
 
   agent A
     prompt: "Do it."

--- a/validator/codes.go
+++ b/validator/codes.go
@@ -4,7 +4,7 @@ package validator
 const (
 	DIP001 = "DIP001" // start node missing
 	DIP002 = "DIP002" // exit node missing
-	DIP003 = "DIP003" // unknown node reference in edge
+	DIP003 = "DIP003" // unknown node reference (edge endpoint or on_failure target)
 	DIP004 = "DIP004" // unreachable node(s) from start
 	DIP005 = "DIP005" // unconditional cycle detected
 	DIP006 = "DIP006" // exit node has outgoing edges
@@ -17,7 +17,7 @@ const (
 var CodeDescription = map[string]string{
 	DIP001: "start node does not exist",
 	DIP002: "exit node does not exist",
-	DIP003: "unknown node reference in edge",
+	DIP003: "unknown node reference in edge or on_failure",
 	DIP004: "node unreachable from start",
 	DIP005: "unconditional cycle detected",
 	DIP006: "exit node has outgoing edges",

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -138,6 +138,13 @@ func reachabilityExplanations() map[string]Explanation {
 			Fix:     "Ensure at least one success path connects start to exit.",
 			Example: "Start -> A [failure]\nA -> End  // no success path",
 		},
+		DIP144: {
+			Code:    DIP144,
+			Summary: "agent node has no failure route",
+			Trigger: "An agent node can fail at runtime but has no fail edge, fallback_target, bounded retry, or graph-level on_failure.",
+			Fix:     "Add a `-> <node> when ctx.outcome = fail` edge, set fallback_target, add retry_target with max_retries, or declare a workflow-level on_failure.",
+			Example: "agent Implement\n  prompt: \"build it\"\nImplement -> Test  // DIP144: no route if Implement fails",
+		},
 	}
 }
 

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -28,8 +28,8 @@ var Explanations = map[string]Explanation{
 	DIP003: {
 		Code:    DIP003,
 		Summary: CodeDescription[DIP003],
-		Trigger: "An edge references a node ID that does not exist in the workflow.",
-		Fix:     "Correct the node name in the edge, or add the missing node.",
+		Trigger: "An edge or on_failure target references a node ID that does not exist in the workflow.",
+		Fix:     "Correct the node name in the edge or on_failure field, or add the missing node.",
 		Example: "Start -> Analize  // typo: \"Analize\" not defined",
 	},
 	DIP004: {

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -5,7 +5,7 @@ import (
 	"github.com/2389-research/dippin-lang/simulate"
 )
 
-// Lint runs all semantic quality checks (DIP101–DIP143) on the workflow
+// Lint runs all semantic quality checks (DIP101–DIP144) on the workflow
 // and returns all diagnostics found. These are warnings, not errors —
 // the workflow can still execute, but the findings indicate likely bugs
 // or quality issues.
@@ -60,6 +60,7 @@ func Lint(w *ir.Workflow) Result {
 	diags = append(diags, lintParamsReenablesTools(w)...)
 	diags = append(diags, lintWritablePaths(w)...)
 	diags = append(diags, lintSubgraphToolAccess(w)...)
+	diags = append(diags, lintAgentFailureRoute(w)...)
 
 	return Result{Diagnostics: diags}
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP143).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP144).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge
@@ -45,6 +45,7 @@ const (
 	DIP141 = "DIP141" // writable_paths nullified by tool_access: none (dead config)
 	DIP142 = "DIP142" // unsafe writable_paths entry (absolute / ~ / parent-escape / brace)
 	DIP143 = "DIP143" // referenced subgraph does not inherit this workflow's tool_access restrictions
+	DIP144 = "DIP144" // agent node has no failure route
 )
 
 func init() {
@@ -92,4 +93,5 @@ func init() {
 	CodeDescription[DIP141] = "writable_paths nullified by tool_access: none (dead config)"
 	CodeDescription[DIP142] = "unsafe writable_paths entry (absolute / ~ / parent-escape / brace)"
 	CodeDescription[DIP143] = "referenced subgraph does not inherit this workflow's tool_access restrictions"
+	CodeDescription[DIP144] = "agent node has no failure route"
 }

--- a/validator/lint_failure_route.go
+++ b/validator/lint_failure_route.go
@@ -18,9 +18,9 @@ func lintAgentFailureRoute(w *ir.Workflow) []Diagnostic {
 			diags = append(diags, Diagnostic{
 				Code:     DIP144,
 				Severity: SeverityWarning,
-				Message:  fmt.Sprintf("agent node %q has no failure route (no fail edge, no fallback_target, no graph on_failure)", n.ID),
+				Message:  fmt.Sprintf("agent node %q has no failure route (no fail edge, no fallback_target, no bounded retry, no graph on_failure)", n.ID),
 				Location: n.Source,
-				Help:     "add `-> <node> when ctx.outcome = fail`, set fallback_target:, or declare a workflow-level on_failure:",
+				Help:     "add `-> <node> when ctx.outcome = fail`, set fallback_target:, add retry_target with max_retries, or declare a workflow-level on_failure:",
 			})
 		}
 	}
@@ -44,7 +44,7 @@ func needsFailureRoute(w *ir.Workflow, n *ir.Node) bool {
 
 // hasFailureRoute reports whether the node has any failure-handling route.
 func hasFailureRoute(w *ir.Workflow, n *ir.Node, outgoing []*ir.Edge) bool {
-	if w.Defaults.OnFailure != "" {
+	if w.Defaults.OnFailure != "" && w.Node(w.Defaults.OnFailure) != nil {
 		return true
 	}
 	if hasBoundedFailureTarget(n.Retry) {

--- a/validator/lint_failure_route.go
+++ b/validator/lint_failure_route.go
@@ -1,0 +1,81 @@
+package validator
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// lintAgentFailureRoute checks DIP144: an agent node that can fail at runtime
+// but has no way to route that failure — no fail edge, no fallback_target, no
+// bounded retry target, and no graph-level on_failure. Such a node is a silent
+// dead-end. Scoped to agent nodes; the exit node and nodes with no outgoing
+// edges are skipped (failure there ends the run, not a routing gap).
+func lintAgentFailureRoute(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, n := range w.Nodes {
+		if needsFailureRoute(w, n) {
+			diags = append(diags, Diagnostic{
+				Code:     DIP144,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("agent node %q has no failure route (no fail edge, no fallback_target, no graph on_failure)", n.ID),
+				Location: n.Source,
+				Help:     "add `-> <node> when ctx.outcome = fail`, set fallback_target:, or declare a workflow-level on_failure:",
+			})
+		}
+	}
+	return diags
+}
+
+// needsFailureRoute reports whether an agent node lacks any failure route.
+func needsFailureRoute(w *ir.Workflow, n *ir.Node) bool {
+	if _, ok := n.Config.(ir.AgentConfig); !ok {
+		return false
+	}
+	if n.ID == w.Exit {
+		return false
+	}
+	outgoing := w.EdgesFrom(n.ID)
+	if len(outgoing) == 0 {
+		return false
+	}
+	return !hasFailureRoute(w, n, outgoing)
+}
+
+// hasFailureRoute reports whether the node has any failure-handling route.
+func hasFailureRoute(w *ir.Workflow, n *ir.Node, outgoing []*ir.Edge) bool {
+	if w.Defaults.OnFailure != "" {
+		return true
+	}
+	if hasBoundedFailureTarget(n.Retry) {
+		return true
+	}
+	return hasFailEdge(outgoing)
+}
+
+// hasBoundedFailureTarget reports whether retry config supplies a recovery target:
+// a fallback_target, or a retry_target bounded by max_retries.
+func hasBoundedFailureTarget(r ir.RetryConfig) bool {
+	if r.FallbackTarget != "" {
+		return true
+	}
+	return r.RetryTarget != "" && r.MaxRetries > 0
+}
+
+// hasFailEdge reports whether any outgoing edge routes on outcome = fail/failure.
+// An unconditional/success edge does NOT count — a hard failure does not traverse it.
+func hasFailEdge(edges []*ir.Edge) bool {
+	for _, e := range edges {
+		cmp, ok := extractEqualityCondition(e)
+		if ok && isOutcomeVar(cmp.Variable) && isFailValue(cmp.Value) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOutcomeVar matches the outcome variable in both namespaced and bare forms.
+func isOutcomeVar(v string) bool { return v == "ctx.outcome" || v == "outcome" }
+
+// isFailValue matches the failure outcome values the engine recognizes.
+func isFailValue(v string) bool { return v == "fail" || v == "failure" }

--- a/validator/lint_failure_route_test.go
+++ b/validator/lint_failure_route_test.go
@@ -1,0 +1,201 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+)
+
+func dip144Fires(diags []Diagnostic, nodeID string) bool {
+	for _, d := range diags {
+		if d.Code == DIP144 && strings.Contains(d.Message, "\""+nodeID+"\"") {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDIP144FiresOnRoutelessAgent(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  agent A
+    prompt: "go"
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done
+`
+	if !hasCode(lintSrc(t, src), DIP144) {
+		t.Fatal("expected DIP144 on routeless agent A")
+	}
+}
+
+func TestDIP144SuppressedByFailEdge(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  agent A
+    prompt: "go"
+  human Rescue
+    mode: freeform
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done when ctx.outcome = success
+    A -> Rescue when ctx.outcome = fail
+    Rescue -> Done
+`
+	if dip144Fires(lintSrc(t, src), "A") {
+		t.Fatal("DIP144 should be suppressed by fail edge on A")
+	}
+}
+
+func TestDIP144SuppressedByFallbackTarget(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  agent A
+    prompt: "go"
+    fallback_target: Done
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done
+`
+	if dip144Fires(lintSrc(t, src), "A") {
+		t.Fatal("DIP144 should be suppressed by fallback_target")
+	}
+}
+
+func TestDIP144SuppressedByBoundedRetry(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  agent A
+    prompt: "go"
+    retry_target: A
+    max_retries: 3
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done
+`
+	if dip144Fires(lintSrc(t, src), "A") {
+		t.Fatal("DIP144 should be suppressed by bounded retry_target + max_retries")
+	}
+}
+
+func TestDIP144SuppressedByFailureEdgeSpelling(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  agent A
+    prompt: "go"
+  human Rescue
+    mode: freeform
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done when ctx.outcome = success
+    A -> Rescue when ctx.outcome = failure
+    Rescue -> Done
+`
+	if dip144Fires(lintSrc(t, src), "A") {
+		t.Fatal("DIP144 should be suppressed by a ctx.outcome = failure edge (alternate spelling)")
+	}
+}
+
+func TestDIP144SkipsExitAndTerminalNodes(t *testing.T) {
+	// Mid is a routeless agent (DIP144 fires — sanity check the lint is active);
+	// Done is the exit node (skipped); Leaf is a terminal agent with no outgoing
+	// edges (skipped). This pins the exit-node and zero-outgoing guards.
+	src := `workflow W
+  start: Mid
+  exit: Done
+  agent Mid
+    prompt: "go"
+  agent Leaf
+    prompt: "leaf"
+  agent Done
+    prompt: "end"
+  edges
+    Mid -> Done
+    Mid -> Leaf
+`
+	diags := lintSrc(t, src)
+	if !dip144Fires(diags, "Mid") {
+		t.Fatal("DIP144 should fire on routeless agent Mid (sanity check)")
+	}
+	if dip144Fires(diags, "Done") {
+		t.Fatal("DIP144 must not fire on the exit node")
+	}
+	if dip144Fires(diags, "Leaf") {
+		t.Fatal("DIP144 must not fire on a terminal node with no outgoing edges")
+	}
+}
+
+func TestDIP144SuppressedByGraphOnFailure(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  defaults
+    on_failure: Rescue
+  agent A
+    prompt: "go"
+  human Rescue
+    mode: freeform
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done
+    Rescue -> Done
+`
+	if dip144Fires(lintSrc(t, src), "A") {
+		t.Fatal("DIP144 should be suppressed by graph on_failure")
+	}
+}
+
+func TestDIP144FiresWithDIP115OnRoutelessGoalGate(t *testing.T) {
+	src := `workflow W
+  start: G
+  exit: Done
+  agent G
+    prompt: "gate"
+    goal_gate: true
+  agent Done
+    prompt: "end"
+  edges
+    G -> Done
+`
+	diags := lintSrc(t, src)
+	if !hasCode(diags, DIP144) {
+		t.Fatal("expected DIP144 on routeless goal_gate agent")
+	}
+	if !hasCode(diags, DIP115) {
+		t.Fatal("expected DIP115 to still fire alongside DIP144 (independent codes)")
+	}
+}
+
+func TestDIP144NotOnHumanOrToolNodes(t *testing.T) {
+	src := `workflow W
+  start: H
+  exit: Done
+  human H
+    mode: freeform
+  tool T
+    command: "echo hi"
+  agent Done
+    prompt: "end"
+    fallback_target: Done
+  edges
+    H -> T
+    T -> Done
+`
+	diags := lintSrc(t, src)
+	if dip144Fires(diags, "H") {
+		t.Fatal("DIP144 must not fire on human node H")
+	}
+	if dip144Fires(diags, "T") {
+		t.Fatal("DIP144 must not fire on tool node T")
+	}
+}

--- a/validator/lint_failure_route_test.go
+++ b/validator/lint_failure_route_test.go
@@ -155,6 +155,24 @@ func TestDIP144SuppressedByGraphOnFailure(t *testing.T) {
 	}
 }
 
+func TestDIP144FiresWhenOnFailureTargetMissing(t *testing.T) {
+	src := `workflow W
+  start: A
+  exit: Done
+  defaults
+    on_failure: Ghost
+  agent A
+    prompt: "go"
+  agent Done
+    prompt: "end"
+  edges
+    A -> Done
+`
+	if !hasCode(lintSrc(t, src), DIP144) {
+		t.Fatal("DIP144 should fire when on_failure points to a nonexistent node (not a real route)")
+	}
+}
+
 func TestDIP144FiresWithDIP115OnRoutelessGoalGate(t *testing.T) {
 	src := `workflow W
   start: G

--- a/validator/lint_test.go
+++ b/validator/lint_test.go
@@ -13,9 +13,10 @@ import (
 // cleanMinimalWorkflow returns a minimal valid workflow with no lint warnings.
 func cleanMinimalWorkflow() *ir.Workflow {
 	return &ir.Workflow{
-		Name:  "clean",
-		Start: "Begin",
-		Exit:  "End",
+		Name:     "clean",
+		Start:    "Begin",
+		Exit:     "End",
+		Defaults: ir.WorkflowDefaults{OnFailure: "End"}, // suppresses DIP144 for all agents
 		Nodes: []*ir.Node{
 			{ID: "Begin", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "Hello."}},
 			{ID: "End", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "Done."}},
@@ -33,8 +34,9 @@ func cleanComplexWorkflow() *ir.Workflow {
 		Start: "Ask",
 		Exit:  "Done",
 		Defaults: ir.WorkflowDefaults{
-			Model:    "claude-opus-4-6",
-			Provider: "anthropic",
+			Model:     "claude-opus-4-6",
+			Provider:  "anthropic",
+			OnFailure: "Done", // suppresses DIP144 for all agents
 		},
 		Nodes: []*ir.Node{
 			{ID: "Ask", Kind: ir.NodeHuman, Config: ir.HumanConfig{Mode: "freeform"},
@@ -111,9 +113,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: source has unconditional edge, conditional branch is safe",
 			workflow: &ir.Workflow{
-				Name:  "cond_only",
-				Start: "A",
-				Exit:  "C",
+				Name:     "cond_only",
+				Start:    "A",
+				Exit:     "C",
+				Defaults: ir.WorkflowDefaults{OnFailure: "C"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
 					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
@@ -134,9 +137,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: node with unconditional incoming edge is fine",
 			workflow: &ir.Workflow{
-				Name:  "uncond_ok",
-				Start: "A",
-				Exit:  "B",
+				Name:     "uncond_ok",
+				Start:    "A",
+				Exit:     "B",
+				Defaults: ir.WorkflowDefaults{OnFailure: "B"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
 					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
@@ -174,9 +178,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP102: mixed conditional + unconditional is fine",
 			workflow: &ir.Workflow{
-				Name:  "with_default",
-				Start: "A",
-				Exit:  "C",
+				Name:     "with_default",
+				Start:    "A",
+				Exit:     "C",
+				Defaults: ir.WorkflowDefaults{OnFailure: "C"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
 					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
@@ -223,9 +228,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP103: different conditions from same node is fine for overlap",
 			workflow: &ir.Workflow{
-				Name:  "no_overlap",
-				Start: "A",
-				Exit:  "C",
+				Name:     "no_overlap",
+				Start:    "A",
+				Exit:     "C",
+				Defaults: ir.WorkflowDefaults{OnFailure: "C"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
 					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
@@ -249,9 +255,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: exhaustive conditions from raw text (not pre-parsed)",
 			workflow: &ir.Workflow{
-				Name:  "raw_exhaustive",
-				Start: "A",
-				Exit:  "C",
+				Name:     "raw_exhaustive",
+				Start:    "A",
+				Exit:     "C",
+				Defaults: ir.WorkflowDefaults{OnFailure: "C"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
 					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
@@ -269,9 +276,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: exhaustive conditions + unconditional fallback (pattern 1)",
 			workflow: &ir.Workflow{
-				Name:  "exhaustive_with_fallback",
-				Start: "Start",
-				Exit:  "Done",
+				Name:     "exhaustive_with_fallback",
+				Start:    "Start",
+				Exit:     "Done",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Done"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Start", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
 					{ID: "Gate", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "gate"}},
@@ -297,9 +305,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: exhaustive conditions + extra variable conditions (pattern 2)",
 			workflow: &ir.Workflow{
-				Name:  "exhaustive_with_extra_conds",
-				Start: "Start",
-				Exit:  "Done",
+				Name:     "exhaustive_with_extra_conds",
+				Start:    "Start",
+				Exit:     "Done",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Done"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Start", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
 					{ID: "Gate", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "gate"}},
@@ -327,9 +336,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: complementary contains/not contains pair (pattern 3)",
 			workflow: &ir.Workflow{
-				Name:  "complementary_pair",
-				Start: "Start",
-				Exit:  "Done",
+				Name:     "complementary_pair",
+				Start:    "Start",
+				Exit:     "Done",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Done"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Start", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
 					{ID: "Pick", Kind: ir.NodeTool, Config: ir.ToolConfig{Command: "echo done", Timeout: 60 * 1e9}},
@@ -351,9 +361,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: custom binary partition on tool_stdout (done/more_questions)",
 			workflow: &ir.Workflow{
-				Name:  "custom_partition",
-				Start: "Start",
-				Exit:  "Done",
+				Name:     "custom_partition",
+				Start:    "Start",
+				Exit:     "Done",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Done"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Start", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
 					{ID: "Check", Kind: ir.NodeTool, Config: ir.ToolConfig{Command: "echo done", Timeout: 30e9}},
@@ -375,9 +386,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: custom partition with 3 values (tasks_remain/in_progress/all_done)",
 			workflow: &ir.Workflow{
-				Name:  "ternary_partition",
-				Start: "Start",
-				Exit:  "Done",
+				Name:     "ternary_partition",
+				Start:    "Start",
+				Exit:     "Done",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Done"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Start", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
 					{ID: "Check", Kind: ir.NodeTool, Config: ir.ToolConfig{Command: "echo status", Timeout: 30e9}},
@@ -422,9 +434,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: mixed unconditional + conditional from same source (pattern 3)",
 			workflow: &ir.Workflow{
-				Name:  "mixed_routing",
-				Start: "Start",
-				Exit:  "Done",
+				Name:     "mixed_routing",
+				Start:    "Start",
+				Exit:     "Done",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Done"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Start", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
 					{ID: "Impl", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "impl"}},
@@ -446,9 +459,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP101: conditional edge with labeled fallback from source (pattern 4)",
 			workflow: &ir.Workflow{
-				Name:  "labeled_fallback",
-				Start: "Start",
-				Exit:  "Done",
+				Name:     "labeled_fallback",
+				Start:    "Start",
+				Exit:     "Done",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Done"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Start", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
 					{ID: "Gate", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "gate"}},
@@ -559,9 +573,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP105: forward path exists even with restart edges",
 			workflow: &ir.Workflow{
-				Name:  "has_path",
-				Start: "A",
-				Exit:  "C",
+				Name:     "has_path",
+				Start:    "A",
+				Exit:     "C",
+				Defaults: ir.WorkflowDefaults{OnFailure: "C"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"}},
 					{ID: "B", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "b"}},
@@ -608,9 +623,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP106: ctx.node.<existingNode>.* is valid — no DIP106",
 			workflow: &ir.Workflow{
-				Name:  "node_scoped_ref_valid",
-				Start: "Planner",
-				Exit:  "Builder",
+				Name:     "node_scoped_ref_valid",
+				Start:    "Planner",
+				Exit:     "Builder",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Builder"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Planner", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "plan"}},
 					{ID: "Builder", Kind: ir.NodeAgent, Config: ir.AgentConfig{
@@ -652,9 +668,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP106: bare node.<existingNode>.* is valid — no DIP106",
 			workflow: &ir.Workflow{
-				Name:  "bare_node_ref_valid",
-				Start: "Planner",
-				Exit:  "Builder",
+				Name:     "bare_node_ref_valid",
+				Start:    "Planner",
+				Exit:     "Builder",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Builder"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Planner", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "plan"}},
 					{ID: "Builder", Kind: ir.NodeAgent, Config: ir.AgentConfig{
@@ -703,9 +720,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP107: writes key that is read downstream is fine",
 			workflow: &ir.Workflow{
-				Name:  "used_write",
-				Start: "A",
-				Exit:  "B",
+				Name:     "used_write",
+				Start:    "A",
+				Exit:     "B",
+				Defaults: ir.WorkflowDefaults{OnFailure: "B"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"},
 						IO: ir.NodeIO{Writes: []string{"data"}}},
@@ -847,9 +865,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP110: start/exit lifecycle nodes exempt from empty prompt",
 			workflow: &ir.Workflow{
-				Name:  "lifecycle_exempt",
-				Start: "Init",
-				Exit:  "Done",
+				Name:     "lifecycle_exempt",
+				Start:    "Init",
+				Exit:     "Done",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Done"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Init", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: ""}},
 					{ID: "Done", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: ""}},
@@ -923,9 +942,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP112: reads key with upstream writer is fine",
 			workflow: &ir.Workflow{
-				Name:  "has_writer",
-				Start: "A",
-				Exit:  "B",
+				Name:     "has_writer",
+				Start:    "A",
+				Exit:     "B",
+				Defaults: ir.WorkflowDefaults{OnFailure: "B"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"},
 						IO: ir.NodeIO{Writes: []string{"data"}}},
@@ -941,9 +961,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP112: node.<existingNode>.* in reads is valid — no DIP112",
 			workflow: &ir.Workflow{
-				Name:  "node_scoped_read_valid",
-				Start: "Planner",
-				Exit:  "Builder",
+				Name:     "node_scoped_read_valid",
+				Start:    "Planner",
+				Exit:     "Builder",
+				Defaults: ir.WorkflowDefaults{OnFailure: "Builder"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "Planner", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "plan"}},
 					{ID: "Builder", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "build"},
@@ -1030,9 +1051,10 @@ func TestLint(t *testing.T) {
 		{
 			name: "DIP112: transitive writes propagation",
 			workflow: &ir.Workflow{
-				Name:  "transitive",
-				Start: "A",
-				Exit:  "C",
+				Name:     "transitive",
+				Start:    "A",
+				Exit:     "C",
+				Defaults: ir.WorkflowDefaults{OnFailure: "C"}, // suppresses DIP144
 				Nodes: []*ir.Node{
 					{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "a"},
 						IO: ir.NodeIO{Writes: []string{"key1"}}},

--- a/validator/validate.go
+++ b/validator/validate.go
@@ -129,14 +129,25 @@ func checkOnFailureTarget(w *ir.Workflow) []Diagnostic {
 }
 
 // buildAllEdgeAdjacency builds an adjacency map including all edges (including restart).
-// It also includes implicit parallel/fan_in edges.
+// It also includes implicit parallel/fan_in edges and the graph-level on_failure route,
+// so a recovery node reachable only via on_failure is not falsely flagged DIP004.
 func buildAllEdgeAdjacency(w *ir.Workflow) map[string][]string {
 	adj := make(map[string][]string)
 	for _, e := range w.Edges {
 		adj[e.From] = append(adj[e.From], e.To)
 	}
 	addParallelFanInEdges(adj, w)
+	addOnFailureEdge(adj, w)
 	return adj
+}
+
+// addOnFailureEdge adds the graph-level on_failure target as reachable from start.
+// One path suffices for reachability; on_failure is conceptually reachable from any
+// failing node, and start is always reachable.
+func addOnFailureEdge(adj map[string][]string, w *ir.Workflow) {
+	if w.Defaults.OnFailure != "" {
+		adj[w.Start] = append(adj[w.Start], w.Defaults.OnFailure)
+	}
 }
 
 // buildNonRestartAdjacency builds an adjacency map excluding restart edges.

--- a/validator/validate.go
+++ b/validator/validate.go
@@ -20,6 +20,7 @@ func Validate(w *ir.Workflow) Result {
 	diags = append(diags, checkStartExists(w)...)
 	diags = append(diags, checkExitExists(w)...)
 	diags = append(diags, checkEdgeEndpoints(w)...)
+	diags = append(diags, checkOnFailureTarget(w)...)
 	diags = append(diags, checkExitNoOutgoing(w)...)
 	diags = append(diags, checkNoDuplicateEdges(w)...)
 	diags = append(diags, checkReachability(w)...)
@@ -102,6 +103,27 @@ func checkEndpoint(w *ir.Workflow, nodeSet map[string]bool, e *ir.Edge, endpoint
 		d.Help = fmt.Sprintf("did you mean %q?", suggestion)
 	} else {
 		d.Help = fmt.Sprintf("declare a node with ID %q or fix the edge %s", endpoint, role)
+	}
+	return []Diagnostic{d}
+}
+
+// checkOnFailureTarget verifies DIP003: the graph-level on_failure route, if set,
+// references an existing node. on_failure is a node reference like an edge endpoint,
+// so it reuses the DIP003 code.
+func checkOnFailureTarget(w *ir.Workflow) []Diagnostic {
+	target := w.Defaults.OnFailure
+	if target == "" || w.Node(target) != nil {
+		return nil
+	}
+	d := Diagnostic{
+		Code:     DIP003,
+		Severity: SeverityError,
+		Message:  fmt.Sprintf("on_failure references unknown node %q", target),
+	}
+	if suggestion := closestNodeID(w, target); suggestion != "" {
+		d.Help = fmt.Sprintf("did you mean %q?", suggestion)
+	} else {
+		d.Help = fmt.Sprintf("declare a node with ID %q or fix the on_failure target", target)
 	}
 	return []Diagnostic{d}
 }

--- a/validator/validate_test.go
+++ b/validator/validate_test.go
@@ -756,3 +756,25 @@ func TestOnFailureKnownNode(t *testing.T) {
 		}
 	}
 }
+
+func TestOnFailureTargetIsReachable(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "t", Start: "A", Exit: "Done",
+		Defaults: ir.WorkflowDefaults{OnFailure: "Rescue"},
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}},
+			{ID: "Rescue", Kind: ir.NodeHuman, Config: ir.HumanConfig{Mode: "freeform"}},
+			{ID: "Done", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "end"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "A", To: "Done"},
+			{From: "Rescue", To: "Done"},
+		},
+	}
+	res := Validate(w)
+	for _, d := range res.Diagnostics {
+		if d.Code == DIP004 {
+			t.Fatalf("Rescue should be reachable via on_failure, got DIP004: %+v", d)
+		}
+	}
+}

--- a/validator/validate_test.go
+++ b/validator/validate_test.go
@@ -730,3 +730,29 @@ func TestDIP006MultipleOutgoing(t *testing.T) {
 		t.Errorf("expected 2 DIP006 diagnostics for two outgoing edges from exit, got %d", count)
 	}
 }
+
+func TestOnFailureUnknownNode(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "t", Start: "A", Exit: "A",
+		Defaults: ir.WorkflowDefaults{OnFailure: "Nope"},
+		Nodes:    []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}}},
+	}
+	res := Validate(w)
+	if !hasCode(res.Diagnostics, DIP003) {
+		t.Fatalf("expected DIP003 for unknown on_failure target, got %+v", res.Diagnostics)
+	}
+}
+
+func TestOnFailureKnownNode(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "t", Start: "A", Exit: "A",
+		Defaults: ir.WorkflowDefaults{OnFailure: "A"},
+		Nodes:    []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "go"}}},
+	}
+	res := Validate(w)
+	for _, d := range res.Diagnostics {
+		if d.Code == DIP003 {
+			t.Fatalf("unexpected DIP003 for valid on_failure target: %+v", d)
+		}
+	}
+}


### PR DESCRIPTION
Closes #92, Closes #93.

Adds a graph-level **`on_failure`** default failure route (#92) and a new lint **DIP144** that flags agent nodes with no failure route (#93). Shipped together because DIP144's cleanest suppressor consumes `on_failure`.

dippin **carries + validates** this authoring surface; the tracker **runtime enforces** it (mirrors the #41/#75 split). It is inert until the tracker reads it — see *Cross-repo* below.

## #92 — `on_failure: <NodeID>`
- **Surface:** a `defaults:` block field → `ir.WorkflowDefaults.OnFailure` (mirrors `restart_target`). A header-level form wouldn't parse today and would be a one-off; the issue's acceptance criteria allow "header/defaults".
- **Structural validation (DIP003):** `Validate()` errors if `on_failure` names a nonexistent node, with a "did you mean?" suggestion. Reuses DIP003 (a new DIP010 would churn ~20 "DIP001–DIP009" range strings for no semantic gain); DIP003's description was broadened to "edge endpoint or on_failure target".
- **DIP004 reachability:** the `on_failure` target is seeded into the reachability adjacency, so a recovery node reachable *only* via the catch-all isn't falsely flagged unreachable. Scoped to DIP004 only — cycle (DIP005) and success-path (DIP105) adjacencies are untouched.
- **Round-trips:** through the `.dip` formatter **and** DOT export/migrate. DOT round-trip follows the tool-safety-defaults precedent (safety-critical graph defaults round-trip with a regression test), not `restart_target` (which is silently DOT-lossy).

### Precedence (documented; runtime enforces)
For an agent node finishing `outcome = fail`/erroring, most-specific wins: **(1)** matching fail edge `when ctx.outcome = fail|failure` → **(2)** bounded node retry (`retry_target` + `max_retries`) → **(3)** node `fallback_target` → **(4)** graph `on_failure` (catch-all) → **(5)** halt. A `goal_gate`'s own `fallback_target` still wins (step 3). dippin validates *existence/shape*; the runtime owns *ordering*.

## #93 — DIP144 (warning): agent node has no failure route
- **Scope:** agent nodes only (there is no `codergen` NodeKind). Skips the exit node and zero-outgoing terminals.
- **Suppressed** by any of: an explicit `ctx.outcome = fail|failure` edge, `fallback_target`, bounded retry (`retry_target` + `max_retries > 0`), or graph `on_failure`. An unconditional/success edge does **not** suppress it — per #93's case study, a sole unconditional edge doesn't catch a hard failure.
- **Fires independently of DIP115** — a routeless `goal_gate` gets both (different lenses, distinct help text).
- Bounded-retry uses node-level `max_retries` only, mirroring DIP104's `isUnboundedRetry` (kept consistent deliberately).

## Decisions worth calling out
- **DIP102 suppression descoped.** #92's acceptance criteria suggested suppressing DIP102 for agent nodes when `on_failure` is set; we deliberately did **not**. DIP102 detects "routing can get stuck on an *unmatched outcome*" — a different concern than failure-route presence, and `on_failure` only catches failures, so blanket-suppressing DIP102 would mask genuine "succeeded but no edge matched" bugs. DIP144 is the purpose-built lint that `on_failure` cleanly suppresses.
- **Examples blast-radius: zero.** All 31 existing examples already route failures (verified DIP144 fires via the CLI on a routeless probe — the zero is genuine, not a wiring gap). Added one demonstrator, `examples/on_failure_route.dip` (also exercises the DIP004 reachability seeding end-to-end: `Escalate` is reachable only via `on_failure`). No existing examples mass-edited.

## Cross-repo follow-up (tracker, separate repo)
A tracker `upstream` issue should be filed, blocking-linked to tracker engine #295:
- The adapter (`pipeline/dippin_adapter.go` `extractWorkflowDefaults`) must copy `OnFailure` — an **unresolved node-ID string**; empty = feature-off.
- The precedence above lives entirely in the engine; state it as the engine contract.
- Confirm whether `tracker validate` treats warnings as fatal — if so, the DIP144 version bump could fail consumer CI on existing `.dip` files; coordinate to keep warnings non-fatal. (DIP144 stays `warning`, no strict flag.)

Per the carry/validate-vs-enforce split, nothing here is gated on tracker readiness — dippin ships the feature now; the tracker enforces whenever it's ready.

## Notes
- Design spec + implementation plan included under `docs/superpowers/`.
- CHANGELOG entry + skill.md mention are intentionally deferred to **tag time** (per CLAUDE.md); this is a pre-tag PR. **Do not tag** (~v0.37.0) without the maintainer's go-ahead.
- Reviewed by a 5-expert design squad + per-task spec/quality reviews + a final holistic pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783201749&installation_id=131176874&pr_number=95&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F95&signature=865ab564a266cabecb12ff66d0aa5fa35087309f75c0eacce3a293997ed07e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow-level on_failure default for graph failure routing
  * New DIP144 lint warning for agent nodes lacking failure routes
  * Validation now checks on_failure targets and includes them in reachability analysis

* **Documentation**
  * Updated diagnostic ranges to include DIP144 and added failure-handling precedence docs
  * Added example workflow, design spec, and implementation plan

* **Tests**
  * Added parsing/formatting/export/migration tests and comprehensive DIP144 scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->