### PR TITLE
fix: surface unparseable edge conditions as DIP010 (Closes #98)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Editor / agent integrations:
 ```sh
 dippin parse pipeline.dip          # JSON IR
 dippin validate pipeline.dip       # structural errors (DIP001-DIP010)
-dippin lint pipeline.dip           # semantic warnings (DIP101-DIP146)
+dippin lint pipeline.dip           # validation + semantic warnings (DIP101-DIP146)
 dippin format pipeline.dip         # canonical formatting
 dippin doctor pipeline.dip         # A-F health report
 dippin cost pipeline.dip           # per-run cost estimate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Editor / agent integrations:
 ```sh
 dippin parse pipeline.dip          # JSON IR
 dippin validate pipeline.dip       # structural errors (DIP001-DIP010)
-dippin lint pipeline.dip           # semantic warnings (DIP101-DIP133)
+dippin lint pipeline.dip           # semantic warnings (DIP101-DIP146)
 dippin format pipeline.dip         # canonical formatting
 dippin doctor pipeline.dip         # A-F health report
 dippin cost pipeline.dip           # per-run cost estimate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Editor / agent integrations:
 
 ```sh
 dippin parse pipeline.dip          # JSON IR
-dippin validate pipeline.dip       # structural errors (DIP001-DIP009)
+dippin validate pipeline.dip       # structural errors (DIP001-DIP010)
 dippin lint pipeline.dip           # semantic warnings (DIP101-DIP133)
 dippin format pipeline.dip         # canonical formatting
 dippin doctor pipeline.dip         # A-F health report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+Dippin-side only — pure detection, no paired runtime release required.
+
+### Added
+- `DIP010` (Error) — an edge `when` condition that cannot be parsed (e.g. an unknown operator, or a tool-node field like `marker_grep` used in operator position) ([#98](https://github.com/2389-research/dippin-lang/issues/98)). Previously the parse error was discarded by `Lint()` and `EnsureConditionsParsed` stopped at the first bad edge, so `validate`/`lint`/`check`/`doctor` greenlit a workflow that hard-fails at `dippin simulate` — and every edge after the first bad one silently lost its AST-dependent lints (DIP103/120/121/122). DIP010 is emitted from `validator.Validate()`, so every command path catches it, and parsing now continues past failures (one diagnostic per bad edge; later edges keep getting linted). Edge conditions only; `manager_loop` node conditions are a separate follow-up.
+
+### Changed
+- `dippin doctor` now exits non-zero when the report contains errors (e.g. DIP010 or any structural DIP001–DIP010), rather than always exiting 0. The report still renders in full; only the exit code changes, so doctor no longer greenlights a workflow that cannot execute.
+
 ## [v0.36.0] — 2026-06-03
 
 Dippin-side only — no paired runtime release required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistr
 
 ## Lint Rules
 
-55 diagnostic codes: DIP001-DIP009 (structural errors), DIP101-DIP146 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
+56 diagnostic codes: DIP001-DIP010 (structural errors), DIP101-DIP146 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ graph LR
 | Shell scripts | `tool_command="#!/bin/sh\nset -eu\nif..."` | Real multiline, real syntax |
 | Model config | Untyped `llm_model="..."` attribute | Typed `model:` field with validation |
 | Branching | `condition="context.x!=y && context.a==b"` | `when ctx.x != "y" and ctx.a == "b"` |
-| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP137) |
+| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP146) |
 | Node types | Shape overloading (`box`=agent, `hexagon`=human) | Explicit `agent`, `tool`, `human` keywords |
 | Composition | No import/include system | `subgraph` with ref (v2) |
 
@@ -131,7 +131,7 @@ Every analysis command (`validate`, `lint`, `doctor`, `parse`, `cost`, `coverage
 |---------|-------------|
 | `dippin parse <file>` | Parse and output IR as JSON |
 | `dippin validate <file>` | Structural validation (DIP001–DIP010) |
-| `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP133) |
+| `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP146) |
 | `dippin check [--format json\|text] <file>` | Parse+validate+lint in one shot (JSON default, for LLM tooling) |
 | `dippin fmt [--check] [--write] <file>` | Format to canonical style |
 | `dippin new [--name N] [--write F] <template>` | Generate a starter .dip from a template |
@@ -390,7 +390,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 | DIP008 | Duplicate node ID |
 | DIP009 | Duplicate edge |
 
-### Warnings (DIP101–DIP133)
+### Warnings (DIP101–DIP146)
 
 | Code | What it catches |
 |------|----------------|

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ Everything flows through `ir.Workflow` — the canonical intermediate representa
 |---------|-------------|
 | `ir/` | Core types: `Workflow`, `Node`, `Edge`, `Condition` AST, typed `NodeConfig` sealed interface |
 | `parser/` | Indentation-aware lexer + recursive-descent parser producing IR |
-| `validator/` | 10 structural checks + 30 semantic lint rules |
+| `validator/` | 10 structural checks + 46 semantic lint rules |
 | `formatter/` | Canonical pretty-printer (idempotent: `format(format(x)) == format(x)`) |
 | `export/` | DOT export with shape mapping, condition serialization, restart edge styling |
 | `migrate/` | DOT→IR→Dippin converter with namespace prefixing and structural parity checker |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ graph LR
 | Shell scripts | `tool_command="#!/bin/sh\nset -eu\nif..."` | Real multiline, real syntax |
 | Model config | Untyped `llm_model="..."` attribute | Typed `model:` field with validation |
 | Branching | `condition="context.x!=y && context.a==b"` | `when ctx.x != "y" and ctx.a == "b"` |
-| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP009, DIP101–DIP137) |
+| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP137) |
 | Node types | Shape overloading (`box`=agent, `hexagon`=human) | Explicit `agent`, `tool`, `human` keywords |
 | Composition | No import/include system | `subgraph` with ref (v2) |
 
@@ -130,7 +130,7 @@ Every analysis command (`validate`, `lint`, `doctor`, `parse`, `cost`, `coverage
 | Command | Description |
 |---------|-------------|
 | `dippin parse <file>` | Parse and output IR as JSON |
-| `dippin validate <file>` | Structural validation (DIP001–DIP009) |
+| `dippin validate <file>` | Structural validation (DIP001–DIP010) |
 | `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP133) |
 | `dippin check [--format json\|text] <file>` | Parse+validate+lint in one shot (JSON default, for LLM tooling) |
 | `dippin fmt [--check] [--write] <file>` | Format to canonical style |
