### PR TITLE
feat: declarable budget/limit attrs — stall_timeout, max_turns exhaustion, DIP145 (Closes #94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistr
 
 ## Lint Rules
 
-53 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP144 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
+54 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP145 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
 
 ## Testing
 

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -187,10 +187,10 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-53 diagnostic codes across two categories:
+54 diagnostic codes across two categories:
 
 - **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP144** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route
+- **DIP101–DIP145** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults
 
 ---
 

--- a/docs/edges.md
+++ b/docs/edges.md
@@ -124,6 +124,10 @@ This means conditions always take precedence over labels, and labels over weight
 
 ## Failure Handling
 
+A node enters the failure cascade when it errors, fails a `goal_gate`, **exhausts
+`max_turns`**, or trips the graph **`stall_timeout`**. All route through the same
+priority order below.
+
 When an agent node finishes with outcome `fail` or errors, the runtime resolves a failure route using the following precedence (first match wins):
 
 | Priority | Mechanism | Description |

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -185,7 +185,7 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-53 diagnostic codes across two categories:
+54 diagnostic codes across two categories:
 
 - **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP144** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route
+- **DIP101–DIP145** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -113,7 +113,7 @@ Agent nodes invoke an LLM. They are the most configurable node kind.
 | `working_dir` | String | — | Per-node working directory override for isolated execution. |
 | `tool_access` | String | — (full catalog) | LLM tool-catalog gate. Set to `none` to strip the model's tool registry on this agent. Bounds the v0.28.2 single-agent multi-tool-call vector (DIP139 warns on unknown values; runtime fail-closes). |
 | `writable_paths` | CSV (globs) | — (unbounded) | Comma-separated glob list bounding where this agent's tools may write (e.g. `workspace/**, .ai/sprints/**`), resolved against the session root. Absent = unbounded. A present-but-empty `writable_paths:` is rejected by `dippin validate`/`pack` (parse error — list at least one glob or omit the field). Malformed values fail **closed** at the runtime (deny-all / refuse-to-start). Enforced on the **native backend** only; `claude-code`/`acp` refuse to start. No brace-expansion globs: `writable_paths` is comma-split, so `*.{md,yaml}` is torn into `*.{md` and `yaml}` — enumerate entries instead (DIP142). Distinct from `writes:` (advisory context keys produced) — `writable_paths:` bounds enforced file-write paths. Enforced by the runtime (not by dippin). |
-| `max_turns` | Integer | 1 | Maximum conversation turns in an agentic loop. A turn is one request-response cycle. Set higher for multi-step tool-using agents. |
+| `max_turns` | Integer | 1 | Maximum request-response cycles in the agent's tool-using loop. **Reaching this limit ends the node with outcome `fail`** — it is a hard cap, not a soft budget. The failure routes through the standard failure cascade (fail edge → bounded retry → `fallback_target` → graph `on_failure` → halt). Ensure a failure route exists (see DIP144) or the run halts on exhaustion. |
 | `cmd_timeout` | Duration | — | Command execution timeout for the agent's agentic loop (e.g., `30s`, `5m`). Applies to tool/command calls made within the agent, not to the LLM API call itself. |
 | `cache_tools` | Boolean | workflow default | Whether to cache tool call results for this agent. Useful for expensive, deterministic tools. |
 | `compaction` | String | workflow default | Context compaction mode for managing long context windows. |
@@ -125,6 +125,15 @@ Agent nodes invoke an LLM. They are the most configurable node kind.
 | `response_format` | String | — | Forces structured JSON output. Values: `json_object` (force valid JSON, any shape), `json_schema` (force JSON matching the schema in `response_schema`). Agent-only. Triggers DIP130 if an unrecognized value is used. |
 | `response_schema` | Multiline | — | JSON Schema definition for structured output. Requires `response_format: json_schema`. Content is preserved verbatim (same as `prompt:`). Must be valid JSON — triggers DIP132 if not. |
 | `params` | Map | — | Generic pass-through parameters for the runtime. Same key-value block syntax as subgraph `params`. Keys that match first-class fields (e.g., `model`) trigger DIP133 hint. |
+
+### max_turns exhaustion
+
+When an agent reaches `max_turns` without completing, the engine treats it as a
+failure (`ctx.outcome = fail`), **not** a successful stop. `max_turns` is therefore
+a routing event, not just a cost control. An agent with `max_turns` set but no
+failure route is a latent dead-end — [DIP144](validation.md#dip144) warns you. Pair
+every bounded `max_turns` with one of: a `when ctx.outcome = fail` edge,
+`fallback_target`, a bounded `retry_target`, or a graph `on_failure`.
 
 ### auto_status
 

--- a/docs/superpowers/plans/2026-06-04-issue-94-budget-attrs.md
+++ b/docs/superpowers/plans/2026-06-04-issue-94-budget-attrs.md
@@ -1,0 +1,885 @@
+# Budget/Limit Attrs (#94) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `stall_timeout` declarable in `.dip`, close a pre-existing DOT export data-loss bug for all four budget fields, add DIP145 (negative-budget lint), and document `max_turns` exhaustion semantics.
+
+**Architecture:** A new `time.Duration` graph default `stall_timeout` lands in `ir.WorkflowDefaults` and flows through the four round-trip surfaces (parser → formatter → DOT export → migrate), exactly mirroring the existing `max_wall_time`. The DOT exporter currently emits *none* of the budget fields (a confirmed data-loss bug); we add a single `appendBudgetGraphAttrs` helper that emits all four. DIP145 is a table-driven range lint firing on any negative budget default. `max_turns` exhaustion is documentation-only (it reuses the #92/#93 failure cascade).
+
+**Tech Stack:** Go; `just` for all build/test (never raw `go`); pre-commit hook runs the full gate (build, vet, golangci-lint, all tests w/ race, gocyclo ≤5, gocognit ≤7, example validation) on every commit.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-issue-94-budget-attrs-design.md`
+
+**Conventions (read before starting):**
+- All testing via `just test-pkg <pkg>` (e.g. `just test-pkg parser`) for fast iteration; `just complexity` for the cyclo/cognit gate; `just fmt` before committing. The `git commit` itself runs the full pre-commit gate — that is the real CI mirror.
+- TDD: write the failing test, run it, watch it fail, then implement.
+- Parser tests parse real `.dip` source — never hand-populate IR fields the parser doesn't set.
+- Stage explicit paths in `git add` (never `git add -A` — `./dippin`/`./wasm` are gitignored build artifacts).
+- Field name is `stall_timeout` everywhere (IR `StallTimeout`, parser/DOT key `stall_timeout`).
+
+---
+
+## Task 1: `stall_timeout` IR field + parser
+
+**Files:**
+- Modify: `ir/ir.go:52-54` (add field to `WorkflowDefaults`)
+- Modify: `parser/parse_defaults.go:134-146` (`applyDefaultBudgetField`)
+- Test: `parser/parser_test.go` (new test), `parser/testdata/defaults_budget.dip` (fixture)
+
+- [ ] **Step 1: Add `stall_timeout` to the budget fixture**
+
+Edit `parser/testdata/defaults_budget.dip`, adding one line to the `defaults` block (after `max_wall_time: 30m`):
+
+```
+  defaults
+    model: claude-sonnet-4-6
+    max_total_tokens: 500000
+    max_cost_cents: 1000
+    max_wall_time: 30m
+    stall_timeout: 5m
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `parser/parser_test.go` (near the existing `TestParseDefaultsBudget` around line 1560):
+
+```go
+func TestParseDefaultsStallTimeout(t *testing.T) {
+	w := parseFixture(t, "defaults_budget.dip")
+	if w.Defaults.StallTimeout != 5*time.Minute {
+		t.Errorf("stall_timeout = %v, want 5m0s", w.Defaults.StallTimeout)
+	}
+}
+
+func TestParseDefaultsNegativeBudgetNoStructuralError(t *testing.T) {
+	src := `workflow Neg
+  goal: "g"
+  start: A
+  exit: A
+
+  defaults
+    max_cost_cents: -5
+    stall_timeout: -5m
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A
+`
+	w, err := NewParser(src, "neg.dip").Parse()
+	if err != nil {
+		t.Fatalf("negative budget must parse without a structural error, got: %v", err)
+	}
+	if w.Defaults.MaxCostCents != -5 {
+		t.Errorf("max_cost_cents = %d, want -5", w.Defaults.MaxCostCents)
+	}
+	if w.Defaults.StallTimeout != -5*time.Minute {
+		t.Errorf("stall_timeout = %v, want -5m0s", w.Defaults.StallTimeout)
+	}
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `just test-pkg parser`
+Expected: FAIL — `w.Defaults.StallTimeout` undefined (field doesn't exist yet).
+
+- [ ] **Step 4: Add the IR field**
+
+In `ir/ir.go`, inside `WorkflowDefaults`, add `StallTimeout` immediately after `MaxWallTime` (line 54):
+
+```go
+	MaxWallTime       time.Duration // Hard ceiling on wall time
+	StallTimeout      time.Duration // Abort/route when no progress for this wall-clock span (0 = disabled)
+```
+
+- [ ] **Step 5: Parse the field**
+
+In `parser/parse_defaults.go`, add a case to `applyDefaultBudgetField` (before the `default:`):
+
+```go
+	case "max_wall_time":
+		p.workflow.Defaults.MaxWallTime = p.parseDuration(val, key, loc)
+	case "stall_timeout":
+		p.workflow.Defaults.StallTimeout = p.parseDuration(val, key, loc)
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `just test-pkg parser`
+Expected: PASS.
+
+- [ ] **Step 7: Check complexity**
+
+Run: `just complexity`
+Expected: passes. (`applyDefaultBudgetField` goes from cyclo 4 → 5, at the cap.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+just fmt
+git add ir/ir.go parser/parse_defaults.go parser/parser_test.go parser/testdata/defaults_budget.dip
+git commit -m "feat: parse stall_timeout graph default into ir.WorkflowDefaults (#94)"
+```
+
+---
+
+## Task 2: Formatter emit + `.dip` round-trip + negative-duration quirk lock
+
+**Files:**
+- Modify: `formatter/format.go:192-204` (`writeDefaultsBudgetFields`)
+- Test: `parser/parser_test.go` (extend `TestParseDefaultsBudgetRoundTrip`), `formatter/format_test.go` (new quirk test)
+
+- [ ] **Step 1: Extend the round-trip test**
+
+In `parser/parser_test.go`, add to `TestParseDefaultsBudgetRoundTrip` (after the `MaxWallTime` assertion at line 1644):
+
+```go
+	if d.StallTimeout != 5*time.Minute {
+		t.Errorf("round-trip: stall_timeout = %v, want 5m0s", d.StallTimeout)
+	}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test-pkg parser`
+Expected: FAIL — formatter drops `stall_timeout`, so the re-parsed value is 0.
+
+- [ ] **Step 3: Emit `stall_timeout` in the formatter**
+
+In `formatter/format.go`, `writeDefaultsBudgetFields`, add after the `MaxWallTime` block (line 201):
+
+```go
+	if d.MaxWallTime != 0 {
+		wr.line("max_wall_time: %s", formatDuration(d.MaxWallTime))
+	}
+	if d.StallTimeout != 0 {
+		wr.line("stall_timeout: %s", formatDuration(d.StallTimeout))
+	}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test-pkg parser`
+Expected: PASS.
+
+- [ ] **Step 5: Write the negative-duration quirk-lock test**
+
+`formatDuration(-5m)` returns `"-5m0s"` (the per-component `> 0` guards fall through to `d.String()`). This is NOT a bug — it re-parses losslessly. Lock it so nobody "fixes" it. Add to `formatter/format_test.go`:
+
+```go
+func TestFormatDurationNegativeRoundTrips(t *testing.T) {
+	for _, d := range []time.Duration{-5 * time.Minute, -30 * time.Second} {
+		s := formatDuration(d)
+		got, err := time.ParseDuration(s)
+		if err != nil {
+			t.Fatalf("formatDuration(%v) = %q, not re-parseable: %v", d, s, err)
+		}
+		if got != d {
+			t.Errorf("round-trip: formatDuration(%v) = %q -> %v, want %v", d, s, got, d)
+		}
+	}
+}
+```
+
+(If `format_test.go` lacks a `time` import, add it.)
+
+- [ ] **Step 6: Run and verify it passes**
+
+Run: `just test-pkg formatter`
+Expected: PASS.
+
+- [ ] **Step 7: Check complexity + commit**
+
+```bash
+just complexity   # writeDefaultsBudgetFields: cyclo 4 -> 5, at cap
+just fmt
+git add formatter/format.go formatter/format_test.go parser/parser_test.go
+git commit -m "feat: emit stall_timeout in formatter; lock negative-duration round-trip (#94)"
+```
+
+---
+
+## Task 3: DOT export — close the gap for all four budget fields
+
+**Files:**
+- Modify: `export/dot.go:61-67` (`reservedGraphAttrs`), `:88-110` (`buildGraphAttrs` + new helper)
+- Test: `export/dot_test.go`
+
+- [ ] **Step 1: Write the failing export test**
+
+In `export/dot_test.go`, add (mirroring `TestExportOnFailureDefault` at line 1445 and `TestExportToolSafetyVarsCollision` at 1412):
+
+```go
+func TestExportBudgetDefaults(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "B", Start: "A", Exit: "A",
+		Defaults: ir.WorkflowDefaults{
+			MaxTotalTokens: 500000,
+			MaxCostCents:   1000,
+			MaxWallTime:    30 * time.Minute,
+			StallTimeout:   5 * time.Minute,
+		},
+		Nodes: []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "x"}}},
+		Edges: []*ir.Edge{{From: "A", To: "A"}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+	for _, want := range []string{
+		`max_total_tokens="500000"`,
+		`max_cost_cents="1000"`,
+		`max_wall_time="30m"`,
+		`stall_timeout="5m"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %s in DOT, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestExportBudgetDefaultsOmitEmpty(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "B", Start: "A", Exit: "A",
+		Nodes: []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "x"}}},
+		Edges: []*ir.Edge{{From: "A", To: "A"}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+	if strings.Contains(out, "stall_timeout") || strings.Contains(out, "max_total_tokens") {
+		t.Errorf("unset budget fields must not be emitted, got:\n%s", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test-pkg export`
+Expected: FAIL — `buildGraphAttrs` never emits budget fields.
+
+- [ ] **Step 3: Add the budget-emit helper**
+
+In `export/dot.go`, add a new helper (place it just after `buildGraphAttrs`, before `addGraphVarsAttrs` at line 112):
+
+```go
+// appendBudgetGraphAttrs emits the workflow budget defaults as DOT graph
+// attributes. Each is omitted when unset (0) so absence round-trips. Durations
+// use formatDuration (the compact Go-duration literal the migrate path parses
+// back with time.ParseDuration), NOT time.Duration.String().
+func appendBudgetGraphAttrs(attrs *[]string, d ir.WorkflowDefaults) {
+	if d.MaxTotalTokens != 0 {
+		*attrs = append(*attrs, fmt.Sprintf("max_total_tokens=%s", dotQuote(fmt.Sprintf("%d", d.MaxTotalTokens))))
+	}
+	if d.MaxCostCents != 0 {
+		*attrs = append(*attrs, fmt.Sprintf("max_cost_cents=%s", dotQuote(fmt.Sprintf("%d", d.MaxCostCents))))
+	}
+	if d.MaxWallTime != 0 {
+		*attrs = append(*attrs, fmt.Sprintf("max_wall_time=%s", dotQuote(formatDuration(d.MaxWallTime))))
+	}
+	if d.StallTimeout != 0 {
+		*attrs = append(*attrs, fmt.Sprintf("stall_timeout=%s", dotQuote(formatDuration(d.StallTimeout))))
+	}
+}
+```
+
+- [ ] **Step 4: Call the helper from `buildGraphAttrs`**
+
+In `export/dot.go` `buildGraphAttrs`, add the call after the `on_failure` block (line 104), before `addGraphVarsAttrs`:
+
+```go
+	if w.Defaults.OnFailure != "" {
+		attrs = append(attrs, fmt.Sprintf("on_failure=%s", dotQuote(w.Defaults.OnFailure)))
+	}
+	appendBudgetGraphAttrs(&attrs, w.Defaults)
+
+	// Add workflow vars (excluding reserved graph attributes)
+	addGraphVarsAttrs(&attrs, w.Vars)
+```
+
+- [ ] **Step 5: Reserve `stall_timeout`**
+
+In `export/dot.go` `reservedGraphAttrs` (line 65, where the three budget keys already are), add `stall_timeout`:
+
+```go
+	"max_total_tokens": true, "max_cost_cents": true, "max_wall_time": true,
+	"stall_timeout": true,
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `just test-pkg export`
+Expected: PASS.
+
+- [ ] **Step 7: Check complexity (the critical gate)**
+
+Run: `just complexity`
+Expected: PASS. `buildGraphAttrs` stays cyclo 5 (the four budget `if`s now live in `appendBudgetGraphAttrs`, which is cyclo 5). Had we inlined them, `buildGraphAttrs` would be cyclo 8 — over the limit.
+
+- [ ] **Step 8: Commit**
+
+```bash
+just fmt
+git add export/dot.go export/dot_test.go
+git commit -m "fix: emit all four budget defaults in DOT export (close data-loss gap) (#94)"
+```
+
+---
+
+## Task 4: Migrate `stall_timeout` + full `.dip → DOT → .dip` round-trip
+
+**Files:**
+- Modify: `migrate/migrate.go:185-196` (`applyIntBudgetDefault`)
+- Test: `migrate/roundtrip_test.go`
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+In `migrate/roundtrip_test.go`, add (mirroring `TestRoundTripToolSafetyDefaults` at line 220). The `90s` case is deliberate — it is the one input whose source string changes (`90s` → `1m30s`), so assert the typed `Duration`, never a string:
+
+```go
+// TestRoundTripBudgetDefaults verifies all four budget defaults round-trip
+// losslessly through parse -> ExportDOT -> Migrate. Asserts Duration equality,
+// never source-string equality (90s normalizes to 1m30s).
+func TestRoundTripBudgetDefaults(t *testing.T) {
+	src := `workflow Budget
+  goal: "round trip"
+  start: A
+  exit: A
+
+  defaults
+    max_total_tokens: 500000
+    max_cost_cents: 1000
+    max_wall_time: 30m
+    stall_timeout: 90s
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A
+`
+	w1, err := dipparser.NewParser(src, "rt.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dot := export.ExportDOT(w1, export.ExportOptions{})
+	w2, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("migrate: %v\nDOT:\n%s", err, dot)
+	}
+	d := w2.Defaults
+	if d.MaxTotalTokens != 500000 {
+		t.Errorf("max_total_tokens = %d, want 500000; DOT:\n%s", d.MaxTotalTokens, dot)
+	}
+	if d.MaxCostCents != 1000 {
+		t.Errorf("max_cost_cents = %d, want 1000; DOT:\n%s", d.MaxCostCents, dot)
+	}
+	if d.MaxWallTime != 30*time.Minute {
+		t.Errorf("max_wall_time = %v, want 30m0s; DOT:\n%s", d.MaxWallTime, dot)
+	}
+	if d.StallTimeout != 90*time.Second {
+		t.Errorf("stall_timeout = %v, want 1m30s; DOT:\n%s", d.StallTimeout, dot)
+	}
+}
+
+// TestRoundTripStallTimeoutVarsCollision verifies a vars entry named
+// stall_timeout is treated as reserved (not double-emitted / not migrated to Vars).
+func TestRoundTripStallTimeoutVarsCollision(t *testing.T) {
+	src := `workflow Collide
+  goal: "round trip"
+  start: A
+  exit: A
+
+  defaults
+    stall_timeout: 5m
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A
+`
+	w1, err := dipparser.NewParser(src, "rt.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dot := export.ExportDOT(w1, export.ExportOptions{})
+	if strings.Count(dot, "stall_timeout") != 1 {
+		t.Errorf("stall_timeout should appear exactly once in DOT, got:\n%s", dot)
+	}
+	w2, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if w2.Defaults.StallTimeout != 5*time.Minute {
+		t.Errorf("stall_timeout = %v, want 5m0s", w2.Defaults.StallTimeout)
+	}
+	if _, ok := w2.Vars["stall_timeout"]; ok {
+		t.Errorf("stall_timeout leaked into Vars: %v", w2.Vars)
+	}
+}
+```
+
+(Ensure `strings` and `time` are imported in `roundtrip_test.go`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test-pkg migrate`
+Expected: FAIL — `stall_timeout` migrates into `Vars` (unknown attr) instead of `StallTimeout`, so `w2.Defaults.StallTimeout` is 0.
+
+- [ ] **Step 3: Migrate `stall_timeout`**
+
+In `migrate/migrate.go` `applyIntBudgetDefault`, add a case before `default:`:
+
+```go
+	case "max_wall_time":
+		return tryApplyDurationDefault(v, &w.Defaults.MaxWallTime)
+	case "stall_timeout":
+		return tryApplyDurationDefault(v, &w.Defaults.StallTimeout)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test-pkg migrate`
+Expected: PASS.
+
+- [ ] **Step 5: Check complexity + commit**
+
+```bash
+just complexity   # applyIntBudgetDefault: cyclo 4 -> 5, at cap (switch)
+just fmt
+git add migrate/migrate.go migrate/roundtrip_test.go
+git commit -m "feat: migrate stall_timeout from DOT; full budget round-trip test (#94)"
+```
+
+---
+
+## Task 5: DIP145 lint — negative graph budget default
+
+**Files:**
+- Modify: `validator/lint_codes.go:3` (comment), `:48` (const), `:96` (CodeDescription)
+- Modify: `validator/explanations.go:205-256` (`configExplanations`)
+- Create: `validator/lint_budget.go`
+- Modify: `validator/lint.go:63` (register)
+- Test: `validator/lint_budget_test.go` (new)
+
+- [ ] **Step 1: Write the failing lint test**
+
+Create `validator/lint_budget_test.go`:
+
+```go
+package validator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+func budgetWorkflow(d ir.WorkflowDefaults) *ir.Workflow {
+	return &ir.Workflow{
+		Name: "B", Start: "A", Exit: "A", Defaults: d,
+		Nodes: []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "x"}}},
+		Edges: []*ir.Edge{{From: "A", To: "A"}},
+	}
+}
+
+func countCode(diags []Diagnostic, code string) int {
+	n := 0
+	for _, d := range diags {
+		if d.Code == code {
+			n++
+		}
+	}
+	return n
+}
+
+func TestDIP145FiresOnNegativeBudgets(t *testing.T) {
+	w := budgetWorkflow(ir.WorkflowDefaults{
+		MaxTotalTokens: -1,
+		MaxCostCents:   -5,
+		MaxWallTime:    -30 * time.Second,
+		StallTimeout:   -5 * time.Minute,
+	})
+	got := countCode(lintBudgetRanges(w), DIP145)
+	if got != 4 {
+		t.Errorf("DIP145 count = %d, want 4 (one per negative field)", got)
+	}
+}
+
+func TestDIP145SilentOnUnsetZero(t *testing.T) {
+	w := budgetWorkflow(ir.WorkflowDefaults{}) // all zero = unset
+	if got := countCode(lintBudgetRanges(w), DIP145); got != 0 {
+		t.Errorf("DIP145 fired on unset (0) budgets: %d, want 0", got)
+	}
+}
+
+func TestDIP145SilentOnValidPositive(t *testing.T) {
+	w := budgetWorkflow(ir.WorkflowDefaults{
+		MaxTotalTokens: 500000,
+		MaxCostCents:   1000,
+		MaxWallTime:    30 * time.Minute,
+		StallTimeout:   5 * time.Minute,
+	})
+	if got := countCode(lintBudgetRanges(w), DIP145); got != 0 {
+		t.Errorf("DIP145 fired on valid positive budgets: %d, want 0", got)
+	}
+}
+
+func TestDIP145MessageNamesFieldAndValue(t *testing.T) {
+	w := budgetWorkflow(ir.WorkflowDefaults{MaxCostCents: -5})
+	diags := lintBudgetRanges(w)
+	if len(diags) != 1 {
+		t.Fatalf("want 1 diag, got %d", len(diags))
+	}
+	msg := diags[0].Message
+	if !strings.Contains(msg, "max_cost_cents") || !strings.Contains(msg, "-5") {
+		t.Errorf("message must name field and value, got: %q", msg)
+	}
+}
+```
+
+(Add `"strings"` to the import block.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test-pkg validator`
+Expected: FAIL — `lintBudgetRanges` and `DIP145` undefined.
+
+- [ ] **Step 3: Add the DIP145 const + description**
+
+In `validator/lint_codes.go`:
+- Line 3 comment: change `(DIP101–DIP144)` to `(DIP101–DIP145)`.
+- After `DIP144` const (line 48), add:
+
+```go
+	DIP144 = "DIP144" // agent node has no failure route
+	DIP145 = "DIP145" // graph budget default is negative
+```
+
+- After the `CodeDescription[DIP144]` line (96), add:
+
+```go
+	CodeDescription[DIP144] = "agent node has no failure route"
+	CodeDescription[DIP145] = "graph budget default is negative"
+```
+
+- [ ] **Step 4: Add the Explanations entry**
+
+In `validator/explanations.go`, inside `configExplanations()` (the map returned at line 205, alongside DIP116), add an entry before the closing brace:
+
+```go
+		DIP145: {
+			Code:    DIP145,
+			Summary: "graph budget default is negative",
+			Trigger: "A workflow budget default (max_total_tokens, max_cost_cents, max_wall_time, or stall_timeout) is set to a negative value.",
+			Fix:     "Use a positive cap, or omit the field / set 0 to mean no limit.",
+			Example: "defaults\n  max_cost_cents: -5    // DIP145: negative; use a positive cap or 0 for no limit",
+		},
+```
+
+- [ ] **Step 5: Implement the lint**
+
+Create `validator/lint_budget.go`:
+
+```go
+package validator
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// lintBudgetRanges checks DIP145: a graph-level budget default must not be
+// negative. Zero means "unset / no limit" (the formatter emits only non-zero
+// values), so only values < 0 are flagged. time.Duration is an int64, so all
+// four fields normalize to int64 for a single uniform check.
+func lintBudgetRanges(w *ir.Workflow) []Diagnostic {
+	d := w.Defaults
+	checks := []struct {
+		name string
+		v    int64
+	}{
+		{"max_total_tokens", int64(d.MaxTotalTokens)},
+		{"max_cost_cents", int64(d.MaxCostCents)},
+		{"max_wall_time", int64(d.MaxWallTime)},
+		{"stall_timeout", int64(d.StallTimeout)},
+	}
+	var diags []Diagnostic
+	for _, c := range checks {
+		if c.v < 0 {
+			diags = append(diags, Diagnostic{
+				Code:     DIP145,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("workflow budget default %s is %d; budgets cannot be negative", c.name, c.v),
+				Help:     "use a positive cap (e.g. max_cost_cents: 1000 for $10.00), or omit it / set 0 for no limit",
+			})
+		}
+	}
+	return diags
+}
+```
+
+- [ ] **Step 6: Register the lint**
+
+In `validator/lint.go`, after `lintAgentFailureRoute` (line 63):
+
+```go
+	diags = append(diags, lintAgentFailureRoute(w)...)
+	diags = append(diags, lintBudgetRanges(w)...)
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `just test-pkg validator`
+Expected: PASS — including `TestExplanationsCoverAllCodes` / `TestExplanationsNoExtra` (the new const + Explanations entry now agree).
+
+- [ ] **Step 8: Check complexity + commit**
+
+```bash
+just complexity   # lintBudgetRanges: cyclo 2, well under
+just fmt
+git add validator/lint_codes.go validator/explanations.go validator/lint_budget.go validator/lint.go validator/lint_budget_test.go
+git commit -m "feat: DIP145 lint for negative graph budget defaults (#94)"
+```
+
+---
+
+## Task 6: Docs — `max_turns` exhaustion, budget fields, DIP145 section, count bumps
+
+**Files:**
+- Modify: `docs/nodes.md:116` (max_turns row + subsection)
+- Modify: `docs/edges.md` (cascade failure sources)
+- Modify: `docs/syntax.md` (defaults table — add four budget rows)
+- Modify: `docs/validation.md` (DIP145 section + DIP144 cross-link + counts)
+- Modify: `docs/llm-reference.md` (counts + range bullet)
+- Modify: `CLAUDE.md:85` (count)
+
+- [ ] **Step 1: Rewrite the `max_turns` row in `docs/nodes.md:116`**
+
+Replace the existing `max_turns` table row with:
+
+```
+| `max_turns` | Integer | 1 | Maximum request-response cycles in the agent's tool-using loop. **Reaching this limit ends the node with outcome `fail`** — it is a hard cap, not a soft budget. The failure routes through the standard failure cascade (fail edge → bounded retry → `fallback_target` → graph `on_failure` → halt). Ensure a failure route exists (see DIP144) or the run halts on exhaustion. |
+```
+
+- [ ] **Step 2: Add a `max_turns exhaustion` subsection**
+
+After the agent-config table in `docs/nodes.md` (near the existing `goal_gate`/`auto_status` prose subsections), add:
+
+```markdown
+### max_turns exhaustion
+
+When an agent reaches `max_turns` without completing, the engine treats it as a
+failure (`ctx.outcome = fail`), **not** a successful stop. `max_turns` is therefore
+a routing event, not just a cost control. An agent with `max_turns` set but no
+failure route is a latent dead-end — [DIP144](validation.md#dip144) warns you. Pair
+every bounded `max_turns` with one of: a `when ctx.outcome = fail` edge,
+`fallback_target`, a bounded `retry_target`, or a graph `on_failure`.
+```
+
+- [ ] **Step 3: Add cascade failure sources in `docs/edges.md`**
+
+In the Routing Priority / Failure Handling section (around line 110), add a sentence listing the failure sources that feed the cascade:
+
+```markdown
+A node enters the failure cascade when it errors, fails a `goal_gate`, **exhausts
+`max_turns`**, or trips the graph **`stall_timeout`**. All route through the same
+priority order below.
+```
+
+- [ ] **Step 4: Add the four budget rows to the `docs/syntax.md` defaults table**
+
+In the `defaults` table (around line 113-124), add (the three existing budget fields are currently undocumented here — this fixes that too):
+
+```
+| `max_total_tokens` | Integer | Hard ceiling on total tokens across the run. `0`/unset = no limit. |
+| `max_cost_cents` | Integer | Hard ceiling on total cost, in **US cents** (e.g. `1000` = $10.00). `0`/unset = no limit. |
+| `max_wall_time` | Duration | Hard ceiling on **wall-clock** run time (e.g. `30m`, `2h`). `0`/unset = no limit. |
+| `stall_timeout` | Duration | **Wall-clock** span with no forward progress before the run aborts and routes through `on_failure` (e.g. `5m`, `90s`). Elapsed time, **not** a turn count. `0`/unset = disabled. |
+```
+
+Add one prose line below the table:
+
+```markdown
+All budget fields use `0` (or unset) to mean **no limit** — `0` does not mean
+"zero budget." The three `max_*` fields bound *totals* (monotonic ceilings);
+`stall_timeout` bounds *inactivity* (a sliding timer).
+```
+
+- [ ] **Step 5: Add the DIP145 section to `docs/validation.md`**
+
+After the DIP144 section (ends ~line 1029), add a new section mirroring the DIP144/DIP116 structure:
+
+```markdown
+### DIP145: Negative Graph Budget Default
+
+A workflow budget default is set to a negative value. Budgets are non-negative;
+`0` (or unset) means **no limit**.
+
+```text
+warning[DIP145]: workflow budget default max_cost_cents is -5; budgets cannot be negative
+```
+
+**Trigger:** `max_total_tokens`, `max_cost_cents`, `max_wall_time`, or
+`stall_timeout` in the `defaults` block is negative.
+
+**Fix:** Use a positive cap, or omit the field / set `0` for no limit. Note `0`
+means *unlimited*, not "zero budget."
+```
+
+- [ ] **Step 6: Cross-link DIP144 → max_turns**
+
+In the DIP144 section of `docs/validation.md` (~line 987-1029), add to the trigger prose:
+
+```markdown
+This warning is especially important for agents with a bounded `max_turns`: turn
+exhaustion ends the node as `fail`, so without a failure route the run halts on
+exhaustion.
+```
+
+- [ ] **Step 7: Bump all count + range strings**
+
+Update each (grep both en-dash `–` and hyphen `-` forms of `DIP101-DIP144`):
+- `CLAUDE.md:85`: `53 diagnostic codes` → `54 diagnostic codes`; `DIP101-DIP144` → `DIP101-DIP145`.
+- `docs/llm-reference.md:188`: `53 diagnostic codes` → `54`; line 191 bullet `DIP101–DIP144` → `DIP101–DIP145`, and append `, negative budget defaults` to the warning list.
+- `docs/validation.md`: line 3 `registers 53` → `54`, `documents 48` → `49`; lines 6, 15, 227, 1049 `DIP101–DIP144` → `DIP101–DIP145`.
+
+Run to find any missed occurrences:
+
+```bash
+grep -rn "DIP101.DIP144\|53 diagnostic\|registers 53\|documents 48" CLAUDE.md docs/ validator/
+```
+
+Expected after edits: no stale `DIP144`-range or `53`/`48` count strings remain (except historical references in `docs/superpowers/` specs, which are dated snapshots — leave those).
+
+- [ ] **Step 8: Regenerate the assembled spec**
+
+Run: `just spec-check` (or the generation step it wraps). If it reports the generated files are stale, run the generator (`scripts/gen-spec.sh`) and stage `docs/generated-spec.md` + `cmd/dippin/generated-spec.md`. NEVER hand-edit the generated files.
+
+Note: the `git commit` pre-commit hook auto-runs gen-spec and will fail if the generated files are stale — so if unsure, just attempt the commit and let the hook regenerate.
+
+- [ ] **Step 9: Commit**
+
+```bash
+just fmt
+git add CLAUDE.md docs/nodes.md docs/edges.md docs/syntax.md docs/validation.md docs/llm-reference.md docs/generated-spec.md cmd/dippin/generated-spec.md
+git commit -m "docs: max_turns exhaustion semantics, budget attrs, DIP145, count bumps (#94)"
+```
+
+---
+
+## Task 7: New lint-clean example exercising the budget attrs
+
+**Files:**
+- Create: `examples/budget_guards.dip`
+
+- [ ] **Step 1: Write the example**
+
+Create `examples/budget_guards.dip` — a cost-ceilinged research+build flow with a stall window and a graph `on_failure` escalation, so the budget abort has somewhere to route (and DIP144 stays suppressed). Adjust node/edge syntax to match a known-good existing example (copy the header/shape from `examples/on_failure_route.dip`):
+
+```
+workflow BudgetGuards
+  goal: "Research and draft with a cost ceiling and a stall guard"
+  start: Research
+  exit: Done
+
+  defaults
+    model: claude-sonnet-4-6
+    max_total_tokens: 500000   # hard ceiling: total tokens across the run; 0 = no limit
+    max_cost_cents: 2000       # hard ceiling: $20.00 total spend; 0 = no limit
+    max_wall_time: 30m         # hard ceiling: wall-clock; 0 = no limit
+    stall_timeout: 5m          # wall-clock; abort if no progress for 5 minutes
+    on_failure: Escalate       # budget / stall / max_turns failures route here
+
+  agent Research
+    prompt: "Research the topic and gather sources."
+    max_turns: 8               # exhaustion ends the node as fail -> routes to on_failure
+
+  agent Draft
+    prompt: "Draft the document from the research."
+    max_turns: 12
+
+  human Escalate
+    mode: freeform
+    prompt: "The run hit a budget/stall/turn limit. How should we proceed?"
+
+  agent Done
+    prompt: "Finalize."
+
+  edges
+    Research -> Draft
+    Draft -> Done
+    Escalate -> Done
+```
+
+- [ ] **Step 2: Validate it parses + is lint-clean**
+
+Run:
+```bash
+just build
+./dippin validate examples/budget_guards.dip
+./dippin lint examples/budget_guards.dip
+```
+Expected: validate passes; lint emits **no DIP144** (the graph `on_failure` suppresses it) and **no DIP145** (all budgets positive). If the example node/edge syntax errors, fix it against `examples/on_failure_route.dip` until clean. Minor warnings on unrelated codes are acceptable but prefer zero.
+
+- [ ] **Step 3: Confirm the example suite still passes**
+
+Run: `just validate-examples` and `just lint-examples`
+Expected: all examples validate; no new failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/budget_guards.dip
+git commit -m "docs: add lint-clean budget_guards example (#94)"
+```
+
+---
+
+## Task 8: Full verification + wasm gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the test suite with race**
+
+Run: `just test-race`
+Expected: all packages PASS.
+
+- [ ] **Step 2: Run the complexity gate**
+
+Run: `just complexity`
+Expected: PASS (no function over cyclo 5 / cognit 7).
+
+- [ ] **Step 3: Verify the wasm build (Netlify preview gate)**
+
+Run: `GOOS=js GOARCH=wasm go build ./cmd/wasm/ ./validator/`
+Expected: builds with no error. (`lint_budget.go` imports only `ir`+`fmt`, wasm-safe.)
+
+(This raw `go build` is the one exception the CI/Netlify gate uses; there is no `just` recipe for the cross-compile check.)
+
+- [ ] **Step 4: Confirm no stale count strings**
+
+Run: `grep -rn "DIP101.DIP144\|53 diagnostic\|registers 53\|documents 48" CLAUDE.md docs/ validator/ cmd/`
+Expected: only dated `docs/superpowers/` snapshots remain (if any); no live docs/code.
+
+- [ ] **Step 5: Final clean status check**
+
+Run: `git status --short`
+Expected: clean (all work committed; no stray `./dippin`/`./wasm` artifacts staged).
+
+---
+
+## Self-Review (completed against the spec)
+
+- **stall_timeout field** → Task 1 (IR+parser), Task 2 (formatter), Task 3 (DOT export), Task 4 (migrate). ✅
+- **max_turns exhaustion semantics** → Task 6 (docs-only, nodes.md + edges.md + DIP144 cross-link). ✅
+- **DOT round-trip gap (all 4 fields)** → Task 3 (export) + Task 4 (migrate round-trip test). ✅
+- **DIP145** → Task 5 (const, description, explanation, lint, register, tests). ✅
+- **0=unset boundary** → Task 5 (`v < 0`) + tests `TestDIP145SilentOnUnsetZero`. ✅
+- **wire-format contract (Go duration literal)** → Task 3 helper uses `formatDuration`; Task 4 asserts Duration equality incl. the `90s` case. ✅
+- **per-node deferred** → not implemented (correct; documented in spec Out of scope). ✅
+- **docs (syntax.md/nodes.md/edges.md/validation.md/llm-reference.md) + count bumps** → Task 6. ✅
+- **new lint-clean example** → Task 7. ✅
+- **wasm gate** → Task 8. ✅
+- **var-collision reserved guard** → Task 3 (reserved) + Task 4 (`TestRoundTripStallTimeoutVarsCollision`). ✅
+- **negative-duration format quirk** → Task 2 (`TestFormatDurationNegativeRoundTrips`). ✅

--- a/docs/superpowers/specs/2026-06-04-issue-94-budget-attrs-design.md
+++ b/docs/superpowers/specs/2026-06-04-issue-94-budget-attrs-design.md
@@ -1,0 +1,320 @@
+# Design: declarable budget/limit attrs — `stall_timeout`, `max_turns` exhaustion, DIP145 (#94)
+
+**Date:** 2026-06-04
+**Issue:** Closes #94 (P2)
+**Status:** Approved design (expert-panel reviewed) — ready for implementation plan
+
+## Summary
+
+Make runtime budget guards declarable in `.dip` and give `max_turns` defined
+exhaustion semantics. dippin **carries + validates + lints** the authoring
+surface; the tracker runtime **enforces** it (`pipeline.BudgetGuard` +
+`pipeline/dippin_adapter.go` `extractWorkflowDefaults`). Every new field is
+**inert** until the tracker reads it — but per the project's
+`never-gate-dippin-on-tracker` principle we ship the surface now and do **not**
+gate any dippin behavior on tracker readiness.
+
+Four changes, one PR:
+
+1. **New graph default `stall_timeout`** (`time.Duration`) — abort/route when no
+   forward progress is made for a wall-clock span. Sibling of the three existing
+   budget ceilings.
+2. **`max_turns` exhaustion semantics** — hitting `max_turns` ends the node with
+   outcome `fail`, routed through the existing #92/#93 failure cascade. **No new
+   declarable action field** (declining the issue's "ideally configurable"
+   `fail|truncate|fallback` enum as YAGNI). Documentation-only.
+3. **Close a pre-existing DOT export data-loss bug.** The three existing budget
+   fields (`max_total_tokens`/`max_cost_cents`/`max_wall_time`) are silently
+   dropped on `.dip → DOT` export today. Fix all three plus emit the new
+   `stall_timeout`, with round-trip tests.
+4. **New lint DIP145** (warning) — a graph budget default set to a **negative**
+   value. Mirrors the existing DIP136 (negative manager_loop control field).
+
+This is dippin-side only. A tracker `upstream` follow-up (extending the existing
+`on-failure-tracker-followup`) is filed once this lands.
+
+## Naming decision (ratified)
+
+The new field is **`stall_timeout`**, a `time.Duration`. Considered
+`no_progress_window` (the issue's spelling) and `no_progress_timeout`. Rejected
+`no_progress_window` because `_window` reads as a *count of iterations*, which
+mismatches the duration type we chose. `_timeout` / `stall_timeout` unambiguously
+signal wall-clock (consistent with the repo's existing `cmd_timeout` duration
+field). `stall_timeout` is the chosen spelling across **every** surface — IR field,
+parser key, formatter, DOT/Attrs key, docs, and the tracker follow-up. This is a
+**new** cross-repo key the tracker has never seen; we get the spelling right once.
+
+## #94.1 — `stall_timeout` graph-level default
+
+### IR
+Add `StallTimeout time.Duration` to `ir.WorkflowDefaults`, next to `MaxWallTime`
+(`ir/ir.go:52-54`). Zero value = unset (matches every sibling). No in-repo package
+reads it — carried metadata for the downstream engine (verified: nothing reads the
+existing budget fields either).
+
+### Surface / parser
+`defaults:` block field only (**not** the workflow header). Verified by the #92
+design: the header parser accepts only `goal`/`start`/`exit`/`requires` + block
+keywords (`parser/parser.go:101-128`); a header field emits "unexpected top-level
+identifier". This is consistent with every other default-semantics field and with
+the three existing budget fields. Parsed in `parser/parse_defaults.go`
+`applyDefaultBudgetField` (the duration-parsed switch, `:134-146`) via one
+`case "stall_timeout": d.StallTimeout = p.parseDuration(...)`.
+
+### Semantics (documented; tracker enforces)
+Abort/route the run when no forward progress is made for the configured wall-clock
+span. Like `max_turns` exhaustion, hitting `stall_timeout` is a **failure** that
+routes through the graph `on_failure` cascade (below). `0`/absent = disabled.
+dippin validates shape/range only; the runtime owns "what counts as progress".
+
+## #94.2 — `max_turns` exhaustion semantics (docs-only)
+
+When an agent node reaches `max_turns` without completing, the engine treats it as
+a **failure** (`ctx.outcome = fail`) — **not** a successful stop — which flows
+through the cascade shipped in #92/#93:
+
+1. matching fail edge (`when ctx.outcome = fail|failure`)
+2. bounded node retry (`retry_target` + `max_retries`)
+3. node `fallback_target`
+4. graph `on_failure` (catch-all)
+5. halt
+
+**No new field.** The issue asks for the action to be "**ideally** configurable" —
+"ideally," not "must." An explicit `fail|truncate|fallback` enum would be **inert**
+(nothing reads it), require its own validation + DOT round-trip + lint, and is the
+speculative configurability the working-style guide says to cut. Reusing the
+cascade gives authors a real, already-validated routing story today. If a concrete
+`truncate` need surfaces later, it is an additive field.
+
+### Docs (load-bearing, not a footnote)
+`docs/nodes.md:116` currently documents `max_turns` as a pure cost lever
+("Set higher for multi-step tool-using agents"). This is the exact ambiguity #94
+calls out. Rewrite the table row to state the exhaustion outcome **inline** (the
+row is what authors scan), and add a short `### max_turns exhaustion` subsection:
+
+> | `max_turns` | Integer | 1 | Maximum request-response cycles in the agent's
+> tool-using loop. **Reaching this limit ends the node with outcome `fail`** — a
+> hard cap, not a soft budget. The failure routes through the standard failure
+> cascade (fail edge → bounded retry → `fallback_target` → graph `on_failure` →
+> halt). Ensure a failure route exists (see DIP144) or the run halts on
+> exhaustion. |
+
+Reciprocally, the Failure Handling / Routing Priority cascade in
+`docs/edges.md:110+` lists `max_turns` exhaustion (and `stall_timeout`) as failure
+*sources* feeding the cascade, alongside `goal_gate` failure and erroring.
+
+### DIP144 interaction (docs-only linkage)
+`max_turns` → `on_failure` makes DIP144 ("agent node has no failure route") the
+guardrail that catches the footgun: a `max_turns`-capped node with no failure route
+is a latent dead-end. **No new lint logic** — DIP144 already fires on routeless
+agents regardless of *why* they fail; do not add `max_turns`-specific logic. Add a
+bidirectional docs cross-link (DIP144 section in `docs/validation.md:987+` ↔ the
+`max_turns` subsection).
+
+## #94.3 — close the pre-existing DOT export data-loss bug
+
+**Framing (corrected by review):** this is not merely "add export for the new
+field." The three **existing** budget fields are silently dropped on `.dip → DOT`
+export *today*: `buildGraphAttrs` (`export/dot.go:89-110`) emits only
+`tool_commands_allow`, `tool_denylist_add`, `on_failure` — never the budget fields
+— yet migrate-IN reads all three (`migrate/migrate.go:185-196`) and they sit in
+`reservedGraphAttrs` (`export/dot.go:61-67`). The round-trip is one-directional and
+lossy: a workflow with budgets exported to DOT loses them. Budget ceilings are
+safety-relevant; the #92/#93 design ratified the precedent that safety-critical
+graph defaults round-trip through DOT *with* a regression test (the tool-safety
+pair). #94 closes this for all four budget fields.
+
+### Wire-format contract (ratified)
+Durations cross the repo boundary as a **Go `time.ParseDuration` literal**
+(canonical compact output of `formatDuration`, e.g. `5m`, `1h30m`). This is the
+**existing** behavior of `max_wall_time` (confirmed: `migrate/migrate_test.go:825`
+asserts `max_wall_time="30m"`; round-trip parses via `time.ParseDuration`). We keep
+it and apply the same to `stall_timeout` — changing `max_wall_time` to an
+integer-seconds wire form would be a breaking, out-of-scope change to a shipped
+field. The spec states this as an explicit contract clause so the tracker adapter
+knows to parse a Go duration literal; the int fields (`max_total_tokens`,
+`max_cost_cents`) remain plain integers. The tracker follow-up names this.
+
+### Export (`export/dot.go`)
+- Emit all four budget fields in `buildGraphAttrs`, each guarded by `!= 0` so an
+  unset field is never written (mirrors the formatter). Durations emit via the same
+  `formatDuration` path the formatter uses — **not** raw `time.Duration.String()` —
+  for round-trip symmetry.
+- **Complexity (measured, mandatory):** `buildGraphAttrs` is cyclo 4 today; adding
+  four inline `if`-emit branches → cyclo 8, **busting ≤5**. Extract
+  `appendBudgetGraphAttrs(w, &attrs)` covering all four fields. This is required to
+  pass the gate, not gold-plating.
+- Add `"stall_timeout": true` to `reservedGraphAttrs` **in lockstep with the emit**
+  — otherwise a `vars` entry literally named `stall_timeout` (migrated into
+  `Workflow.Vars`) would emit twice in the `graph [...]` block. (The three existing
+  budget keys are already reserved.)
+
+### Migrate (`migrate/migrate.go`)
+Add `case "stall_timeout": return tryApplyDurationDefault(v, &w.Defaults.StallTimeout)`
+to `applyIntBudgetDefault` (`:185`). Switch case — near-zero cognit cost.
+
+### Formatter (`formatter/format.go`)
+Add `stall_timeout` to `writeDefaultsBudgetFields` (`:193`), guarded `!= 0`, via
+`formatDuration`. Adds one `if` → cyclo 5 (at the cap, passes). No extraction
+needed; don't over-extract.
+
+## #94.4 — DIP145 lint (warning): negative graph budget default
+
+Fires when any of the four graph budget defaults is **negative** (`< 0`):
+`max_total_tokens`, `max_cost_cents`, `max_wall_time`, `stall_timeout`.
+
+- **`0` = unset = no warning** for all four (the formatter emits with `!= 0`; `0` is
+  structurally indistinguishable from unset, and there is no coherent "zero-length"
+  semantic). Condition is `v < 0`, **not** `<= 0`. Getting this wrong false-positives
+  on every workflow that omits a budget.
+- **Reachability confirmed empirically:** `strconv.Atoi("-5")` and
+  `time.ParseDuration("-5m")` both succeed with no error
+  (`parser/parse_helpers.go:45,61`), so a negative lands in the IR with no
+  structural diagnostic. DIP145 is reachable and **disjoint** from any DIP00x
+  (no double-firing — verified there is no input triggering both).
+- **Precedent:** DIP136 already lints negative manager_loop control fields
+  (`poll_interval`/`max_cycles`) with "0 means unset" framing. DIP145 mirrors its
+  voice. One unified DIP145 covers all four budget fields (DIP136 is
+  manager_loop-scoped and does not cover the int ceilings, so no merge).
+- **Structure (complexity-safe):** `time.Duration` is an `int64`, so table-drive on
+  normalized `int64` — cyclo ~2, trivially testable:
+  ```go
+  checks := []struct{ name string; v int64 }{
+      {"max_total_tokens", int64(d.MaxTotalTokens)},
+      {"max_cost_cents",   int64(d.MaxCostCents)},
+      {"max_wall_time",    int64(d.MaxWallTime)},
+      {"stall_timeout",    int64(d.StallTimeout)},
+  }
+  for _, c := range checks { if c.v < 0 { /* append DIP145 */ } }
+  ```
+  New file `validator/lint_budget.go`; register `lintBudgetRanges` in
+  `validator/lint.go` (near `lintCompactionThreshold`).
+
+### Message + Help (the `0 = no limit` footgun fix)
+The message **names the field and the value**; the Help **states the 0-convention**
+so an author doesn't "fix" a negative by setting `0` (which means *unlimited*, the
+opposite of intent — the single highest-leverage clarity fix in this issue):
+
+> **Message:** `workflow budget default max_cost_cents is -5; budgets cannot be negative`
+> **Help:** `use a positive cap (e.g. max_cost_cents: 1000 for $10.00), or omit it / set 0 for no limit`
+
+### Explanations entry (4-field, test-gated)
+```
+DIP145: {
+    Code:    DIP145,
+    Summary: "graph budget default is negative",
+    Trigger: "A workflow budget default (max_total_tokens, max_cost_cents, max_wall_time, or stall_timeout) is set to a negative value.",
+    Fix:     "Use a positive cap, or omit the field / set 0 to mean no limit.",
+    Example: "defaults\n  max_cost_cents: -5    // DIP145: negative; use a positive cap or 0 for no limit",
+}
+```
+`TestExplanationsCoverAllCodes`/`NoExtra` enforce this atomically against the
+`CodeDescription[DIP145]` const.
+
+## Per-node budgets — deferred (Out of scope)
+
+`max_turns` stays the only per-node knob (already there; we just define its
+exhaustion). **No** per-node `max_total_tokens`/`max_cost_cents`/`max_wall_time`/
+`stall_timeout`. Tracker #67's contract is graph-level (`graph.Attrs`); no concrete
+per-node need surfaced; adding per-node ceilings invents a node-vs-defaults
+precedence story with no runtime to honor it. Adding them later is purely additive
+(new `AgentConfig` fields) and breaks nothing shipped here. **Named explicitly as a
+deferred decision:** the most likely-missed one is per-node `max_wall_time` (the IR
+already has per-node `CmdTimeout` and `MaxTurns`, so authors may expect it).
+
+## Docs
+
+- **`docs/syntax.md` defaults table (`:113-124`)** currently omits all three budget
+  fields entirely. Add all **four** with units and the 0-convention:
+  - `max_total_tokens` (Integer) — hard ceiling on total tokens; `0`/unset = no limit.
+  - `max_cost_cents` (Integer) — hard ceiling on cost in **US cents** (`1000` = $10.00); `0`/unset = no limit.
+  - `max_wall_time` (Duration) — hard ceiling on **wall-clock** run time (`30m`, `2h`); `0`/unset = no limit.
+  - `stall_timeout` (Duration) — **wall-clock** span with no forward progress before the run aborts and routes through `on_failure` (`5m`, `90s`); elapsed time, **not** a turn count; `0`/unset = disabled.
+- State the **`0 = no limit`** convention once, prominently, in the budget
+  subsection: *"`0` (or unset) means **no limit** — it does not mean 'zero budget'."*
+- Distinguish the family: the three `max_*` fields bound **totals** (monotonic
+  ceilings); `stall_timeout` bounds **inactivity** (a sliding timer). One sentence
+  prevents the author mental-model error.
+- `docs/nodes.md:116` — the `max_turns` row + exhaustion subsection (above).
+- `docs/edges.md:110+` — list `max_turns`/`stall_timeout` exhaustion as cascade
+  failure sources.
+
+## Examples blast radius
+
+Measured: no example sets any budget default; only `stress_edge_cases.dip` uses
+`max_turns: 10` (valid). **DIP145 will not fire on any existing example.** Add
+**one new lint-clean example** that teaches the feature end-to-end: a cost ceiling +
+`stall_timeout` + `max_turns` on an agent, all layered on a graph `on_failure` so
+the budget abort has somewhere to go (and DIP144 stays suppressed). Inline comments
+state units, the 0-convention, and "wall-clock" for `stall_timeout`. Verify
+lint-clean with `just lint-examples`.
+
+## Lint plumbing + count strings (test-gated)
+
+- const + `CodeDescription[DIP145]` (`validator/lint_codes.go`); 4-field
+  `Explanations[DIP145]` (`validator/explanations.go`); register `lintBudgetRanges`
+  in `validator/lint.go`.
+- Bump every hardcoded range / count string (prose only, no machine contract):
+  - `"53 diagnostic codes"` → **54**: `CLAUDE.md:85`, `docs/llm-reference.md:188`,
+    `docs/validation.md:3`.
+  - `"documents 48 of them"` → **49**: `docs/validation.md:3` (DIP145 *gets* a
+    dedicated section, so the documented count moves too — write the section before
+    bumping the count, or the 49 is a lie).
+  - `DIP101–DIP144` → `DIP101–DIP145`: grep **both** the en-dash (`–`) and hyphen
+    (`-`) forms across `CLAUDE.md`, `validator/lint.go`, `validator/lint_codes.go:3`,
+    `docs/validation.md` (`:3,:6,:15,:227,:1049`), `docs/llm-reference.md`
+    (`:188,:191`).
+- Regenerate `docs/generated-spec.md` + `cmd/dippin/generated-spec.md` via
+  `scripts/gen-spec.sh` (never hand-edit the generated files).
+- No automated test guards the prose counts — add a one-line count check to the PR
+  description.
+
+## Cross-repo follow-up (tracker, separate repo)
+
+Extends the existing `on-failure-tracker-followup`. File a tracker `upstream` issue
+(`area/dippin-lang`), specifying:
+- Adapter (`pipeline/dippin_adapter.go` `extractWorkflowDefaults`) copies the now-
+  exported budget keys + `stall_timeout` into `graph.Attrs`.
+- **Wire-format contract:** `max_wall_time`/`stall_timeout` arrive as Go
+  `time.ParseDuration` literals (compact form); `max_total_tokens`/`max_cost_cents`
+  as plain integers. `stall_timeout` is a **new** key not in tracker #67.
+- Budget / stall abort routes through the graph `on_failure` cascade (same as
+  `max_turns` exhaustion and `on_failure` itself). Empty/zero = feature-off.
+
+## Testing (TDD — failing test first each step)
+
+- **parser:** `stall_timeout` → `WorkflowDefaults.StallTimeout`; negative
+  (`stall_timeout: -5m`, `max_cost_cents: -5`) parses with **no** structural
+  diagnostic (proves the DIP145 premise in-repo).
+- **formatter:** round-trip mirroring `TestParseDefaultsBudgetRoundTrip`; assert the
+  typed `Duration`, never the source string (`90s` → `1m30s` normalizes). Lock the
+  `formatDuration(-5*time.Minute) == "-5m0s"` quirk with a parse→format→parse
+  semantic-equality test (it is not a bug; don't "fix" it).
+- **DOT export/migrate:** export emits all four budget fields; `.dip → DOT → .dip`
+  round-trip preserves them (assert `Duration` equality). Include a `90s` case (the
+  one input whose string changes) and a `vars`-named-`stall_timeout` collision case
+  (proves the `reservedGraphAttrs` fix — no double-emit). A `1h30m` DOT-quoted
+  duration migrates in correctly.
+- **DIP145:** fires on each negative field; **silent on 0**; silent on positive;
+  message names field + value; Help states the 0-convention.
+- `TestExplanationsCoverAllCodes`/`NoExtra` for DIP145.
+- `TestLintExamples` still zero-DIP108; new example lint-clean (no DIP144).
+- `GOOS=js GOARCH=wasm go build ./cmd/wasm/ ./validator/` (Netlify preview gate —
+  `lint_budget.go` imports only `ir`+`fmt`, wasm-safe).
+
+## Build order
+
+1. `stall_timeout`: IR field → parser → formatter → DOT export (+ close the 3-field
+   export gap, extract `appendBudgetGraphAttrs`) → migrate → round-trip tests.
+2. DIP145 lint + plumbing (`lint_budget.go`, codes, explanations, register).
+3. New lint-clean example + docs (`syntax.md`, `nodes.md`, `edges.md`,
+   `validation.md` DIP145 section + DIP144 cross-link) + count/range bumps + spec
+   regen.
+4. wasm build verification.
+
+## Out of scope
+
+Per-node budget fields; tracker runtime enforcement; any `error`/strict-flag
+severity for DIP145; a `max_turns` action enum (`fail|truncate|fallback`); changing
+`max_wall_time`'s wire format to integer seconds; node-existence validation for
+`restart_target`/`retry_target`/`fallback_target` (a pre-existing #92 follow-up).

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -122,6 +122,14 @@ The optional `defaults` block sets graph-level configuration that applies to all
 | `cache_tools` | Boolean | Whether to cache tool call results |
 | `compaction` | String | Context compaction mode for long pipelines |
 | `on_failure` | String | Graph-level default failure route — node to jump to when an agent has no other failure route (see [edges.md](edges.md) for the full precedence cascade) |
+| `max_total_tokens` | Integer | Hard ceiling on total tokens across the run. `0`/unset = no limit. |
+| `max_cost_cents` | Integer | Hard ceiling on total cost, in **US cents** (e.g. `1000` = $10.00). `0`/unset = no limit. |
+| `max_wall_time` | Duration | Hard ceiling on **wall-clock** run time (e.g. `30m`, `2h`). `0`/unset = no limit. |
+| `stall_timeout` | Duration | **Wall-clock** span with no forward progress before the run aborts and routes through `on_failure` (e.g. `5m`, `90s`). Elapsed time, **not** a turn count. `0`/unset = disabled. |
+
+All budget fields use `0` (or unset) to mean **no limit** — `0` does not mean
+"zero budget." The three `max_*` fields bound *totals* (monotonic ceilings);
+`stall_timeout` bounds *inactivity* (a sliding timer).
 
 ---
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,9 +1,9 @@
 # Validation and Linting Reference
 
-Dippin registers 53 diagnostic codes split into two categories; this page documents 48 of them in dedicated sections (the linter registers a few additional internal codes without dedicated sections):
+Dippin registers 54 diagnostic codes split into two categories; this page documents 49 of them in dedicated sections (the linter registers a few additional internal codes without dedicated sections):
 
 - **Structural validation** (DIP001–DIP009): Errors that **must** be fixed. A workflow with any of these cannot execute.
-- **Semantic linting** (DIP101–DIP144): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
+- **Semantic linting** (DIP101–DIP145): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
 
 Run `dippin validate <file>` for structural checks only, or `dippin lint <file>` for both.
 
@@ -12,7 +12,7 @@ graph LR
     SRC[".dip file"] --> PARSE["Parser"]
     PARSE --> IR["IR"]
     IR --> VAL["Structural Validation<br>DIP001–DIP009<br>(errors)"]
-    IR --> LINT["Semantic Linting<br>DIP101–DIP144<br>(warnings)"]
+    IR --> LINT["Semantic Linting<br>DIP101–DIP145<br>(warnings)"]
     VAL --> DIAG["Diagnostics"]
     LINT --> DIAG
 ```
@@ -224,7 +224,7 @@ error[DIP009]: duplicate edge
 
 ---
 
-## Semantic Lint Warnings (DIP101–DIP144)
+## Semantic Lint Warnings (DIP101–DIP145)
 
 ### DIP101: Node Only Reachable via Conditional Edges
 
@@ -996,6 +996,10 @@ warning[DIP144]: agent node "Build" has no failure route (no fail edge, no fallb
   = help: add `-> <node> when ctx.outcome = fail`, set fallback_target:, add retry_target with max_retries, or declare a workflow-level on_failure:
 ```
 
+This warning is especially important for agents with a bounded `max_turns`: turn
+exhaustion ends the node as `fail`, so without a failure route the run halts on
+exhaustion.
+
 **What triggers it**: An `agent` node that has none of:
 - An outgoing edge with `when ctx.outcome = fail` (or `failure`)
 - A `fallback_target` field
@@ -1030,6 +1034,23 @@ See [edges.md](edges.md) — Failure Handling for the full five-level precedence
 
 ---
 
+### DIP145: Negative Graph Budget Default
+
+A workflow budget default is set to a negative value. Budgets are non-negative;
+`0` (or unset) means **no limit**.
+
+```text
+warning[DIP145]: workflow budget default max_cost_cents is -5; budgets cannot be negative
+```
+
+**Trigger:** `max_total_tokens`, `max_cost_cents`, `max_wall_time`, or
+`stall_timeout` in the `defaults` block is negative.
+
+**Fix:** Use a positive cap, or omit the field / set `0` for no limit. Note `0`
+means *unlimited*, not "zero budget."
+
+---
+
 ## Running Validation
 
 ### Structural validation only
@@ -1046,7 +1067,7 @@ Runs DIP001–DIP009. Exit code 0 if all pass, 1 if any errors.
 dippin lint pipeline.dip
 ```
 
-Runs all DIP001–DIP009 errors and DIP101–DIP144 warnings. Exit code 1 only for errors; warnings alone exit 0.
+Runs all DIP001–DIP009 errors and DIP101–DIP145 warnings. Exit code 1 only for errors; warnings alone exit 0.
 
 ### JSON output for CI
 

--- a/examples/budget_guards.dip
+++ b/examples/budget_guards.dip
@@ -1,0 +1,33 @@
+workflow BudgetGuards
+  goal: "Research and draft with a cost ceiling and a stall guard"
+  start: Research
+  exit: Done
+
+  defaults
+    model: claude-sonnet-4-6
+    provider: anthropic
+    max_total_tokens: 500000
+    max_cost_cents: 2000
+    max_wall_time: 30m
+    stall_timeout: 5m
+    on_failure: Escalate
+
+  agent Research
+    prompt: "Research the topic and gather sources."
+    max_turns: 8
+
+  agent Draft
+    prompt: "Draft the document from the research."
+    max_turns: 12
+
+  human Escalate
+    mode: freeform
+    prompt: "The run hit a budget/stall/turn limit. How should we proceed?"
+
+  agent Done
+    prompt: "Finalize."
+
+  edges
+    Research -> Draft
+    Draft -> Done
+    Escalate -> Done

--- a/export/dot.go
+++ b/export/dot.go
@@ -63,6 +63,7 @@ var reservedGraphAttrs = map[string]bool{
 	"fidelity": true, "default_fidelity": true,
 	"max_retries": true, "default_max_retry": true, "max_restarts": true,
 	"max_total_tokens": true, "max_cost_cents": true, "max_wall_time": true,
+	"stall_timeout":       true,
 	"tool_commands_allow": true, "tool_denylist_add": true,
 	"on_failure": true,
 }
@@ -102,11 +103,31 @@ func buildGraphAttrs(w *ir.Workflow, rankDir string) []string {
 	if w.Defaults.OnFailure != "" {
 		attrs = append(attrs, fmt.Sprintf("on_failure=%s", dotQuote(w.Defaults.OnFailure)))
 	}
+	appendBudgetGraphAttrs(&attrs, w.Defaults)
 
 	// Add workflow vars (excluding reserved graph attributes)
 	addGraphVarsAttrs(&attrs, w.Vars)
 
 	return attrs
+}
+
+// appendBudgetGraphAttrs emits the workflow budget defaults as DOT graph
+// attributes. Each is omitted when unset (0) so absence round-trips. Durations
+// use formatDuration (the compact Go-duration literal the migrate path parses
+// back with time.ParseDuration), NOT time.Duration.String().
+func appendBudgetGraphAttrs(attrs *[]string, d ir.WorkflowDefaults) {
+	if d.MaxTotalTokens != 0 {
+		*attrs = append(*attrs, fmt.Sprintf("max_total_tokens=%s", dotQuote(fmt.Sprintf("%d", d.MaxTotalTokens))))
+	}
+	if d.MaxCostCents != 0 {
+		*attrs = append(*attrs, fmt.Sprintf("max_cost_cents=%s", dotQuote(fmt.Sprintf("%d", d.MaxCostCents))))
+	}
+	if d.MaxWallTime != 0 {
+		*attrs = append(*attrs, fmt.Sprintf("max_wall_time=%s", dotQuote(formatDuration(d.MaxWallTime))))
+	}
+	if d.StallTimeout != 0 {
+		*attrs = append(*attrs, fmt.Sprintf("stall_timeout=%s", dotQuote(formatDuration(d.StallTimeout))))
+	}
 }
 
 // addGraphVarsAttrs adds workflow vars as graph attributes, excluding reserved keys.

--- a/export/dot_test.go
+++ b/export/dot_test.go
@@ -1567,6 +1567,43 @@ func TestExportDOTToolRoutingOmitWhenZero(t *testing.T) {
 	}
 }
 
+func TestExportBudgetDefaults(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "B", Start: "A", Exit: "A",
+		Defaults: ir.WorkflowDefaults{
+			MaxTotalTokens: 500000,
+			MaxCostCents:   1000,
+			MaxWallTime:    30 * time.Minute,
+			StallTimeout:   5 * time.Minute,
+		},
+		Nodes: []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "x"}}},
+		Edges: []*ir.Edge{{From: "A", To: "A"}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+	for _, want := range []string{
+		`max_total_tokens="500000"`,
+		`max_cost_cents="1000"`,
+		`max_wall_time="30m"`,
+		`stall_timeout="5m"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %s in DOT, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestExportBudgetDefaultsOmitEmpty(t *testing.T) {
+	w := &ir.Workflow{
+		Name: "B", Start: "A", Exit: "A",
+		Nodes: []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "x"}}},
+		Edges: []*ir.Edge{{From: "A", To: "A"}},
+	}
+	out := ExportDOT(w, ExportOptions{})
+	if strings.Contains(out, "stall_timeout") || strings.Contains(out, "max_total_tokens") {
+		t.Errorf("unset budget fields must not be emitted, got:\n%s", out)
+	}
+}
+
 func TestExportAgentWritablePaths(t *testing.T) {
 	w := &ir.Workflow{
 		Name: "T", Start: "A", Exit: "A",

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -200,6 +200,9 @@ func writeDefaultsBudgetFields(wr *writer, d ir.WorkflowDefaults) {
 	if d.MaxWallTime != 0 {
 		wr.line("max_wall_time: %s", formatDuration(d.MaxWallTime))
 	}
+	if d.StallTimeout != 0 {
+		wr.line("stall_timeout: %s", formatDuration(d.StallTimeout))
+	}
 	writeDefaultsToolSafetyFields(wr, d)
 }
 

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -189,7 +189,8 @@ func writeDefaultsCompactionFields(wr *writer, d ir.WorkflowDefaults) {
 	writeDefaultsBudgetFields(wr, d)
 }
 
-// writeDefaultsBudgetFields writes max_total_tokens, max_cost_cents, and max_wall_time.
+// writeDefaultsBudgetFields writes max_total_tokens, max_cost_cents, max_wall_time,
+// and stall_timeout, then delegates to writeDefaultsToolSafetyFields.
 func writeDefaultsBudgetFields(wr *writer, d ir.WorkflowDefaults) {
 	if d.MaxTotalTokens != 0 {
 		wr.line("max_total_tokens: %d", d.MaxTotalTokens)

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -2227,3 +2227,16 @@ func TestFormatAgentWritablePathsRoundTrips(t *testing.T) {
 		t.Errorf("WritablePaths after format round-trip = %v, want [workspace/** .ai/sprints/**]", got)
 	}
 }
+
+func TestFormatDurationNegativeRoundTrips(t *testing.T) {
+	for _, d := range []time.Duration{-5 * time.Minute, -30 * time.Second} {
+		s := formatDuration(d)
+		got, err := time.ParseDuration(s)
+		if err != nil {
+			t.Fatalf("formatDuration(%v) = %q, not re-parseable: %v", d, s, err)
+		}
+		if got != d {
+			t.Errorf("round-trip: formatDuration(%v) = %q -> %v, want %v", d, s, got, d)
+		}
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -52,6 +52,7 @@ type WorkflowDefaults struct {
 	MaxTotalTokens    int           // Hard ceiling on total tokens
 	MaxCostCents      int           // Hard ceiling on cost in cents (USD)
 	MaxWallTime       time.Duration // Hard ceiling on wall time
+	StallTimeout      time.Duration // Abort/route when no progress for this wall-clock span (0 = disabled)
 	ToolCommandsAllow string        // Comma-separated glob allowlist for tool shell commands
 	ToolDenylistAdd   string        // Comma-separated globs appended to the runtime's default denylist
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -190,6 +190,8 @@ func applyIntBudgetDefault(k, v string, w *ir.Workflow) bool {
 		return tryApplyIntDefault(v, &w.Defaults.MaxCostCents)
 	case "max_wall_time":
 		return tryApplyDurationDefault(v, &w.Defaults.MaxWallTime)
+	case "stall_timeout":
+		return tryApplyDurationDefault(v, &w.Defaults.StallTimeout)
 	default:
 		return false
 	}

--- a/migrate/roundtrip_test.go
+++ b/migrate/roundtrip_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/2389-research/dippin-lang/export"
 	"github.com/2389-research/dippin-lang/ir"
@@ -507,5 +508,87 @@ func TestMigrateAgentWritablePaths(t *testing.T) {
 	cfg := got.Node("A").Config.(ir.AgentConfig)
 	if len(cfg.WritablePaths) != 2 || cfg.WritablePaths[0] != "workspace/**" || cfg.WritablePaths[1] != ".ai/**" {
 		t.Errorf("WritablePaths after migrate = %v, want [workspace/** .ai/**]", cfg.WritablePaths)
+	}
+}
+
+// TestRoundTripBudgetDefaults verifies all four budget defaults round-trip
+// losslessly through parse -> ExportDOT -> Migrate. Asserts Duration equality,
+// never source-string equality (90s normalizes to 1m30s).
+func TestRoundTripBudgetDefaults(t *testing.T) {
+	src := `workflow Budget
+  goal: "round trip"
+  start: A
+  exit: A
+
+  defaults
+    max_total_tokens: 500000
+    max_cost_cents: 1000
+    max_wall_time: 30m
+    stall_timeout: 90s
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A
+`
+	w1, err := dipparser.NewParser(src, "rt.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dot := export.ExportDOT(w1, export.ExportOptions{})
+	w2, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("migrate: %v\nDOT:\n%s", err, dot)
+	}
+	d := w2.Defaults
+	if d.MaxTotalTokens != 500000 {
+		t.Errorf("max_total_tokens = %d, want 500000; DOT:\n%s", d.MaxTotalTokens, dot)
+	}
+	if d.MaxCostCents != 1000 {
+		t.Errorf("max_cost_cents = %d, want 1000; DOT:\n%s", d.MaxCostCents, dot)
+	}
+	if d.MaxWallTime != 30*time.Minute {
+		t.Errorf("max_wall_time = %v, want 30m0s; DOT:\n%s", d.MaxWallTime, dot)
+	}
+	if d.StallTimeout != 90*time.Second {
+		t.Errorf("stall_timeout = %v, want 1m30s; DOT:\n%s", d.StallTimeout, dot)
+	}
+}
+
+// TestRoundTripStallTimeoutVarsCollision verifies a vars entry named
+// stall_timeout is treated as reserved (not double-emitted / not migrated to Vars).
+func TestRoundTripStallTimeoutVarsCollision(t *testing.T) {
+	src := `workflow Collide
+  goal: "round trip"
+  start: A
+  exit: A
+
+  defaults
+    stall_timeout: 5m
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A
+`
+	w1, err := dipparser.NewParser(src, "rt.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dot := export.ExportDOT(w1, export.ExportOptions{})
+	if strings.Count(dot, "stall_timeout") != 1 {
+		t.Errorf("stall_timeout should appear exactly once in DOT, got:\n%s", dot)
+	}
+	w2, err := Migrate(dot)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if w2.Defaults.StallTimeout != 5*time.Minute {
+		t.Errorf("stall_timeout = %v, want 5m0s", w2.Defaults.StallTimeout)
+	}
+	if _, ok := w2.Vars["stall_timeout"]; ok {
+		t.Errorf("stall_timeout leaked into Vars: %v", w2.Vars)
 	}
 }

--- a/parser/parse_defaults.go
+++ b/parser/parse_defaults.go
@@ -139,6 +139,8 @@ func (p *Parser) applyDefaultBudgetField(key, val string, loc ir.SourceLocation)
 		p.workflow.Defaults.MaxCostCents = p.parseInt(val, key, loc)
 	case "max_wall_time":
 		p.workflow.Defaults.MaxWallTime = p.parseDuration(val, key, loc)
+	case "stall_timeout":
+		p.workflow.Defaults.StallTimeout = p.parseDuration(val, key, loc)
 	default:
 		p.diagnostics = append(p.diagnostics,
 			fmt.Sprintf("unknown defaults field %q at %d:%d", key, loc.Line, loc.Column))

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1677,6 +1677,9 @@ func TestParseDefaultsBudgetRoundTrip(t *testing.T) {
 	if d.MaxWallTime != 30*time.Minute {
 		t.Errorf("round-trip: max_wall_time = %v, want 30m0s", d.MaxWallTime)
 	}
+	if d.StallTimeout != 5*time.Minute {
+		t.Errorf("round-trip: stall_timeout = %v, want 5m0s", d.StallTimeout)
+	}
 }
 
 func TestParseDefaultsOnFailureRoundTrip(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1571,6 +1571,41 @@ func TestParseDefaultsBudget(t *testing.T) {
 	}
 }
 
+func TestParseDefaultsStallTimeout(t *testing.T) {
+	w := parseFixture(t, "defaults_budget.dip")
+	if w.Defaults.StallTimeout != 5*time.Minute {
+		t.Errorf("stall_timeout = %v, want 5m0s", w.Defaults.StallTimeout)
+	}
+}
+
+func TestParseDefaultsNegativeBudgetNoStructuralError(t *testing.T) {
+	src := `workflow Neg
+  goal: "g"
+  start: A
+  exit: A
+
+  defaults
+    max_cost_cents: -5
+    stall_timeout: -5m
+
+  agent A
+    prompt: "Do it."
+
+  edges
+    A -> A
+`
+	w, err := NewParser(src, "neg.dip").Parse()
+	if err != nil {
+		t.Fatalf("negative budget must parse without a structural error, got: %v", err)
+	}
+	if w.Defaults.MaxCostCents != -5 {
+		t.Errorf("max_cost_cents = %d, want -5", w.Defaults.MaxCostCents)
+	}
+	if w.Defaults.StallTimeout != -5*time.Minute {
+		t.Errorf("stall_timeout = %v, want -5m0s", w.Defaults.StallTimeout)
+	}
+}
+
 func TestParseHumanTimeout(t *testing.T) {
 	w := parseFixture(t, "human_timeout.dip")
 	gate := findNode(t, w, "Gate")

--- a/parser/testdata/defaults_budget.dip
+++ b/parser/testdata/defaults_budget.dip
@@ -8,6 +8,7 @@ workflow DefaultsBudget
     max_total_tokens: 500000
     max_cost_cents: 1000
     max_wall_time: 30m
+    stall_timeout: 5m
 
   agent A
     prompt: "Do it."

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -253,6 +253,13 @@ func configExplanations() map[string]Explanation {
 			Fix:     "Use a valid reasoning_effort: none, minimal, low, medium, high, xhigh, or max.",
 			Example: "node A { reasoning_effort extreme }  // invalid value",
 		},
+		DIP145: {
+			Code:    DIP145,
+			Summary: "graph budget default is negative",
+			Trigger: "A workflow budget default (max_total_tokens, max_cost_cents, max_wall_time, or stall_timeout) is set to a negative value.",
+			Fix:     "Use a positive cap, or omit the field / set 0 to mean no limit.",
+			Example: "defaults\n  max_cost_cents: -5    // DIP145: negative; use a positive cap or 0 for no limit",
+		},
 	}
 }
 

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -5,7 +5,7 @@ import (
 	"github.com/2389-research/dippin-lang/simulate"
 )
 
-// Lint runs all semantic quality checks (DIP101–DIP144) on the workflow
+// Lint runs all semantic quality checks (DIP101–DIP145) on the workflow
 // and returns all diagnostics found. These are warnings, not errors —
 // the workflow can still execute, but the findings indicate likely bugs
 // or quality issues.
@@ -61,6 +61,7 @@ func Lint(w *ir.Workflow) Result {
 	diags = append(diags, lintWritablePaths(w)...)
 	diags = append(diags, lintSubgraphToolAccess(w)...)
 	diags = append(diags, lintAgentFailureRoute(w)...)
+	diags = append(diags, lintBudgetRanges(w)...)
 
 	return Result{Diagnostics: diags}
 }

--- a/validator/lint_budget.go
+++ b/validator/lint_budget.go
@@ -1,0 +1,37 @@
+package validator
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// lintBudgetRanges checks DIP145: a graph-level budget default must not be
+// negative. Zero means "unset / no limit" (the formatter emits only non-zero
+// values), so only values < 0 are flagged. Integer fields use %d; duration
+// fields use time.Duration.String() so messages are human-readable.
+func lintBudgetRanges(w *ir.Workflow) []Diagnostic {
+	d := w.Defaults
+	checks := []struct {
+		name string
+		neg  bool
+		val  string
+	}{
+		{"max_total_tokens", d.MaxTotalTokens < 0, fmt.Sprintf("%d", d.MaxTotalTokens)},
+		{"max_cost_cents", d.MaxCostCents < 0, fmt.Sprintf("%d", d.MaxCostCents)},
+		{"max_wall_time", d.MaxWallTime < 0, d.MaxWallTime.String()},
+		{"stall_timeout", d.StallTimeout < 0, d.StallTimeout.String()},
+	}
+	var diags []Diagnostic
+	for _, c := range checks {
+		if c.neg {
+			diags = append(diags, Diagnostic{
+				Code:     DIP145,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("workflow budget default %s is %s; budgets cannot be negative", c.name, c.val),
+				Help:     "use a positive cap (e.g. max_cost_cents: 1000 for $10.00), or omit it / set 0 for no limit",
+			})
+		}
+	}
+	return diags
+}

--- a/validator/lint_budget_test.go
+++ b/validator/lint_budget_test.go
@@ -1,0 +1,86 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+func budgetTestWorkflow(d ir.WorkflowDefaults) *ir.Workflow {
+	return &ir.Workflow{
+		Name: "B", Start: "A", Exit: "A", Defaults: d,
+		Nodes: []*ir.Node{{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "x"}}},
+		Edges: []*ir.Edge{{From: "A", To: "A"}},
+	}
+}
+
+func countDiagCode(diags []Diagnostic, code string) int {
+	n := 0
+	for _, d := range diags {
+		if d.Code == code {
+			n++
+		}
+	}
+	return n
+}
+
+func TestDIP145FiresOnNegativeBudgets(t *testing.T) {
+	w := budgetTestWorkflow(ir.WorkflowDefaults{
+		MaxTotalTokens: -1,
+		MaxCostCents:   -5,
+		MaxWallTime:    -30 * time.Second,
+		StallTimeout:   -5 * time.Minute,
+	})
+	got := countDiagCode(lintBudgetRanges(w), DIP145)
+	if got != 4 {
+		t.Errorf("DIP145 count = %d, want 4 (one per negative field)", got)
+	}
+}
+
+func TestDIP145SilentOnUnsetZero(t *testing.T) {
+	w := budgetTestWorkflow(ir.WorkflowDefaults{})
+	if got := countDiagCode(lintBudgetRanges(w), DIP145); got != 0 {
+		t.Errorf("DIP145 fired on unset (0) budgets: %d, want 0", got)
+	}
+}
+
+func TestDIP145SilentOnValidPositive(t *testing.T) {
+	w := budgetTestWorkflow(ir.WorkflowDefaults{
+		MaxTotalTokens: 500000,
+		MaxCostCents:   1000,
+		MaxWallTime:    30 * time.Minute,
+		StallTimeout:   5 * time.Minute,
+	})
+	if got := countDiagCode(lintBudgetRanges(w), DIP145); got != 0 {
+		t.Errorf("DIP145 fired on valid positive budgets: %d, want 0", got)
+	}
+}
+
+func TestDIP145MessageNamesFieldAndValue(t *testing.T) {
+	w := budgetTestWorkflow(ir.WorkflowDefaults{MaxCostCents: -5})
+	diags := lintBudgetRanges(w)
+	if len(diags) != 1 {
+		t.Fatalf("want 1 diag, got %d", len(diags))
+	}
+	msg := diags[0].Message
+	if !strings.Contains(msg, "max_cost_cents") || !strings.Contains(msg, "-5") {
+		t.Errorf("message must name field and value, got: %q", msg)
+	}
+}
+
+func TestDIP145DurationMessageIsReadable(t *testing.T) {
+	w := budgetTestWorkflow(ir.WorkflowDefaults{StallTimeout: -5 * time.Minute})
+	diags := lintBudgetRanges(w)
+	if len(diags) != 1 {
+		t.Fatalf("want 1 diag, got %d", len(diags))
+	}
+	msg := diags[0].Message
+	if !strings.Contains(msg, "-5m") {
+		t.Errorf("duration message must be human-readable (contain -5m), got: %q", msg)
+	}
+	if strings.Contains(msg, "300000000000") {
+		t.Errorf("duration message must NOT show raw nanoseconds, got: %q", msg)
+	}
+}

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP144).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP145).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge
@@ -46,6 +46,7 @@ const (
 	DIP142 = "DIP142" // unsafe writable_paths entry (absolute / ~ / parent-escape / brace)
 	DIP143 = "DIP143" // referenced subgraph does not inherit this workflow's tool_access restrictions
 	DIP144 = "DIP144" // agent node has no failure route
+	DIP145 = "DIP145" // graph budget default is negative
 )
 
 func init() {
@@ -94,4 +95,5 @@ func init() {
 	CodeDescription[DIP142] = "unsafe writable_paths entry (absolute / ~ / parent-escape / brace)"
 	CodeDescription[DIP143] = "referenced subgraph does not inherit this workflow's tool_access restrictions"
 	CodeDescription[DIP144] = "agent node has no failure route"
+	CodeDescription[DIP145] = "graph budget default is negative"
 }


### PR DESCRIPTION
## Summary

Closes #94. Makes runtime budget guards declarable in `.dip` and gives `max_turns` defined exhaustion semantics. **dippin carries + validates + lints; the tracker runtime enforces** — every new field is inert until the tracker reads it, and (per the project's `never-gate-dippin-on-tracker` principle) no dippin behavior is gated on tracker readiness. Sibling of the just-merged `on_failure` work (#95 / #92 #93); budget/stall/turn failures route through that same graph-level cascade.

Design + plan + expert-panel review notes: `docs/superpowers/specs/2026-06-04-issue-94-budget-attrs-design.md`, `docs/superpowers/plans/2026-06-04-issue-94-budget-attrs.md`.

## What changed

**New graph default `stall_timeout` (`time.Duration`).** Abort/route when no forward progress is made for a wall-clock span; `0`/unset = disabled. Flows through all four round-trip surfaces exactly like its sibling `max_wall_time`: parser → formatter → DOT export → migrate.
- **Naming:** the issue sketched `no_progress_window`, but `_window` reads as an iteration *count*, mismatching the duration type. Renamed to **`stall_timeout`** (consistent with the repo's `cmd_timeout`). This is a *new* cross-repo key the tracker has never seen — spelled once, everywhere.

**`max_turns` exhaustion semantics (docs-only).** Reaching `max_turns` now has defined behavior: outcome = `fail`, routed through the existing failure cascade (fail edge → bounded retry → `fallback_target` → graph `on_failure` → halt). **No new action field** — the issue asked for the action to be "*ideally* configurable"; an inert `fail|truncate|fallback` enum is the speculative config we decline (YAGNI). Documented in `docs/nodes.md` (+ a `max_turns exhaustion` subsection) and `docs/edges.md` (cascade failure sources), with a bidirectional DIP144 cross-link.

**Closed a pre-existing DOT export data-loss bug.** `buildGraphAttrs` emitted *none* of the budget fields, even though they migrate *in* and are reserved — so `.dip → DOT` silently dropped every budget ceiling. Now emits all four (the 3 pre-existing + `stall_timeout`) via an extracted `appendBudgetGraphAttrs` helper (extraction is mandatory: inlining would bust the cyclo ≤5 gate). Budget ceilings are safety-relevant — same round-trip-with-test treatment `on_failure` got in #95.

**New lint DIP145 (warning).** Fires when any graph budget default is **negative** (`< 0`). **`0` = unset = no warning** for all four (matches the formatter's `!= 0` emit guard — getting this wrong would false-positive on every workflow that omits a budget). Table-driven; messages name the field + a readable value (`stall_timeout is -5m0s`, not raw nanoseconds) and the Help text states the `0 = no limit` convention so authors don't "fix" a negative by setting `0` (which means *unlimited*). Mirrors the existing DIP136 (negative manager_loop control field).

**Per-node budgets: deferred** (YAGNI; `max_turns` stays the only per-node knob; tracker #67's contract is graph-level). Named explicitly in the spec's Out-of-scope.

## Blast radius

No existing example sets any budget default; only `stress_edge_cases.dip` uses `max_turns` (valid) — so **DIP145 fires on zero existing examples**. Added one new lint-clean example, `examples/budget_guards.dip` (cost ceiling + stall window + `max_turns` layered on a graph `on_failure`), demonstrating the feature end-to-end. DIP count strings bumped 53→54 / 48→49 documented / `DIP101–DIP144`→`DIP101–DIP145`; generated spec regenerated.

## Cross-repo follow-up (tracker — separate repo)

This PR is dippin-side only. A tracker `upstream` follow-up (extending the existing `on_failure` follow-up) is needed to unblock tracker #67: the adapter (`pipeline/dippin_adapter.go` `extractWorkflowDefaults`) copies the now-exported budget keys + the new `stall_timeout` into `graph.Attrs`, and budget/stall abort routes through the `on_failure` cascade. **Wire-format contract:** `max_wall_time`/`stall_timeout` cross the boundary as Go `time.ParseDuration` literals (compact form, e.g. `5m`); `max_total_tokens`/`max_cost_cents` as plain integers.

## Test Plan

- [x] `just test-race` — all packages green (parser, formatter, export, migrate, validator)
- [x] Round-trip tests assert typed `time.Duration` equality (incl. the `90s`→`1m30s` normalization case) and a vars-named-`stall_timeout` collision guard
- [x] DIP145: fires per negative field, silent on `0`/unset, silent on positive, readable duration message — verified end-to-end via `dippin lint`
- [x] `just complexity` (cyclo ≤5 / cognit ≤7) — `appendBudgetGraphAttrs` extraction keeps `buildGraphAttrs` under the gate
- [x] `just wasm` + `GOOS=js GOARCH=wasm go build ./validator/` (Netlify preview gate)
- [x] `just validate-examples` / `just lint-examples` — new example lint-clean, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783267660&installation_id=131176874&pr_number=96&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F96&signature=70e37aa63acdbdb7a9b1b53e8c49bcf8b5049d53e592ee4199693de6417dedf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `stall_timeout` workflow default for declaring inactivity timeout thresholds
  * Added DIP145 lint warning to catch negative budget defaults

* **Documentation**
  * Expanded workflow defaults documentation covering `max_total_tokens`, `max_cost_cents`, `max_wall_time`, and `stall_timeout`
  * Clarified `max_turns` exhaustion behavior and failure cascade routing semantics
  * Added new example workflow demonstrating budget guards and escalation patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->