@@ -376,7 +376,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
   = help: did you mean "Interpret"? (declared at line 12)
 ```
 
-### Errors (DIP001–DIP009)
+### Errors (DIP001–DIP010)
 
 | Code | What it catches |
 |------|----------------|
@@ -525,7 +525,7 @@ Everything flows through `ir.Workflow` — the canonical intermediate representa
 |---------|-------------|
 | `ir/` | Core types: `Workflow`, `Node`, `Edge`, `Condition` AST, typed `NodeConfig` sealed interface |
 | `parser/` | Indentation-aware lexer + recursive-descent parser producing IR |
-| `validator/` | 9 structural checks + 30 semantic lint rules |
+| `validator/` | 10 structural checks + 30 semantic lint rules |
 | `formatter/` | Canonical pretty-printer (idempotent: `format(format(x)) == format(x)`) |
 | `export/` | DOT export with shape mapping, condition serialization, restart edge styling |
 | `migrate/` | DOT→IR→Dippin converter with namespace prefixing and structural parity checker |

--- a/cmd/dippin/cli.go
+++ b/cmd/dippin/cli.go
@@ -174,7 +174,7 @@ func printGlobalUsage(w io.Writer) {
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "commands:")
 	fmt.Fprintln(w, "  parse <file>                      Parse and output IR as JSON")
-	fmt.Fprintln(w, "  validate <file>                   Run structural validation (DIP001-DIP009)")
+	fmt.Fprintln(w, "  validate <file>                   Run structural validation (DIP001-DIP010)")
 	fmt.Fprintln(w, "  lint <file>                       Run validation and semantic linting")
 	fmt.Fprintln(w, "  check [--format text|json] <file> Parse+validate+lint (JSON default, for LLM tooling)")
 	fmt.Fprintln(w, "  fmt [--check] [--write] <file>    Format a .dip file")

--- a/cmd/dippin/cmd_doctor.go
+++ b/cmd/dippin/cmd_doctor.go
@@ -37,12 +37,21 @@ func (c *CLI) CmdDoctor(args []string) ExitCode {
 	return c.renderDoctorReport(report)
 }
 
-// renderDoctorReport outputs the doctor report in the selected format.
+// renderDoctorReport outputs the doctor report in the selected format and
+// exits non-zero when the report contains errors — a workflow that fails
+// structural validation (e.g. DIP010) cannot execute, so doctor must not
+// greenlight it. Warnings/hints alone still exit OK.
 func (c *CLI) renderDoctorReport(r *doctor.Report) ExitCode {
 	if c.Format == FormatJSON {
-		return c.renderJSON(r)
+		if code := c.renderJSON(r); code != ExitOK {
+			return code
+		}
+	} else {
+		renderDoctorText(c.Stdout, r)
 	}
-	renderDoctorText(c.Stdout, r)
+	if r.Lint.Errors > 0 {
+		return ExitError
+	}
 	return ExitOK
 }
 

--- a/cmd/dippin/cmd_pack.go
+++ b/cmd/dippin/cmd_pack.go
@@ -76,7 +76,7 @@ func dispatchPack(stdout, stderr io.Writer, shadowEntry, dest string, dryRun boo
 	return packToFile(stderr, ctx, shadowEntry, dest)
 }
 
-// validateEntryPrePack runs structural validation (DIP001-DIP009) on the entry
+// validateEntryPrePack runs structural validation (DIP001-DIP010) on the entry
 // workflow before invoking dipx.Pack. Per spec § "CLI", pack "runs structural
 // validation first (same checks as `dippin validate`); refuses to pack invalid
 // input." This lives at the CLI layer (not inside dipx) because the spec's

--- a/cmd/dippin/cmd_pack_test.go
+++ b/cmd/dippin/cmd_pack_test.go
@@ -109,7 +109,7 @@ func TestRunPack_NoArgs(t *testing.T) {
 }
 
 // TestRunPack_RejectsInvalidWorkflow confirms Fix H1: pack runs structural
-// validation (DIP001-DIP009) on the entry workflow first and refuses to pack
+// validation (DIP001-DIP010) on the entry workflow first and refuses to pack
 // when validation errors are present. Here the workflow declares exit: S but
 // "S" has no outgoing edges (DIP004 would fire if there were unreachable nodes,
 // or DIP002 if exit references a missing node, etc.). The workflow below

--- a/cmd/dippin/cmd_validate.go
+++ b/cmd/dippin/cmd_validate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/2389-research/dippin-lang/validator"
 )
 
-// CmdValidate runs structural validation (DIP001-DIP009) on a workflow.
+// CmdValidate runs structural validation (DIP001-DIP010) on a workflow.
 func (c *CLI) CmdValidate(args []string) ExitCode {
 	path, code := parseSingleFileArg("validate", "usage: dippin validate <file>", args, c.Stderr)
 	if code != ExitCode(-1) {

--- a/cmd/dippin/cmd_validate_conditions_test.go
+++ b/cmd/dippin/cmd_validate_conditions_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// reproDIP010 is the issue #98 repro: an edge using a tool-node field
+// (marker_grep) as an operator is unparseable.
+const reproDIP010 = `workflow Repro
+  goal: "repro"
+  start: A
+  exit: Z
+
+  tool A
+    command: "echo ok"
+  agent Z
+    prompt: "done"
+
+  edges
+    A -> Z when marker_grep "^ok"
+`
+
+func writeRepro(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "repro.dip")
+	if err := os.WriteFile(p, []byte(reproDIP010), 0o644); err != nil {
+		t.Fatalf("write repro: %v", err)
+	}
+	return p
+}
+
+// TestCmdValidate_DIP010 — validate must now FAIL (exit 1) and report DIP010 on
+// stderr, where it previously passed silently.
+func TestCmdValidate_DIP010(t *testing.T) {
+	_, stderr, code := runCLI(t, "validate", writeRepro(t))
+	if code != ExitError {
+		t.Fatalf("want ExitError, got %d; stderr: %s", code, stderr)
+	}
+	if !strings.Contains(stderr, "error[DIP010]") {
+		t.Errorf("expected error[DIP010] on stderr, got:\n%s", stderr)
+	}
+}
+
+// TestCmdCheck_DIP010 — check writes diagnostics to stdout (text format) and
+// exits non-zero on errors.
+func TestCmdCheck_DIP010(t *testing.T) {
+	stdout, _, code := runCLI(t, "check", "--format", "text", writeRepro(t))
+	if code != ExitError {
+		t.Fatalf("want ExitError, got %d", code)
+	}
+	if !strings.Contains(stdout, "error[DIP010]") {
+		t.Errorf("expected error[DIP010] on stdout, got:\n%s", stdout)
+	}
+}
+
+// TestCmdDoctor_DIP010 — doctor now exits non-zero when the report contains
+// errors (the workflow can't execute), rather than always returning OK.
+func TestCmdDoctor_DIP010(t *testing.T) {
+	stdout, stderr, code := runCLI(t, "doctor", writeRepro(t))
+	if code != ExitError {
+		t.Fatalf("want ExitError from doctor on a workflow with errors, got %d; stderr: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "Health Report") {
+		t.Errorf("expected the health report to still render, got:\n%s", stdout)
+	}
+}

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -561,7 +561,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP145) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP146) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -189,9 +189,9 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-55 diagnostic codes across two categories:
+56 diagnostic codes across two categories:
 
-- **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
+- **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
 - **DIP101–DIP146** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access
 
 ---
@@ -560,7 +560,7 @@ Use `dippin help` (not `--help`) to see all commands.
 | Command | Purpose |
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
-| `dippin validate <file>` | Structural checks only (DIP001-DIP009) |
+| `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
 | `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP145) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |

--- a/cmd/dippin/main_test.go
+++ b/cmd/dippin/main_test.go
@@ -2004,11 +2004,13 @@ func TestCmdCoverage_NoConds(t *testing.T) {
 // --- renderDoctorSuggestions (cmd_doctor.go:79) ---
 
 func TestCmdDoctor_WithSuggestions(t *testing.T) {
-	// unhealthy.dip has lint warnings + unreachable node -> generates suggestions.
+	// unhealthy.dip has lint warnings + an unreachable node (DIP004, an error) ->
+	// generates suggestions. doctor renders the report but exits non-zero because
+	// the report contains errors.
 	stdout, stderr, code := runCLI(t, "doctor", testdata("unhealthy.dip"))
 
-	if code != ExitOK {
-		t.Fatalf("expected exit 0, got %d; stderr: %s", code, stderr)
+	if code != ExitError {
+		t.Fatalf("expected ExitError (report has DIP004), got %d; stderr: %s", code, stderr)
 	}
 	if !strings.Contains(stdout, "Suggestions") {
 		t.Errorf("expected 'Suggestions' section in output, got: %s", stdout)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ dippin-lang/
 │
 ├── validator/          # Graph validation + semantic linting
 │   ├── codes.go        # Error code constants (DIP001–DIP010)
-│   ├── lint_codes.go   # Warning code constants (DIP101–DIP145)
+│   ├── lint_codes.go   # Warning code constants (DIP101–DIP146)
 │   ├── diagnostic.go   # Diagnostic type, Result, Severity
 │   ├── validate.go     # 10 structural checks
 │   ├── lint.go         # Lint orchestration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,10 +55,10 @@ dippin-lang/
 │   └── resolve_nofollow_other.go # oNoFollow=0 fallback (non-unix: js/wasm, Windows)
 │
 ├── validator/          # Graph validation + semantic linting
-│   ├── codes.go        # Error code constants (DIP001–DIP009)
+│   ├── codes.go        # Error code constants (DIP001–DIP010)
 │   ├── lint_codes.go   # Warning code constants (DIP101–DIP145)
 │   ├── diagnostic.go   # Diagnostic type, Result, Severity
-│   ├── validate.go     # 9 structural checks
+│   ├── validate.go     # 10 structural checks
 │   ├── lint.go         # Lint orchestration
 │   ├── lint_reachability.go  # DIP101, DIP102, DIP105, exhaustive detection
 │   ├── lint_conditions.go    # DIP103, DIP120
@@ -180,7 +180,7 @@ dippin-lang/
 
 ### Loader Tier (dipx)
 
-The `dipx` package is a bounded exception to the "packages only depend on `ir`" rule: it imports `ir + parser + simulate` to materialize a parsed, condition-normalized workflow tree from a `.dipx` bundle (or from a `.dip` on disk via `dirSource`). It MUST NOT import `validator`, `cost`, `formatter`, or any analysis package — that would invert the analysis dependency direction. Pack-time structural validation (DIP001–DIP009) is therefore invoked at the CLI layer in `cmd/dippin/cmd_pack.go` (`validateEntryPrePack`), not inside `dipx` itself.
+The `dipx` package is a bounded exception to the "packages only depend on `ir`" rule: it imports `ir + parser + simulate` to materialize a parsed, condition-normalized workflow tree from a `.dipx` bundle (or from a `.dip` on disk via `dirSource`). It MUST NOT import `validator`, `cost`, `formatter`, or any analysis package — that would invert the analysis dependency direction. Pack-time structural validation (DIP001–DIP010) is therefore invoked at the CLI layer in `cmd/dippin/cmd_pack.go` (`validateEntryPrePack`), not inside `dipx` itself.
 
 The package's central type-encoded ordering invariant is `verifiedBytes`: an unexported wrapper produced exclusively by the hash-verification step. The Open pathway's `parser.NewParser(string(verifiedBytes.Bytes()), …)` site cannot be reached without going through hash verification first, making "parse before verify" structurally impossible. Two additional `parser.NewParser` sites exist for the dirSource and Pack pathways (which consume trusted local-disk bytes, not bundle bytes); a CI test (`TestInvariant_ParserNewParserSiteCount`) pins the total to exactly three.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -103,7 +103,7 @@ dippin validate <file>
 
 **Input**: `.dip` or `.dot` file
 
-**Checks**: The 9 structural validation rules that must pass for a workflow to be executable. See [validation.md](validation.md) for details on each code.
+**Checks**: The 10 structural validation rules that must pass for a workflow to be executable. See [validation.md](validation.md) for details on each code.
 
 **Output**:
 - If all checks pass: `"validation passed"` (text mode) or empty JSON array
@@ -124,7 +124,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 
 ### lint
 
-Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP145).
+Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP146).
 
 ```bash
 dippin lint [--extra-models <spec>] <file>
@@ -132,7 +132,7 @@ dippin lint [--extra-models <spec>] <file>
 
 **Input**: `.dip` or `.dot` file
 
-**Checks**: All 55 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP145) are reported but don't affect the exit code.
+**Checks**: All 55 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP146) are reported but don't affect the exit code.
 
 **Output**: All diagnostics (errors and warnings) to stderr.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,7 +95,7 @@ dippin parse pipeline.dip
 
 ### validate
 
-Run structural validation checks (DIP001–DIP009) on a workflow.
+Run structural validation checks (DIP001–DIP010) on a workflow.
 
 ```bash
 dippin validate <file>
@@ -124,7 +124,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 
 ### lint
 
-Run both structural validation and semantic linting (DIP001–DIP009 + DIP101–DIP145).
+Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP145).
 
 ```bash
 dippin lint [--extra-models <spec>] <file>
@@ -132,7 +132,7 @@ dippin lint [--extra-models <spec>] <file>
 
 **Input**: `.dip` or `.dot` file
 
-**Checks**: All 54 diagnostic rules. Errors (DIP001–DIP009) cause exit code 1. Warnings (DIP101–DIP145) are reported but don't affect the exit code.
+**Checks**: All 55 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP145) are reported but don't affect the exit code.
 
 **Output**: All diagnostics (errors and warnings) to stderr.
 
@@ -751,7 +751,7 @@ dippin pack [-o <output>] [--dry-run] <entry.dip>
 - `-o <path>` — output path (default: `<entry>.dipx`; `-` writes the bundle to stdout)
 - `--dry-run` — validate and walk refs without writing output
 
-**Behavior**: Runs structural validation (DIP001–DIP009) on the entry first. Walks every transitively-reachable subgraph ref under the entry's directory, computes per-file SHA-256, and writes a deterministic ZIP (fixed mtimes, sorted entries, no platform metadata, UTF-8 filename bit always set). File output is atomic — the bundle is written to a unique temp file alongside `<output>` and renamed on success. Symlinks anywhere between the entry's source root and a leaf `.dip` are refused.
+**Behavior**: Runs structural validation (DIP001–DIP010) on the entry first. Walks every transitively-reachable subgraph ref under the entry's directory, computes per-file SHA-256, and writes a deterministic ZIP (fixed mtimes, sorted entries, no platform metadata, UTF-8 filename bit always set). File output is atomic — the bundle is written to a unique temp file alongside `<output>` and renamed on success. Symlinks anywhere between the entry's source root and a leaf `.dip` are refused.
 
 **Exit codes**: bundle ladder (see *Exit Codes* above).
 

--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -18,7 +18,7 @@ This starts the server on stdio (stdin/stdout), speaking JSON-RPC 2.0 per the LS
 
 | Feature | Description |
 |---------|-------------|
-| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP145 semantic) |
+| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP146 semantic) |
 | **Hover** | Tooltip showing node kind, model, provider, prompt preview, and field summary |
 | **Go-to-definition** | Jump from a node reference in an edge to the node's declaration |
 | **Autocomplete** | Node IDs in edges, field names within node blocks, keywords |

--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -18,7 +18,7 @@ This starts the server on stdio (stdin/stdout), speaking JSON-RPC 2.0 per the LS
 
 | Feature | Description |
 |---------|-------------|
-| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP009 structural, DIP101–DIP145 semantic) |
+| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP145 semantic) |
 | **Hover** | Tooltip showing node kind, model, provider, prompt preview, and field summary |
 | **Go-to-definition** | Jump from a node reference in an edge to the node's declaration |
 | **Autocomplete** | Node IDs in edges, field names within node blocks, keywords |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -111,7 +111,7 @@ if result.HasErrors() {
     }
 }
 
-// Semantic lint (DIP101–DIP145) — warnings
+// Semantic lint (DIP101–DIP146) — warnings
 lintResult := validator.Lint(workflow)
 for _, d := range lintResult.Diagnostics {
     fmt.Println(d.String())

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -100,7 +100,7 @@ The CLI commands `lint`, `validate`, and `pack` call this automatically. Direct 
 ```go
 import "github.com/2389-research/dippin-lang/validator"
 
-// Structural checks (DIP001–DIP009) — must pass
+// Structural checks (DIP001–DIP010) — must pass
 result := validator.Validate(workflow)
 if result.HasErrors() {
     for _, d := range result.Diagnostics {

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -187,7 +187,7 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-55 diagnostic codes across two categories:
+56 diagnostic codes across two categories:
 
-- **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
+- **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
 - **DIP101–DIP146** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access

--- a/docs/superpowers/specs/2026-06-05-issue-98-unparseable-edge-condition-design.md
+++ b/docs/superpowers/specs/2026-06-05-issue-98-unparseable-edge-condition-design.md
@@ -1,0 +1,242 @@
+# DIP010 — unparseable edge condition (issue #98)
+
+**Status:** design approved (post expert-panel review)
+**Branch:** `fix/98-unparseable-edge-condition`
+**Date:** 2026-06-05
+
+## Problem
+
+`validator.Lint()` discards the error from `simulate.EnsureConditionsParsed()`
+(`validator/lint.go:20`, `_ = simulate.EnsureConditionsParsed(w)`), and that
+function early-returns on the **first** unparseable edge condition
+(`simulate/condition.go:269-281`). Consequences:
+
+1. An invalid `when …` edge condition (e.g. `A -> Z when marker_grep "^ok"`,
+   easy to write because `marker_grep` is a real tool-node field) produces **no
+   diagnostic at all**. `dippin validate`/`lint`/`check`/`doctor` greenlight a
+   file that hard-fails at `dippin simulate` and at runtime
+   (`edge A -> Z: invalid condition "marker_grep \"^ok\"": unknown operator "^ok"`).
+2. **Cascade masking:** the early-return leaves every edge *after* the bad one
+   with `Condition.Parsed == nil`. Lints that read the parsed AST then silently
+   skip those edges.
+
+### Corrected premise (from empirical panel review)
+
+The issue claims DIP101/102/103/120 are masked. That is **wrong for DIP101/102**:
+`hasUnconditionalEdge`/`allEdgesConditional`/`hasMissingDefault`
+(`lint_reachability.go:92,113,156`) test only `Condition == nil` / `!= nil` —
+they fire on *presence*, never reading `.Parsed`, so they are **not** masked.
+The lints actually masked are the `.Parsed`-dependent ones:
+
+- **DIP103** `lint_conditions.go:53`
+- **DIP120** `lint_conditions.go:126`
+- **DIP121** `lint_condition_types.go:49`
+- **DIP122** `lint_condition_types.go:115`
+- exhaustiveness/auto-suppression (`extractEqualityCondition`
+  `lint_reachability.go:312`, `hasComplementaryPair` `:357`)
+
+Empirically verified: a valid graph emits DIP120; inserting an earlier bad edge
+makes **DIP120 vanish**. This is the discriminating behavior for the cascade test.
+
+## Decisions (with rationale)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Code | **DIP010**, structural, `SeverityError` | Execution-blocking (undefined routing). DIP010 is unused; structural range is DIP001–DIP009. Mirrors DIP003 (unknown node ref is structural though "about" an edge). |
+| Where emitted | **`validator.Validate()`** | Run by every command path (validate/lint/check/watch/simulate/pack/wasm/doctor/test/lsp). One check, caught everywhere. Sidesteps the four-CLI-paths gotcha. |
+| Accumulate-all | **Validator parses edges itself** via `simulate.ParseCondition` (option c) | Only approach yielding one diagnostic *per* bad edge. Leaves `EnsureConditionsParsed` + its 6 callers **untouched**. No `simulate` API change; wasm-safe (`ParseCondition` is pure string→AST). |
+| Scope | **Edges only** | Matches issue. `manager_loop` stop/steer conditions have the same swallowed-error class but no lint reads their `.Parsed` (manager-loop lints use Raw-based `conditionPresent`) — separate follow-up. |
+| Doctor | **Exit non-zero on `SeverityError`** | User decision. `doctor` becomes a gate, not just a report. Note: this now makes doctor exit non-zero for *any* error (incl. existing DIP001–009), so `unhealthy.dip`'s DIP004 flips `TestCmdDoctor_WithSuggestions` to `ExitError`. |
+
+## Implementation
+
+### 1. `validator/validate_conditions.go` (new file)
+
+Isolates the single `simulate` import to one file (keeps `validate.go` `ir`-only).
+File-level doc comment states *why* it's separate.
+
+```go
+package validator
+
+import (
+	"fmt"
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/simulate"
+)
+
+// edgeNeedsParse mirrors simulate.ensureEdgeConditionParsed's guard
+// (simulate/condition.go:285): skip nil / already-parsed / empty conditions.
+func edgeNeedsParse(e *ir.Edge) bool {
+	return e.Condition != nil && e.Condition.Parsed == nil && e.Condition.Raw != ""
+}
+
+// edgeParseFailure pairs an edge with its condition parse error.
+// (Not named *Error — it does not implement the error interface.)
+type edgeParseFailure struct {
+	edge *ir.Edge
+	err  error
+}
+
+// parseEdgeConditions parses every edge condition that needs it, populating
+// Condition.Parsed for each that succeeds (idempotent; guarded by Parsed!=nil).
+// Unlike simulate.EnsureConditionsParsed it does NOT stop at the first failure —
+// every parseable edge is populated, so one bad condition cannot mask the
+// AST-dependent lints (DIP103/120/121/122) on later edges. Returns one failure
+// per unparseable edge.
+//
+// NOTE: this mutates w (lazily populates Condition.Parsed), consistent with the
+// codebase's lazy-population pattern (see CLAUDE.md "Key gotcha"). Idempotent.
+func parseEdgeConditions(w *ir.Workflow) []edgeParseFailure {
+	var failures []edgeParseFailure
+	for _, e := range w.Edges {
+		f := parseOneEdge(e)
+		if f != nil {
+			failures = append(failures, *f)
+		}
+	}
+	return failures
+}
+
+// parseOneEdge parses a single edge's condition (mirrors checkEndpoint split
+// idiom to stay under the cognitive-complexity ceiling).
+func parseOneEdge(e *ir.Edge) *edgeParseFailure {
+	if !edgeNeedsParse(e) {
+		return nil
+	}
+	parsed, err := simulate.ParseCondition(e.Condition.Raw)
+	if err != nil {
+		return &edgeParseFailure{edge: e, err: err}
+	}
+	e.Condition.Parsed = parsed
+	return nil
+}
+
+// checkEdgeConditions verifies DIP010: every edge condition is parseable.
+func checkEdgeConditions(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, f := range parseEdgeConditions(w) {
+		diags = append(diags, Diagnostic{
+			Code:     DIP010,
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("edge %s -> %s: invalid condition %q: %v", f.edge.From, f.edge.To, f.edge.Condition.Raw, f.err),
+			Location: f.edge.Source,
+			Help:     "valid operators: = == != contains startswith endswith in (combine with and/or/not)",
+		})
+	}
+	return diags
+}
+```
+
+Wire into `Validate()` (`validate.go:28`-ish), after the existing structural checks:
+```go
+diags = append(diags, checkEdgeConditions(w)...)
+```
+
+### 2. `validator/lint.go` — cascade fix for standalone `Lint()`
+
+Replace `_ = simulate.EnsureConditionsParsed(w)` with:
+```go
+// Populate edge condition ASTs accumulate-all (one bad edge must not mask the
+// AST-dependent lints DIP103/120/121/122 on later edges). DIP010 (from Validate)
+// reports the failures; here we only need the population side effect.
+parseEdgeConditions(w)
+// manager_loop node conditions: still populated by EnsureConditionsParsed in the
+// common (no-bad-edge) case; behavior-preserving.
+_ = simulate.EnsureConditionsParsed(w)
+```
+
+### 3. `cmd/dippin/cmd_doctor.go` — doctor exits non-zero on errors
+
+```go
+func (c *CLI) renderDoctorReport(r *doctor.Report) ExitCode {
+	if c.Format == FormatJSON {
+		if code := c.renderJSON(r); code != ExitOK {
+			return code
+		}
+	} else {
+		renderDoctorText(c.Stdout, r)
+	}
+	if r.Lint.Errors > 0 {
+		return ExitError
+	}
+	return ExitOK
+}
+```
+
+### 4. Registration (build gates — all mandatory unless noted)
+
+- `validator/codes.go`: add `DIP010 = "DIP010"` const (after DIP009) + `CodeDescription[DIP010] = "edge condition cannot be parsed"` to the map literal (structural codes live here, NOT `lint_codes.go`'s `init()`).
+- `validator/explanations.go`: add full 4-field `Explanations[DIP010]` (Summary/Trigger/Fix/Example) in the structural block.
+- `validator/validate_test.go:655`: add `DIP010` to the hardcoded `TestCodeDescriptionCoverage` slice (consistency; parity tests already cover it).
+- Update in-code range comments: `codes.go:3`, `diagnostic.go:3`, `validate.go:11` → DIP001–DIP010.
+
+Parity is auto-enforced: `TestExplanationsCoverAllCodes`/`NoExtra`
+(`explanations_test.go:5,19`) fail the build if DIP010 is in only one map.
+
+### 5. Docs + generated spec
+
+Bump count `55 → 56` codes / `54 → 55` documented sections and range
+`DIP001–DIP009 → DIP001–DIP010` in hand-authored docs: `CLAUDE.md:85`,
+`docs/validation.md` (`:3` counts, `:5,14,47,1191,1199` ranges + **new DIP010
+subsection** after DIP009), `docs/llm-reference.md:190,192`, `docs/cli.md`,
+`docs/architecture.md`, `docs/editor-setup.md`, `docs/integration.md`,
+`README.md`, `site/content/*`, `site/static/skill.md`.
+
+**Then regenerate:** `docs/llm-reference.md` + `site/static/skill.md` are gen-spec
+*inputs* — run `./scripts/gen-spec.sh` and commit outputs `docs/generated-spec.md`
++ `cmd/dippin/generated-spec.md` (+ `site/static/llms-full.txt` if CI copies it).
+`releasecheck_test.go:44` + CI fail on a stale-spec diff.
+
+**Do NOT hand-edit:** `docs/generated-spec.md`, `cmd/dippin/generated-spec.md`,
+`site/static/llms-full.txt` (generated); `docs/superpowers/**`,
+`docs/build_dippin.dot`, `docs/evolution_report.md` (frozen/legacy records).
+
+Update `CHANGELOG.md`.
+
+## Tests (TDD — failing first; real parser-driven fixtures, never hand-set `.Parsed`)
+
+Helpers: `lintSrc(t, src)` (`lint_writable_paths_test.go:10`), `hasCode`/`codes`
+(`lint_tool_access_test.go:70,79`), `countCode` (`lint_subgraph_tool_access_test.go:12`),
+`runCLI` (`main_test.go:15`), CLI template `cmd_validate_crossfile_test.go:11-33`.
+Add a new **`validateSrc(t, src)`** helper mirroring `lintSrc` but calling
+`Validate` (none exists; `validate_test.go` hand-builds IR — do not copy that).
+
+1. **Repro** — `A -> Z when marker_grep "^ok"` → exactly one DIP010, `SeverityError`,
+   `Location` set to the edge source.
+2. **Cascade** (corrected) — verified fixture: an earlier unparseable edge
+   (`B -> C when marker_grep "^ok"` → DIP010) and a LATER valid edge referencing
+   an undefined namespace (`D -> E when badns.flavor = vanilla` → DIP120). Assert
+   **both** DIP010 (Validate) and DIP120 (Lint) fire. Pre-fix DIP120 is suppressed;
+   this is the discriminating assertion. (Asserting DIP101/102 here proves nothing.)
+3. **Multiple bad edges** → `countCode(diags, DIP010) == 2`.
+4. **All-valid** → no DIP010; existing behavior unchanged.
+5. **`parseEdgeConditions` unit test** → good edges get `.Parsed != nil` past a bad
+   edge; bad edges reported.
+6. **CLI integration** — streams matter:
+   - `dippin validate <repro>` → `ExitError` + `error[DIP010]` on **stderr**.
+   - `dippin check --format text <repro>` → `ExitError` + DIP010 on **stdout**.
+   - `dippin doctor <repro>` → `ExitError` (new); assert via `--format json`
+     `lint.errors >= 1` and/or grade < A.
+7. **Negative / scope** — an unparseable `manager_loop stop_condition` does **NOT**
+   emit DIP010 (edges-only boundary).
+8. **Parity** — DIP010 present in `CodeDescription` + `Explanations`.
+
+Existing test to update: `TestCmdDoctor_WithSuggestions` (`main_test.go:2008`) →
+expect `ExitError` (unhealthy.dip has DIP004). Watch `just validate-examples` —
+empirically no example flips red, but re-confirm.
+
+## Out of scope (noted follow-ups)
+
+- `manager_loop` node-condition swallowed-error (same class; no lint reads node `.Parsed`).
+- Adding a condition-parse pass to `just check`/CI (issue option 3).
+
+## Risk notes
+
+- **No new strictness:** DIP010 surfaces the *same* `ParseCondition` gate
+  `dippin simulate` already enforces — any condition failing it already fails
+  simulate today.
+- **`Validate()` non-pure:** now lazily populates `Condition.Parsed` (idempotent,
+  guarded) — documented, consistent with existing pattern.
+- **DIP009 co-fire:** a duplicated bad edge emits both DIP009 (Raw-keyed) and
+  DIP010 — both true, benign.
+- **WASM green:** only adds `simulate.ParseCondition` (already imported).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -233,7 +233,7 @@ condition leaves the edge's routing undefined, so the workflow cannot execute â€
 it fails at `dippin simulate` and at runtime. The most common cause is using a
 tool-node field (like `marker_grep`) or an unknown operator in operator position.
 
-```
+```text
 error[DIP010]: edge A -> Z: invalid condition "marker_grep \"^ok\"": unknown operator "^ok"
   --> pipeline.dip:14:5
   = help: valid operators: = == != contains startswith endswith in (combine with and/or/not)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,8 +1,8 @@
 # Validation and Linting Reference
 
-Dippin registers 55 diagnostic codes split into two categories; this page gives a dedicated section to every code except `DIP138`, which is reserved and has no firing logic (54 documented sections):
+Dippin registers 56 diagnostic codes split into two categories; this page gives a dedicated section to every code except `DIP138`, which is reserved and has no firing logic (55 documented sections):
 
-- **Structural validation** (DIP001–DIP009): Errors that **must** be fixed. A workflow with any of these cannot execute.
+- **Structural validation** (DIP001–DIP010): Errors that **must** be fixed. A workflow with any of these cannot execute.
 - **Semantic linting** (DIP101–DIP146): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
 
 Run `dippin validate <file>` for structural checks only, or `dippin lint <file>` for both.
@@ -11,7 +11,7 @@ Run `dippin validate <file>` for structural checks only, or `dippin lint <file>`
 graph LR
     SRC[".dip file"] --> PARSE["Parser"]
     PARSE --> IR["IR"]
-    IR --> VAL["Structural Validation<br>DIP001–DIP009<br>(errors)"]
+    IR --> VAL["Structural Validation<br>DIP001–DIP010<br>(errors)"]
     IR --> LINT["Semantic Linting<br>DIP101–DIP146<br>(warnings)"]
     VAL --> DIAG["Diagnostics"]
     LINT --> DIAG
@@ -44,7 +44,7 @@ In JSON output mode (`--format json`), diagnostics are emitted as an array of ob
 
 ---
 
-## Structural Validation Errors (DIP001–DIP009)
+## Structural Validation Errors (DIP001–DIP010)
 
 ### DIP001: Start Node Missing
 
@@ -221,6 +221,30 @@ error[DIP009]: duplicate edge
 **What triggers it**: Two edges with identical source, target, and condition raw text.
 
 **Note**: Edges with different conditions on the same (from, to) pair are **not** duplicates — that's intentional conditional branching.
+
+---
+
+### DIP010: Unparseable Edge Condition
+
+**Severity**: Error
+
+Every edge `when` condition must parse into a valid expression. An unparseable
+condition leaves the edge's routing undefined, so the workflow cannot execute —
+it fails at `dippin simulate` and at runtime. The most common cause is using a
+tool-node field (like `marker_grep`) or an unknown operator in operator position.
+
+```
+error[DIP010]: edge A -> Z: invalid condition "marker_grep \"^ok\"": unknown operator "^ok"
+  --> pipeline.dip:14:5
+  = help: valid operators: = == != contains startswith endswith in (combine with and/or/not)
+```
+
+**What triggers it**: An edge condition that fails to parse — an unknown operator,
+or a field name used where an operator is expected.
+
+**Note**: One diagnostic fires per unparseable edge (parsing does not stop at the
+first failure), and every parseable edge is still checked by the AST-dependent
+lints (DIP103/DIP120/DIP121/DIP122), so one bad condition no longer masks the rest.
 
 ---
 
@@ -1188,7 +1212,7 @@ escape — not that the child's tools are restricted at runtime.
 dippin validate pipeline.dip
 ```
 
-Runs DIP001–DIP009. Exit code 0 if all pass, 1 if any errors.
+Runs DIP001–DIP010. Exit code 0 if all pass, 1 if any errors.
 
 ### Full lint (validation + semantic)
 
@@ -1196,7 +1220,7 @@ Runs DIP001–DIP009. Exit code 0 if all pass, 1 if any errors.
 dippin lint pipeline.dip
 ```
 
-Runs all DIP001–DIP009 errors and DIP101–DIP146 warnings. Exit code 1 only for errors; warnings alone exit 0.
+Runs all DIP001–DIP010 errors and DIP101–DIP146 warnings. Exit code 1 only for errors; warnings alone exit 0.
 
 ### JSON output for CI
 

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -68,7 +68,7 @@ dippin-lang/
 │
 ├── validator/          # Graph validation + semantic linting
 │   ├── validate.go     # 10 structural checks (DIP001-DIP010)
-│   ├── lint.go         # Lint orchestration (DIP101-DIP133)
+│   ├── lint.go         # Lint orchestration (DIP101-DIP146)
 │   └── diagnostic.go   # Diagnostic type, Result, Severity
 │
 ├── formatter/          # Canonical .dip source formatter
@@ -103,7 +103,7 @@ dippin-lang/
   </div>
   <div class="decision-card">
     <h4>No short-circuiting validation</h4>
-    <p>All 10 structural checks and all 30 semantic checks run unconditionally. A single call reports every issue, not just the first. This enables batch fixing.</p>
+    <p>All 10 structural checks and all 46 semantic checks run unconditionally. A single call reports every issue, not just the first. This enables batch fixing.</p>
   </div>
   <div class="decision-card">
     <h4>Zero external dependencies</h4>

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -67,7 +67,7 @@ dippin-lang/
 │   └── parse_helpers.go   # Shared utilities
 │
 ├── validator/          # Graph validation + semantic linting
-│   ├── validate.go     # 9 structural checks (DIP001-DIP009)
+│   ├── validate.go     # 10 structural checks (DIP001-DIP010)
 │   ├── lint.go         # Lint orchestration (DIP101-DIP133)
 │   └── diagnostic.go   # Diagnostic type, Result, Severity
 │
@@ -103,7 +103,7 @@ dippin-lang/
   </div>
   <div class="decision-card">
     <h4>No short-circuiting validation</h4>
-    <p>All 9 structural checks and all 30 semantic checks run unconditionally. A single call reports every issue, not just the first. This enables batch fixing.</p>
+    <p>All 10 structural checks and all 30 semantic checks run unconditionally. A single call reports every issue, not just the first. This enables batch fixing.</p>
   </div>
   <div class="decision-card">
     <h4>Zero external dependencies</h4>

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -50,13 +50,13 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 <div class="cmd-card">
   <h3>validate</h3>
   <div class="cmd-usage">dippin validate &lt;file&gt;</div>
-  <p>Run structural validation checks (DIP001-DIP009) on a workflow. Outputs "validation passed" or diagnostic messages. Exit code 1 if any errors found.</p>
+  <p>Run structural validation checks (DIP001-DIP010) on a workflow. Outputs "validation passed" or diagnostic messages. Exit code 1 if any errors found.</p>
 </div>
 
 <div class="cmd-card">
   <h3>lint</h3>
   <div class="cmd-usage">dippin lint [--extra-models &lt;spec&gt;] &lt;file&gt;</div>
-  <p>Run both structural validation and semantic linting (DIP001-DIP009 + DIP101-DIP134). All 40 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
+  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP134). All 40 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
   <dl>
     <dt><code>--extra-models "provider:model1,model2;provider2:model3"</code></dt>
     <dd>Extend the DIP108 model catalog at runtime for private or newly-released models.</dd>
@@ -154,7 +154,7 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 <div class="cmd-card">
   <h3>pack</h3>
   <div class="cmd-usage">dippin pack [-o &lt;out&gt;] [--dry-run] &lt;entry.dip&gt;</div>
-  <p>Build a deterministic <code>.dipx</code> bundle from a <code>.dip</code> entry, walking every transitively-reachable subgraph ref. Runs structural validation (DIP001–DIP009) before packing. <code>-o -</code> writes to stdout; <code>--dry-run</code> validates and walks refs without writing. File output is atomic via <code>os.CreateTemp</code> + rename. Refuses symlinks anywhere in the source tree, including parent components.</p>
+  <p>Build a deterministic <code>.dipx</code> bundle from a <code>.dip</code> entry, walking every transitively-reachable subgraph ref. Runs structural validation (DIP001–DIP010) before packing. <code>-o -</code> writes to stdout; <code>--dry-run</code> validates and walks refs without writing. File output is atomic via <code>os.CreateTemp</code> + rename. Refuses symlinks anywhere in the source tree, including parent components.</p>
 </div>
 
 <div class="cmd-card">

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -56,7 +56,7 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 <div class="cmd-card">
   <h3>lint</h3>
   <div class="cmd-usage">dippin lint [--extra-models &lt;spec&gt;] &lt;file&gt;</div>
-  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP134). All 40 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
+  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP146). All 55 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
   <dl>
     <dt><code>--extra-models "provider:model1,model2;provider2:model3"</code></dt>
     <dd>Extend the DIP108 model catalog at runtime for private or newly-released models.</dd>

--- a/site/content/glossary.md
+++ b/site/content/glossary.md
@@ -51,7 +51,7 @@ subtitle: "Terms you'll encounter authoring .dip files and using the dippin tool
 
 ## Diagnostics
 
-**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP010 are structural errors (parse / shape failures). DIP101–DIP133 are semantic warnings (style, correctness hints, model catalog issues).
+**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP010 are structural errors (parse / shape failures). DIP101–DIP146 are semantic warnings (style, correctness hints, model catalog issues).
 
 **Exhaustive conditions** — A pair of edge conditions detected as covering all outcomes (e.g., `when ctx.status = success` + `when ctx.status = fail`). Suppresses DIP101 / DIP102 warnings.
 

--- a/site/content/glossary.md
+++ b/site/content/glossary.md
@@ -51,7 +51,7 @@ subtitle: "Terms you'll encounter authoring .dip files and using the dippin tool
 
 ## Diagnostics
 
-**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP009 are structural errors (parse / shape failures). DIP101–DIP133 are semantic warnings (style, correctness hints, model catalog issues).
+**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP010 are structural errors (parse / shape failures). DIP101–DIP133 are semantic warnings (style, correctness hints, model catalog issues).
 
 **Exhaustive conditions** — A pair of edge conditions detected as covering all outcomes (e.g., `when ctx.status = success` + `when ctx.status = fail`). Suppresses DIP101 / DIP102 warnings.
 

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -1,8 +1,8 @@
 ---
 title: "Validation & Linting"
-description: "40 diagnostic checks for AI pipeline workflows. 9 structural errors and 31 semantic warnings catch bugs before runtime."
+description: "56 diagnostic checks for AI pipeline workflows. 10 structural errors and 46 semantic warnings catch bugs before runtime."
 section_label: "Diagnostics"
-subtitle: "40 diagnostic checks — 9 structural errors and 31 semantic warnings — to catch problems before runtime."
+subtitle: "56 diagnostic checks — 10 structural errors and 46 semantic warnings — to catch problems before runtime."
 ---
 
 ## Overview

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -9,7 +9,7 @@ subtitle: "40 diagnostic checks — 9 structural errors and 31 semantic warnings
 
 Dippin provides two levels of analysis:
 
-**Structural validation** (DIP001-DIP009): Errors that must be fixed. A workflow with any of these cannot execute. Run with `dippin validate`.
+**Structural validation** (DIP001-DIP010): Errors that must be fixed. A workflow with any of these cannot execute. Run with `dippin validate`.
 
 **Semantic linting** (DIP101-DIP134): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
 
@@ -23,7 +23,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
   = help: did you mean "Interpret"?
 ```
 
-## Structural Errors (DIP001-DIP009)
+## Structural Errors (DIP001-DIP010)
 
 These must be fixed for a workflow to be valid. Each causes exit code 1.
 

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -1,8 +1,8 @@
 ---
 title: "Validation & Linting"
-description: "56 diagnostic checks for AI pipeline workflows. 10 structural errors and 46 semantic warnings catch bugs before runtime."
+description: "56 diagnostic codes for AI pipeline workflows. 10 structural errors and 46 semantic warnings catch bugs before runtime."
 section_label: "Diagnostics"
-subtitle: "56 diagnostic checks — 10 structural errors and 46 semantic warnings — to catch problems before runtime."
+subtitle: "56 diagnostic codes — 10 structural errors and 46 semantic warnings — to catch problems before runtime."
 ---
 
 ## Overview

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -11,7 +11,7 @@ Dippin provides two levels of analysis:
 
 **Structural validation** (DIP001-DIP010): Errors that must be fixed. A workflow with any of these cannot execute. Run with `dippin validate`.
 
-**Semantic linting** (DIP101-DIP134): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
+**Semantic linting** (DIP101-DIP146): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
 
 ### Diagnostic Format
 
@@ -99,7 +99,7 @@ These must be fixed for a workflow to be valid. Each causes exit code 1.
   = help: remove the duplicate edge</pre>
 </div>
 
-## Semantic Warnings (DIP101-DIP134)
+## Semantic Warnings (DIP101-DIP146)
 
 These flag likely bugs or questionable patterns. Warnings alone exit 0.
 

--- a/site/static/llms-full.txt
+++ b/site/static/llms-full.txt
@@ -189,10 +189,10 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-54 diagnostic codes across two categories:
+56 diagnostic codes across two categories:
 
-- **DIP001–DIP009** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch
-- **DIP101–DIP145** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults
+- **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
+- **DIP101–DIP146** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access
 
 ---
 
@@ -282,7 +282,7 @@ Invalid values fall back to no-tools at runtime (fail-closed) and are flagged by
 
 `tool_access` may also be set per-branch on a block-form `parallel` node; an omitted branch value inherits the target agent's setting.
 
-**Subgraph boundary:** `tool_access` does not cross a `subgraph_ref` / `ref` file boundary — a referenced child `.dip` (`manager_loop` or `subgraph` node) is governed entirely by its own file. When a workflow declares `tool_access` and also references a subgraph, [DIP143](https://2389-research.github.io/dippin-lang/validation.html#dip143) (Hint) reminds you to give the child's agents their own `tool_access`. This is distinct from the rejected in-file graph-topology lint ([#57](https://github.com/2389-research/dippin-lang/issues/57)): it concerns the cross-*file* boundary, and cross-file enforcement is tracked as [#89](https://github.com/2389-research/dippin-lang/issues/89).
+**Subgraph boundary:** `tool_access` does not cross a `subgraph_ref` / `ref` file boundary — a referenced child `.dip` (`manager_loop` or `subgraph` node) is governed entirely by its own file. When a workflow declares `tool_access` and also references a subgraph, [DIP143](https://2389-research.github.io/dippin-lang/validation.html#dip143) (Hint) reminds you to give the child's agents their own `tool_access`. This is distinct from the rejected in-file graph-topology lint ([#57](https://github.com/2389-research/dippin-lang/issues/57)): it concerns the cross-*file* boundary. Native `dippin lint` now resolves the child across that boundary: [DIP146](https://2389-research.github.io/dippin-lang/validation.html#dip146) (Hint) fires when a resolved child restricts no agent's `tool_access` while a workflow on the path does, superseding DIP143 for boundaries it can resolve ([#89](https://github.com/2389-research/dippin-lang/issues/89)). DIP143 remains the filesystem-free advisory (e.g. the wasm playground) and the fallback when the child can't be resolved.
 
 **Writable Paths (`writable_paths:`)** — *added v0.35.0; an enforcing runtime is required.*
 
@@ -560,8 +560,8 @@ Use `dippin help` (not `--help`) to see all commands.
 | Command | Purpose |
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
-| `dippin validate <file>` | Structural checks only (DIP001-DIP009) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP145) |
+| `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP146) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |
@@ -688,6 +688,7 @@ The primary loop for authoring .dip files:
 | DIP143 | Workflow uses `tool_access` but references a subgraph — child agents unguarded | Open the referenced `.dip` and set `tool_access` on its agents directly; parent restrictions do not cross the file boundary |
 | DIP144 | Agent node has no failure route | Add `-> <node> when ctx.outcome = fail`, set `fallback_target`, add `retry_target` with `max_retries`, or declare `on_failure:` in defaults |
 | DIP145 | Graph budget default is negative | Use a positive cap, or omit the field / set `0` to mean no limit |
+| DIP146 | Referenced subgraph child restricts no agent's `tool_access` while a workflow on the path does (cross-file) | Set `tool_access` on the child's agents; native `dippin lint` resolves the child and supersedes DIP143 |
 
 ## Best Practices
 

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -381,7 +381,7 @@ Use `dippin help` (not `--help`) to see all commands.
 | Command | Purpose |
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
-| `dippin validate <file>` | Structural checks only (DIP001-DIP009) |
+| `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
 | `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP145) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -382,7 +382,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP145) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP146) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |

--- a/validator/codes.go
+++ b/validator/codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for graph structure validation (DIP001–DIP009).
+// Diagnostic codes for graph structure validation (DIP001–DIP010).
 const (
 	DIP001 = "DIP001" // start node missing
 	DIP002 = "DIP002" // exit node missing
@@ -11,6 +11,7 @@ const (
 	DIP007 = "DIP007" // parallel/fan_in mismatch
 	DIP008 = "DIP008" // duplicate node ID
 	DIP009 = "DIP009" // duplicate edge
+	DIP010 = "DIP010" // unparseable edge condition
 )
 
 // CodeDescription maps each code to a short human-readable description.
@@ -24,4 +25,5 @@ var CodeDescription = map[string]string{
 	DIP007: "parallel fan-out/fan-in mismatch",
 	DIP008: "duplicate node ID",
 	DIP009: "duplicate edge",
+	DIP010: "edge condition cannot be parsed",
 }

--- a/validator/diagnostic.go
+++ b/validator/diagnostic.go
@@ -1,8 +1,9 @@
 // Package validator performs graph structure validation on Dippin IR workflows.
 //
-// It implements checks DIP001 through DIP009, covering structural correctness
+// It implements checks DIP001 through DIP010, covering structural correctness
 // of the workflow graph: start/exit existence, edge validity, reachability,
-// cycle detection, parallel/fan-in pairing, and duplicate detection.
+// cycle detection, parallel/fan-in pairing, duplicate detection, and edge
+// condition parseability.
 //
 // The validator is a pure IR consumer — it takes a *ir.Workflow and returns
 // a Result containing all diagnostics found. It always runs all checks and

--- a/validator/diagnostic.go
+++ b/validator/diagnostic.go
@@ -5,9 +5,11 @@
 // cycle detection, parallel/fan-in pairing, duplicate detection, and edge
 // condition parseability.
 //
-// The validator is a pure IR consumer — it takes a *ir.Workflow and returns
-// a Result containing all diagnostics found. It always runs all checks and
-// never short-circuits, so a single pass reports everything.
+// The validator takes a *ir.Workflow and returns a Result containing all
+// diagnostics found. It always runs all checks and never short-circuits, so a
+// single pass reports everything. Validate has one documented side effect: it
+// lazily populates edge Condition.Parsed for parseable conditions (idempotent),
+// so callers should not assume the workflow is left unmutated.
 package validator
 
 import (

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -74,6 +74,13 @@ var Explanations = map[string]Explanation{
 		Fix:     "Remove the duplicate edge declaration.",
 		Example: "Start -> Analyze\nStart -> Analyze  // duplicate edge",
 	},
+	DIP010: {
+		Code:    DIP010,
+		Summary: CodeDescription[DIP010],
+		Trigger: "An edge's when-condition cannot be parsed (e.g. an unknown operator, or a tool-node field like marker_grep used in operator position).",
+		Fix:     "Use a valid condition: var op value, where op is = == != contains startswith endswith in (combine with and/or/not).",
+		Example: "A -> Z when marker_grep \"^ok\"  // invalid: marker_grep is not an operator",
+	},
 }
 
 func init() {

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -16,15 +16,19 @@ import (
 //	lintResult := validator.Lint(w)
 func Lint(w *ir.Workflow) Result {
 	// Ensure condition ASTs are populated — the AST-dependent lint checks
-	// (DIP103/120/121/122) read Condition.Parsed.
+	// (DIP103/120/121/122) read edge Condition.Parsed.
 	//
 	// parseEdgeConditions populates every parseable edge accumulate-all, so one
 	// unparseable edge does not mask those lints on later edges (the bug behind
 	// DIP010 / issue #98). Edge parse failures are reported as DIP010 from
-	// Validate; here we only need the population side effect. EnsureConditionsParsed
-	// then populates manager_loop node conditions; no lint reads node-condition
-	// Parsed today, so it is harmless that its edge walk re-fails and returns
-	// early when an edge is unparseable.
+	// Validate; here we only need the population side effect.
+	//
+	// EnsureConditionsParsed then populates manager_loop node conditions in the
+	// common case. If an edge is unparseable it returns early before reaching the
+	// node loop, leaving node conditions unparsed — but that changes no lint
+	// result: the manager_loop checks gate on condition *presence* via
+	// conditionPresent (Raw != "" || Parsed != nil), which is Raw-dominated for
+	// any declared condition, and no lint inspects a node condition's parsed AST.
 	parseEdgeConditions(w)
 	_ = simulate.EnsureConditionsParsed(w)
 

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -15,8 +15,17 @@ import (
 //	structureResult := validator.Validate(w)
 //	lintResult := validator.Lint(w)
 func Lint(w *ir.Workflow) Result {
-	// Ensure condition ASTs are populated — the parser stores raw text
-	// but lint checks (DIP101, DIP102, DIP103) need parsed ASTs.
+	// Ensure condition ASTs are populated — the AST-dependent lint checks
+	// (DIP103/120/121/122) read Condition.Parsed.
+	//
+	// parseEdgeConditions populates every parseable edge accumulate-all, so one
+	// unparseable edge does not mask those lints on later edges (the bug behind
+	// DIP010 / issue #98). Edge parse failures are reported as DIP010 from
+	// Validate; here we only need the population side effect. EnsureConditionsParsed
+	// then populates manager_loop node conditions; no lint reads node-condition
+	// Parsed today, so it is harmless that its edge walk re-fails and returns
+	// early when an edge is unparseable.
+	parseEdgeConditions(w)
 	_ = simulate.EnsureConditionsParsed(w)
 
 	var diags []Diagnostic

--- a/validator/validate.go
+++ b/validator/validate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/2389-research/dippin-lang/ir"
 )
 
-// Validate runs all graph-structure checks (DIP001–DIP009) on the workflow
+// Validate runs all graph-structure checks (DIP001–DIP010) on the workflow
 // and returns all diagnostics found. It always runs all checks — never
 // short-circuits — so that a single pass reports everything.
 func Validate(w *ir.Workflow) Result {
@@ -26,6 +26,7 @@ func Validate(w *ir.Workflow) Result {
 	diags = append(diags, checkReachability(w)...)
 	diags = append(diags, checkNoCycles(w)...)
 	diags = append(diags, checkParallelFanIn(w)...)
+	diags = append(diags, checkEdgeConditions(w)...)
 
 	return Result{Diagnostics: diags}
 }

--- a/validator/validate_conditions.go
+++ b/validator/validate_conditions.go
@@ -1,0 +1,80 @@
+package validator
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/simulate"
+)
+
+// This file holds the one structural check that needs to parse edge conditions
+// (DIP010). It is separate from validate.go so the dependency on the simulate
+// package — the only cross-package import the validator's structural checks
+// have — stays isolated to a single file. simulate.ParseCondition is pure
+// string→AST (no filesystem), so this remains wasm-safe.
+
+// edgeNeedsParse reports whether an edge's condition still needs parsing.
+// Mirrors the guard in simulate.ensureEdgeConditionParsed: skip conditions that
+// are absent, already parsed, or have no raw text.
+func edgeNeedsParse(e *ir.Edge) bool {
+	return e.Condition != nil && e.Condition.Parsed == nil && e.Condition.Raw != ""
+}
+
+// edgeParseFailure pairs an edge with the error from parsing its condition.
+// It is not named *Error because it does not implement the error interface.
+type edgeParseFailure struct {
+	edge *ir.Edge
+	err  error
+}
+
+// parseEdgeConditions parses every edge condition that needs it, populating
+// Condition.Parsed for each that succeeds. Unlike simulate.EnsureConditionsParsed
+// it does NOT stop at the first failure — every parseable edge is populated, so
+// one bad condition cannot mask the AST-dependent lints (DIP103/120/121/122) on
+// later edges. It returns one failure per unparseable edge.
+//
+// This mutates w by lazily populating Condition.Parsed, consistent with how the
+// codebase treats Parsed as lazily-populated shared state. The population is
+// idempotent (guarded by Parsed != nil).
+func parseEdgeConditions(w *ir.Workflow) []edgeParseFailure {
+	var failures []edgeParseFailure
+	for _, e := range w.Edges {
+		if f := parseOneEdge(e); f != nil {
+			failures = append(failures, *f)
+		}
+	}
+	return failures
+}
+
+// parseOneEdge parses a single edge's condition, populating Parsed on success or
+// returning a failure on error. Split out to keep parseEdgeConditions under the
+// cognitive-complexity ceiling (mirrors the checkEndpoint extraction idiom).
+func parseOneEdge(e *ir.Edge) *edgeParseFailure {
+	if !edgeNeedsParse(e) {
+		return nil
+	}
+	parsed, err := simulate.ParseCondition(e.Condition.Raw)
+	if err != nil {
+		return &edgeParseFailure{edge: e, err: err}
+	}
+	e.Condition.Parsed = parsed
+	return nil
+}
+
+// checkEdgeConditions verifies DIP010: every edge condition can be parsed.
+// An unparseable condition leaves the edge's routing undefined — the workflow
+// cannot execute deterministically — so it is a structural error, emitted here
+// (from Validate) rather than as a lint warning, so every command path catches it.
+func checkEdgeConditions(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, f := range parseEdgeConditions(w) {
+		diags = append(diags, Diagnostic{
+			Code:     DIP010,
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("edge %s -> %s: invalid condition %q: %v", f.edge.From, f.edge.To, f.edge.Condition.Raw, f.err),
+			Location: f.edge.Source,
+			Help:     "valid operators: = == != contains startswith endswith in (combine with and/or/not)",
+		})
+	}
+	return diags
+}

--- a/validator/validate_conditions_test.go
+++ b/validator/validate_conditions_test.go
@@ -1,0 +1,178 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/2389-research/dippin-lang/parser"
+)
+
+// validateSrc parses src through the real parser and runs structural Validate.
+// Mirrors lintSrc but exercises the parse-then-validate path (the contract under
+// test for DIP010) — never hand-build IR with Condition.Parsed pre-set.
+func validateSrc(t *testing.T, src string) []Diagnostic {
+	t.Helper()
+	w, err := parser.NewParser(src, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return Validate(w).Diagnostics
+}
+
+// TestDIP010_InvalidEdgeCondition is the issue #98 repro: an edge using a
+// tool-node field (marker_grep) as an operator is unparseable and must surface
+// as a structural error rather than passing validation silently.
+func TestDIP010_InvalidEdgeCondition(t *testing.T) {
+	src := `workflow Repro
+  goal: "repro"
+  start: A
+  exit: Z
+
+  tool A
+    command: "echo ok"
+  agent Z
+    prompt: "done"
+
+  edges
+    A -> Z when marker_grep "^ok"
+`
+	diags := validateSrc(t, src)
+	if !hasCode(diags, "DIP010") {
+		t.Fatalf("expected DIP010 for unparseable edge condition, got: %v", codes(diags))
+	}
+}
+
+// cascadeSrc has an unparseable edge (B -> C) that appears BEFORE a valid edge
+// (D -> E) which references an undefined namespace (badns) and so should trip
+// DIP120. Pre-fix, EnsureConditionsParsed bails at B -> C and D -> E keeps
+// Parsed == nil, silently suppressing DIP120. The fix populates every parseable
+// edge regardless of earlier failures.
+const cascadeSrc = `workflow W
+  goal: "cascade"
+  start: A
+  exit: E
+
+  agent A
+    prompt: "a"
+  agent B
+    prompt: "b"
+  agent C
+    prompt: "c"
+  agent D
+    prompt: "d"
+  agent E
+    prompt: "e"
+
+  edges
+    A -> B
+    B -> C when marker_grep "^ok"
+    A -> D
+    D -> E when badns.flavor = vanilla
+`
+
+// TestDIP010_BadEdgeDoesNotMaskLaterLint proves the cascade fix from Lint alone:
+// a downstream AST-dependent lint (DIP120) still fires even though an earlier
+// edge is unparseable.
+func TestDIP010_BadEdgeDoesNotMaskLaterLint(t *testing.T) {
+	diags := lintSrc(t, cascadeSrc)
+	if !hasCode(diags, DIP120) {
+		t.Fatalf("expected DIP120 on the later valid edge despite an earlier unparseable edge, got: %v", codes(diags))
+	}
+}
+
+// TestDIP010_OnePerBadEdge verifies accumulate-all: every unparseable edge gets
+// its own diagnostic rather than stopping at the first.
+func TestDIP010_OnePerBadEdge(t *testing.T) {
+	src := `workflow W
+  goal: "two bad"
+  start: A
+  exit: C
+
+  agent A
+    prompt: "a"
+  agent B
+    prompt: "b"
+  agent C
+    prompt: "c"
+
+  edges
+    A -> B when marker_grep "^ok"
+    B -> C when another_grep "^no"
+`
+	diags := validateSrc(t, src)
+	if n := countCode(diags, "DIP010"); n != 2 {
+		t.Fatalf("expected 2 DIP010 (one per bad edge), got %d: %v", n, codes(diags))
+	}
+}
+
+// TestDIP010_ValidConditionsClean confirms no false positives on valid conditions.
+func TestDIP010_ValidConditionsClean(t *testing.T) {
+	src := `workflow W
+  goal: "valid"
+  start: A
+  exit: C
+
+  agent A
+    prompt: "a"
+  agent B
+    prompt: "b"
+  agent C
+    prompt: "c"
+
+  edges
+    A -> B when ctx.outcome = success
+    B -> C when ctx.score contains high
+`
+	diags := validateSrc(t, src)
+	if hasCode(diags, "DIP010") {
+		t.Fatalf("unexpected DIP010 on valid conditions: %v", codes(diags))
+	}
+}
+
+// TestParseEdgeConditions_PopulatesPastFailure is the unit-level proof: good
+// edges get Parsed populated even when an earlier edge fails, and each failure
+// is reported once.
+func TestParseEdgeConditions_PopulatesPastFailure(t *testing.T) {
+	w, err := parser.NewParser(cascadeSrc, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	failures := parseEdgeConditions(w)
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure (B -> C), got %d", len(failures))
+	}
+	for _, e := range w.Edges {
+		if e.From == "D" && e.To == "E" {
+			if e.Condition == nil || e.Condition.Parsed == nil {
+				t.Fatalf("expected D -> E to be parsed despite the earlier bad edge")
+			}
+		}
+		if e.From == "B" && e.To == "C" {
+			if e.Condition != nil && e.Condition.Parsed != nil {
+				t.Fatalf("expected the unparseable B -> C to keep Parsed == nil")
+			}
+		}
+	}
+}
+
+// TestDIP010_EdgesOnly confirms the scope boundary: an unparseable manager_loop
+// node condition does NOT emit DIP010 (DIP010 covers edge conditions only).
+func TestDIP010_EdgesOnly(t *testing.T) {
+	src := `workflow M
+  goal: "scope"
+  start: S
+  exit: D
+
+  manager_loop S
+    subgraph_ref: child.dip
+    stop_condition: marker_grep "^ok"
+  agent D
+    prompt: "done"
+
+  edges
+    S -> D
+`
+	diags := validateSrc(t, src)
+	if hasCode(diags, "DIP010") {
+		t.Fatalf("DIP010 should not fire for manager_loop node conditions: %v", codes(diags))
+	}
+}

--- a/validator/validate_test.go
+++ b/validator/validate_test.go
@@ -652,7 +652,7 @@ func TestLevenshtein(t *testing.T) {
 }
 
 func TestCodeDescriptionCoverage(t *testing.T) {
-	codes := []string{DIP001, DIP002, DIP003, DIP004, DIP005, DIP006, DIP007, DIP008, DIP009}
+	codes := []string{DIP001, DIP002, DIP003, DIP004, DIP005, DIP006, DIP007, DIP008, DIP009, DIP010}
 	for _, c := range codes {
 		if desc, ok := CodeDescription[c]; !ok || desc == "" {
 			t.Errorf("CodeDescription[%q] is missing or empty", c)


### PR DESCRIPTION
## Problem

An invalid edge `when` condition — e.g. `A -> Z when marker_grep "^ok"` (easy to write, since `marker_grep` is a real *tool-node* field) — passed `validate`/`lint`/`check`/`doctor` **silently**, yet hard-failed at `dippin simulate` and at runtime:

```
edge A -> Z: invalid condition "marker_grep \"^ok\"": unknown operator "^ok"
```

`validator.Lint()` discarded the error from `simulate.EnsureConditionsParsed()` (`validator/lint.go:20`), which **early-returned on the first** unparseable edge. So the bad condition produced no diagnostic, and every edge *after* it kept `Condition.Parsed == nil`, silently disabling the AST-dependent lints for the rest of the graph. These are exactly the commands an author runs to gain confidence a `.dip` is correct.

## Fix

- **New structural code DIP010** (`SeverityError`), emitted from `validator.Validate()` — which is run by **every** command path (validate/lint/check/watch/simulate/pack/wasm/doctor), so one check is caught everywhere. `validator/validate_conditions.go` parses each edge via the already-exported, wasm-safe `simulate.ParseCondition`, populating `Condition.Parsed` for every parseable edge and collecting **one failure per bad edge** (accumulate-all — parsing no longer stops at the first failure, so later edges keep getting linted).
- **`EnsureConditionsParsed` and its 6 callers are untouched** — no `simulate` API change, `wasm` stays green.
- **`Lint()`** now populates edge ASTs accumulate-all too, so a standalone lint pass is also un-masked.
- **`dippin doctor`** now exits non-zero when the report contains errors (it previously always exited 0), so it no longer greenlights a workflow that cannot execute. The report still renders in full.

## Corrected premise

The issue named DIP101/102/103/120 as the masked lints. Empirically (verified in review) only the `.Parsed`-dependent lints — **DIP103/120/121/122** — are masked; DIP101/102 fire on condition *presence* alone. The cascade regression test therefore asserts a downstream **DIP120** survives an earlier bad edge (a fixture that genuinely discriminates the fix).

## Scope

Edge conditions only. `manager_loop` stop/steer node conditions have the same swallowed-error class but no lint reads their `.Parsed` today — noted as a separate follow-up.

## Tests

All real-parser-driven (no hand-built IR with pre-set `.Parsed`):
- repro → DIP010 fires, `validate`/`check`/`doctor` exit non-zero
- **cascade** → DIP120 still fires on a later edge despite an earlier unparseable one
- one DIP010 per bad edge (count == 2); valid conditions clean; `parseEdgeConditions` unit; manager_loop edges-only scope boundary
- CLI integration (stream-correct: validate→stderr, check→stdout); `TestCmdDoctor_WithSuggestions` updated to `ExitError`

## Notes

- Catalog counts / structural range bumped to **DIP001–DIP010 / 56 codes**; generated spec regenerated. Reviewed via a 5-expert design panel + adversarial code-review pass.
- After merge this batches into a minor bump — not tagging without the maintainer's go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783525014&installation_id=131176874&pr_number=103&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F103&signature=49601d50752864f8bef616e36d423f40d1925dd768c99076a7ce3b119d7fa3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DIP010 (unparseable edge condition); each bad edge emits one error.
  * `doctor` now exits non-zero when the health report contains errors while still rendering the full report.

* **Documentation**
  * Updated CLI/help, site docs, and changelog to reflect structural validation DIP001–DIP010, lint warnings DIP101–DIP146, and updated diagnostic totals (56).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->