### PR TITLE
Harden cross-file tool_access resolver: refuse symlinked / root-escaping children (Closes #100)

### DIFF
--- a/cmd/dippin/crossfile_tool_access.go
+++ b/cmd/dippin/crossfile_tool_access.go
@@ -44,8 +44,11 @@ func crossFileToolAccess(entry *ir.Workflow, entryPath string) ([]validator.Diag
 	intentSeen := validator.WorkflowDeclaresToolAccess(entry)
 	// root is the containment anchor for every child ref, captured ONCE from the
 	// entry's directory and threaded unchanged (never recomputed per-parent — see
-	// spec D2/C2). absOrClean makes it absolute so ensureUnderRoot's filepath.Rel
-	// can compare it against absolute child targets.
+	// spec D2/C2). absOrClean makes it absolute when possible (it falls back to a
+	// lexical Clean only if filepath.Abs fails, e.g. an unavailable cwd) so
+	// ensureUnderRoot's filepath.Rel can compare it against absolute child targets;
+	// in the fallback case a relative root simply fails the Rel check and refuses,
+	// which is the safe (fail-soft) direction.
 	root := filepath.Dir(absOrClean(entryPath))
 	walkBoundaries(entry, intentSeen, 0, root, visited, &diags, classified)
 	return diags, classified

--- a/cmd/dippin/crossfile_tool_access.go
+++ b/cmd/dippin/crossfile_tool_access.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/2389-research/dippin-lang/dipx"
 	"github.com/2389-research/dippin-lang/ir"
 	"github.com/2389-research/dippin-lang/validator"
 )
@@ -42,25 +42,30 @@ func crossFileToolAccess(entry *ir.Workflow, entryPath string) ([]validator.Diag
 		visited[key] = true
 	}
 	intentSeen := validator.WorkflowDeclaresToolAccess(entry)
-	walkBoundaries(entry, intentSeen, 0, visited, &diags, classified)
+	// root is the containment anchor for every child ref, captured ONCE from the
+	// entry's directory and threaded unchanged (never recomputed per-parent — see
+	// spec D2/C2). absOrClean makes it absolute so ensureUnderRoot's filepath.Rel
+	// can compare it against absolute child targets.
+	root := filepath.Dir(absOrClean(entryPath))
+	walkBoundaries(entry, intentSeen, 0, root, visited, &diags, classified)
 	return diags, classified
 }
 
 // walkBoundaries inspects each subgraph/manager_loop boundary in w.
-func walkBoundaries(w *ir.Workflow, intentSeen bool, depth int, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+func walkBoundaries(w *ir.Workflow, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
 	for _, n := range w.Nodes {
 		_, ref := boundaryKindRef(n)
 		if ref == "" || n.Source.File == "" {
 			continue
 		}
-		visitBoundary(n, ref, intentSeen, depth, visited, diags, classified)
+		visitBoundary(n, ref, intentSeen, depth, root, visited, diags, classified)
 	}
 }
 
 // visitBoundary resolves one boundary's child, records its posture, emits DIP146
 // when the path shows intent and the child is zero-intent, then recurses.
-func visitBoundary(n *ir.Node, ref string, intentSeen bool, depth int, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
-	child, childPath := resolveBoundaryChild(n, ref)
+func visitBoundary(n *ir.Node, ref string, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+	child, childPath := resolveBoundaryChild(n, ref, root)
 	if child == nil {
 		classified[n.Source] = postureUnresolved
 		return
@@ -70,28 +75,36 @@ func visitBoundary(n *ir.Node, ref string, intentSeen bool, depth int, visited m
 	if intentSeen && posture == postureZeroIntent {
 		*diags = append(*diags, boundaryDiag(n, ref))
 	}
-	maybeRecurse(child, childPath, intentSeen, depth, visited, diags, classified)
+	maybeRecurse(child, childPath, intentSeen, depth, root, visited, diags, classified)
 }
 
 // maybeRecurse descends into a child's own boundaries unless it was already
 // visited (cycle guard) or the depth cap is reached. The child is marked visited
 // before recursing (pre-order) so cycles terminate.
-func maybeRecurse(child *ir.Workflow, childPath string, intentSeen bool, depth int, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+func maybeRecurse(child *ir.Workflow, childPath string, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
 	key := canonicalKey(childPath)
 	if key == "" || visited[key] || depth+1 > crossFileMaxDepth {
 		return
 	}
 	visited[key] = true
 	childIntent := intentSeen || validator.WorkflowDeclaresToolAccess(child)
-	walkBoundaries(child, childIntent, depth+1, visited, diags, classified)
+	walkBoundaries(child, childIntent, depth+1, root, visited, diags, classified)
 }
 
-// resolveBoundaryChild resolves ref relative to the boundary node's source file
-// and parses the child workflow. Fail-soft: any error yields (nil, "").
-// Callers (walkBoundaries) guarantee ref != "" and n.Source.File != "".
-func resolveBoundaryChild(n *ir.Node, ref string) (*ir.Workflow, string) {
-	path := resolveBoundaryRefPath(ref, n.Source.File)
-	data, err := os.ReadFile(path)
+// resolveBoundaryChild resolves ref relative to the boundary node's source file,
+// refusing root-escaping or symlinked targets, then parses the child workflow.
+// Fail-soft: ANY error (escape, symlink, read, parse) yields (nil, ""), routing
+// the boundary to postureUnresolved so the per-file DIP143 advisory is retained.
+// This is detection parity with the pack walker (Lstat-based, not the parser's
+// stronger O_NOFOLLOW open-once — the residual leaf TOCTOU matches pack's; a lint
+// emits only DIP codes, never file content). Callers (walkBoundaries) guarantee
+// ref != "" and n.Source.File != "".
+func resolveBoundaryChild(n *ir.Node, ref, root string) (*ir.Workflow, string) {
+	path, err := resolveChildPath(n.Source.File, ref, root)
+	if err != nil {
+		return nil, ""
+	}
+	data, err := dipx.ReadNoFollowSymlinks(path, root)
 	if err != nil {
 		return nil, ""
 	}
@@ -102,13 +115,22 @@ func resolveBoundaryChild(n *ir.Node, ref string) (*ir.Workflow, string) {
 	return w, path
 }
 
-// resolveBoundaryRefPath resolves a (possibly relative) ref against the parent's
-// source file directory, mirroring DIP135's resolveRefPath.
-func resolveBoundaryRefPath(ref, sourceFile string) string {
-	if filepath.IsAbs(ref) {
-		return ref
+// resolveChildPath joins ref against parentFile's directory and refuses any result
+// that escapes root. Pack-identical (mirrors dipx's resolveRefOnDisk): filepath.Join
+// swallows the leading slash of an absolute ref, so abs refs are RE-ROOTED under
+// root, not read out-of-root. The filepath.Abs is load-bearing — at the entry level
+// parentFile (n.Source.File) may be relative while root is absolute, and
+// ensureUnderRoot's filepath.Rel needs both absolute. Do not simplify it away.
+func resolveChildPath(parentFile, ref, root string) (string, error) {
+	target := filepath.Clean(filepath.Join(filepath.Dir(parentFile), ref))
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
 	}
-	return filepath.Join(filepath.Dir(sourceFile), ref)
+	if err := ensureUnderRoot(abs, root); err != nil {
+		return "", err
+	}
+	return abs, nil
 }
 
 // classifyChild determines a child's tool_access posture from its agent nodes.

--- a/cmd/dippin/crossfile_tool_access_test.go
+++ b/cmd/dippin/crossfile_tool_access_test.go
@@ -470,3 +470,121 @@ func TestCrossFile_IntentionalOpenWorkerFires(t *testing.T) {
 		t.Fatalf("want 1 DIP146 (known intentional-open FP, Hint-mitigated), got %d", got)
 	}
 }
+
+// childWithBoundary is a full-restrict child that itself delegates to `ref`,
+// so a refusal/resolution can be observed one hop below the entry.
+func childWithBoundary(ref string) string {
+	return `workflow Child
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  manager_loop Sup
+    subgraph_ref: ` + ref + `
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+}
+
+func hasPosture(classified map[ir.SourceLocation]childPosture, want childPosture) bool {
+	for _, p := range classified {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+// T1 — a boundary child ref that is a SYMLINK (even to a legitimate in-root .dip)
+// is refused: fail-soft -> postureUnresolved, DIP143 retained (supersedes==false),
+// no DIP146, no error. Also pins the policy that a benign in-root symlink target
+// is still refused unconditionally (do not "fix" into a false-positive exception).
+func TestCrossFile_SymlinkedChildRefused(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":     entryRestrictsRefs("child.dip"),
+		"realchild.dip": childZeroIntent,
+	})
+	if err := os.Symlink(filepath.Join(dir, "realchild.dip"), filepath.Join(dir, "child.dip")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (symlinked child refused), got %d", got)
+	}
+	for _, p := range classified {
+		if p != postureUnresolved {
+			t.Errorf("want postureUnresolved (DIP143 retained), got %v", p)
+		}
+	}
+}
+
+// T2 — a child ref that ESCAPES the entry-file containment root is refused
+// fail-soft. The entry lives in a subdir so its root is dir/sub; `../escape.dip`
+// resolves to dir/escape.dip, outside root but inside the temp tree (so current,
+// unhardened code WOULD read it and fire DIP146 — making this red-first).
+func TestCrossFile_RootEscapingChildRefused(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"sub/entry.dip": entryRestrictsRefs("../escape.dip"),
+		"escape.dip":    childZeroIntent,
+	})
+	diags, classified := crossDiags(t, dir, "sub/entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (root-escaping child refused), got %d", got)
+	}
+	for _, p := range classified {
+		if p != postureUnresolved {
+			t.Errorf("want postureUnresolved (DIP143 retained), got %v", p)
+		}
+	}
+}
+
+// T6 — a child reached through a SYMLINKED ANCESTOR DIRECTORY is refused
+// (the assertNoSymlinkAncestor vector), even though the leaf itself is a real file.
+func TestCrossFile_SymlinkedAncestorRefused(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":         entryRestrictsRefs("linkdir/child.dip"),
+		"realdir/child.dip": childZeroIntent,
+	})
+	if err := os.Symlink(filepath.Join(dir, "realdir"), filepath.Join(dir, "linkdir")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (symlinked ancestor refused), got %d", got)
+	}
+	for _, p := range classified {
+		if p != postureUnresolved {
+			t.Errorf("want postureUnresolved (DIP143 retained), got %v", p)
+		}
+	}
+}
+
+// T11 — refusal at DEPTH: entry -> child (real, full-restrict) -> grandchild via
+// a symlink. The child classifies normally (full-restrict, no DIP146); the
+// grandchild boundary is refused (postureUnresolved); recursion continues without
+// abort. Distinct code path from T1 (refusal mid-recursion).
+func TestCrossFile_SymlinkRefusalAtDepth(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":     entryRestrictsRefs("child.dip"),
+		"child.dip":     childWithBoundary("grandlink.dip"),
+		"realgrand.dip": childZeroIntent,
+	})
+	if err := os.Symlink(filepath.Join(dir, "realgrand.dip"), filepath.Join(dir, "grandlink.dip")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (grandchild symlink refused), got %d: %v", got, diags)
+	}
+	if !hasPosture(classified, postureFullRestrict) {
+		t.Errorf("want the child boundary classified full-restrict: %v", classified)
+	}
+	if !hasPosture(classified, postureUnresolved) {
+		t.Errorf("want the grandchild boundary classified unresolved: %v", classified)
+	}
+}

--- a/cmd/dippin/crossfile_tool_access_test.go
+++ b/cmd/dippin/crossfile_tool_access_test.go
@@ -588,3 +588,137 @@ func TestCrossFile_SymlinkRefusalAtDepth(t *testing.T) {
 		t.Errorf("want the grandchild boundary classified unresolved: %v", classified)
 	}
 }
+
+// T3 — HIGHEST-VALUE GUARD: a subdir child whose ref climbs back UP into the entry
+// root must still resolve. entry -> sub/child.dip (full-restrict) -> ../other.dip
+// (zero-intent, == root/other.dip, in-root). Correct (entry-anchored fixed root):
+// other resolves, DIP146 fires on the child->other edge => count 1. A BUGGY
+// per-parent-root recompute (root = dir(sub/child.dip) = root/sub) would refuse
+// ../other.dip (escapes root/sub) => count 0. So this fails under that bug.
+func TestCrossFile_SubdirChildClimbsBackIntoRoot(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":     entryRestrictsRefs("sub/child.dip"),
+		"sub/child.dip": childWithBoundary("../other.dip"),
+		"other.dip":     childZeroIntent,
+	})
+	diags, _ := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 1 {
+		t.Fatalf("want 1 DIP146 on the climb-back ../other.dip edge, got %d: %v", got, diags)
+	}
+}
+
+// T4 — legit sibling AND subdirectory children resolve normally; DIP146
+// supersession works exactly as before the hardening (regression guard).
+func TestCrossFile_LegitSiblingAndSubdirResolve(t *testing.T) {
+	sibling := writeWorkflows(t, map[string]string{
+		"entry.dip": entryRestrictsRefs("child.dip"),
+		"child.dip": childZeroIntent,
+	})
+	if got := countCode(firstDiags(t, sibling, "entry.dip"), validator.DIP146); got != 1 {
+		t.Fatalf("sibling: want 1 DIP146, got %d", got)
+	}
+	subdir := writeWorkflows(t, map[string]string{
+		"entry.dip":     entryRestrictsRefs("sub/child.dip"),
+		"sub/child.dip": childZeroIntent,
+	})
+	if got := countCode(firstDiags(t, subdir, "entry.dip"), validator.DIP146); got != 1 {
+		t.Fatalf("subdir: want 1 DIP146, got %d", got)
+	}
+}
+
+// T5 — policy pin: a symlink whose target is a perfectly legitimate in-root file
+// is STILL refused (all symlinks refused unconditionally, matching pack). Pins the
+// conservative policy so it is not later "fixed" into a false-positive exception.
+func TestCrossFile_BenignInRootSymlinkRefused(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":  entryRestrictsRefs("child.dip"),
+		"target.dip": childZeroIntent,
+	})
+	if err := os.Symlink(filepath.Join(dir, "target.dip"), filepath.Join(dir, "child.dip")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (benign in-root symlink still refused), got %d", got)
+	}
+	if !hasPosture(classified, postureUnresolved) {
+		t.Errorf("want postureUnresolved, got %v", classified)
+	}
+}
+
+// T7 — lynchpin guard (spec D2): a RELATIVE entry path must still resolve legit
+// children. crossDiags always builds an absolute entry path, so this drives the
+// pass with a relative path via os.Chdir. If root were left relative (no absOrClean),
+// ensureUnderRoot's filepath.Rel(relRoot, absChild) would error and refuse every
+// child => count 0. Not parallel-safe (mutates cwd); the file uses no t.Parallel.
+func TestCrossFile_RelativeEntryResolves(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip": entryRestrictsRefs("child.dip"),
+		"child.dip": childZeroIntent,
+	})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	w, err := loadWorkflow("entry.dip")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	diags, _ := crossFileToolAccess(w, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 1 {
+		t.Fatalf("want 1 DIP146 with a relative entry path, got %d", got)
+	}
+}
+
+// T8 — an absolute ref is re-rooted under the parent dir (filepath.Join swallows
+// the leading slash), not read out-of-root. /etc/passwd re-roots to <root>/etc/passwd
+// which does not exist => postureUnresolved (DIP143 retained). Documents re-rooting;
+// it does NOT assert literal absolute-path refusal.
+func TestCrossFile_AbsoluteRefReRooted(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip": entryRestrictsRefs("/etc/passwd"),
+	})
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (abs ref re-rooted, target absent), got %d", got)
+	}
+	for _, p := range classified {
+		if p != postureUnresolved {
+			t.Errorf("want postureUnresolved, got %v", p)
+		}
+	}
+}
+
+// T9 — a symlink that would form a cycle is refused at the first hop (so the cycle
+// is never entered) and the walk terminates. Termination of NON-symlink cycles is
+// covered by TestCrossFile_CycleTerminates / TestCrossFile_SelfReferenceTerminates;
+// this only asserts the refusal short-circuit does not hang.
+func TestCrossFile_SymlinkCycleRefused(t *testing.T) {
+	a := childWithBoundary("blink.dip") // a.dip -> blink.dip
+	dir := writeWorkflows(t, map[string]string{
+		"a.dip": a,
+	})
+	// blink.dip is a symlink back to a.dip (a would-be a->blink->a cycle).
+	if err := os.Symlink(filepath.Join(dir, "a.dip"), filepath.Join(dir, "blink.dip")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "a.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (symlink hop refused), got %d", got)
+	}
+	if !hasPosture(classified, postureUnresolved) {
+		t.Errorf("want the symlink boundary classified unresolved: %v", classified)
+	}
+}
+
+// firstDiags runs the pass and returns only the diagnostics (helper for cases that
+// don't inspect the classified map).
+func firstDiags(t *testing.T, dir, entry string) []validator.Diagnostic {
+	t.Helper()
+	diags, _ := crossDiags(t, dir, entry)
+	return diags
+}

--- a/cmd/dippin/pack_shadow.go
+++ b/cmd/dippin/pack_shadow.go
@@ -13,17 +13,18 @@ import (
 	"github.com/2389-research/dippin-lang/parser"
 )
 
-// ensureUnderRoot rejects any absolute path that resolves outside rootDir.
-// Guards the shadow-tree writer against a malicious subgraph ref like
-// `subgraph: ../../../escape.dip`, which would otherwise cause
-// writeShadowFile to write outside the temp shadow dir (since
-// filepath.Join(shadowDir, "../../../escape.dip") escapes). dipx.Pack does
-// its own escape check, but it runs AFTER we've built the shadow tree —
-// too late to prevent the out-of-tree write.
+// ensureUnderRoot rejects any absolute path that resolves outside rootDir, via
+// the same lexical `..`-component check the pack walker uses (resolveRefOnDisk).
+// Shared by two CLI subsystems: the pack shadow-tree writer (guarding against a
+// ref like `subgraph: ../../../escape.dip` that would make writeShadowFile write
+// out of the temp dir) and the cross-file tool_access lint (#100), which uses it
+// fail-soft to refuse root-escaping child refs. absPath MUST be absolute (the
+// callers absolutize before calling); a relative rootDir makes filepath.Rel error
+// and is reported as an escape.
 func ensureUnderRoot(absPath, rootDir string) error {
 	rel, err := filepath.Rel(rootDir, absPath)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("pack-inline: ref escapes source root: %s", absPath)
+		return fmt.Errorf("ref escapes source root: %s", absPath)
 	}
 	return nil
 }

--- a/dipx/dipx_test.go
+++ b/dipx/dipx_test.go
@@ -647,6 +647,12 @@ func TestReadNoFollowSymlinks(t *testing.T) {
 		t.Fatalf("happy path: content mismatch")
 	}
 
+	// not-regular-file (directory) refused — symlink-independent, so it runs on
+	// every platform even when os.Symlink is unsupported and the cases below skip.
+	if _, err := ReadNoFollowSymlinks(root, root); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("not-regular-file (directory): err = %v, want ErrPathUnsafe", err)
+	}
+
 	link := filepath.Join(root, "link.dip")
 	if err := os.Symlink(good, link); err != nil {
 		t.Skip("symlinks not supported on this platform")
@@ -668,9 +674,5 @@ func TestReadNoFollowSymlinks(t *testing.T) {
 	}
 	if _, err := ReadNoFollowSymlinks(filepath.Join(linkdir, "f.dip"), root); !errors.Is(err, ErrPathUnsafe) {
 		t.Fatalf("ancestor symlink: err = %v, want ErrPathUnsafe", err)
-	}
-
-	if _, err := ReadNoFollowSymlinks(realdir, root); !errors.Is(err, ErrPathUnsafe) {
-		t.Fatalf("not-regular-file (directory): err = %v, want ErrPathUnsafe", err)
 	}
 }

--- a/dipx/dipx_test.go
+++ b/dipx/dipx_test.go
@@ -627,3 +627,50 @@ func TestPack_HonorsContextCancellation(t *testing.T) {
 		t.Fatalf("Pack err = %v, want context.Canceled", err)
 	}
 }
+
+// TestReadNoFollowSymlinks pins the contract of the now-exported no-follow read
+// primitive: happy path reads, leaf-symlink refusal, ancestor-symlink refusal,
+// and the not-regular-file branch (the documented fail-soft path for a ref that
+// resolves to a directory, including the root dir itself).
+func TestReadNoFollowSymlinks(t *testing.T) {
+	root := t.TempDir()
+
+	good := filepath.Join(root, "good.dip")
+	if err := os.WriteFile(good, []byte(minimalDipSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := ReadNoFollowSymlinks(good, root)
+	if err != nil {
+		t.Fatalf("happy path: unexpected err %v", err)
+	}
+	if string(data) != minimalDipSrc {
+		t.Fatalf("happy path: content mismatch")
+	}
+
+	link := filepath.Join(root, "link.dip")
+	if err := os.Symlink(good, link); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	if _, err := ReadNoFollowSymlinks(link, root); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("leaf symlink: err = %v, want ErrPathUnsafe", err)
+	}
+
+	realdir := filepath.Join(root, "real")
+	if err := os.Mkdir(realdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realdir, "f.dip"), []byte(minimalDipSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	linkdir := filepath.Join(root, "linkdir")
+	if err := os.Symlink(realdir, linkdir); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	if _, err := ReadNoFollowSymlinks(filepath.Join(linkdir, "f.dip"), root); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("ancestor symlink: err = %v, want ErrPathUnsafe", err)
+	}
+
+	if _, err := ReadNoFollowSymlinks(realdir, root); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("not-regular-file (directory): err = %v, want ErrPathUnsafe", err)
+	}
+}

--- a/dipx/helpers.go
+++ b/dipx/helpers.go
@@ -389,9 +389,12 @@ func parsePackSource(path string, raw []byte, isEntry bool) (*ir.Workflow, error
 // a tree containing `sub -> /etc` would otherwise let a leaf `sub/foo.dip` read
 // `/etc/foo.dip`, because Lstat on the leaf reports a regular file, not a symlink.
 //
-// It does NOT perform the `..`-escape (containment) check — callers must run that
+// It does NOT perform the `..`-escape (containment) check — callers MUST run that
 // separately BEFORE calling this (the pack walker via resolveRefOnDisk, the lint
-// via ensureUnderRoot). rootDir is only the ancestor-scan boundary here.
+// via ensureUnderRoot) and MUST pass a path already proven to be under rootDir.
+// rootDir is only the ancestor-scan boundary here: if path is not under rootDir,
+// filepath.Rel yields `..` components and the ancestor scan would Lstat paths
+// outside rootDir.
 //
 // rootDir itself is treated as the trust anchor: it is an absolute path supplied
 // by the caller, may itself be a user-specified symlink, and is not re-validated.

--- a/dipx/helpers.go
+++ b/dipx/helpers.go
@@ -314,7 +314,7 @@ func (s *packWalkState) visitNext() error {
 // Enforces the per-file uncompressed cap (maxPerFileBytes) at Pack time so
 // the producer cannot emit a bundle that fails its own round-trip in Open.
 func (s *packWalkState) readAndRecord(cur string) (packedFile, *ir.Workflow, error) {
-	raw, err := readNoFollowSymlinks(cur, s.rootDir)
+	raw, err := ReadNoFollowSymlinks(cur, s.rootDir)
 	if err != nil {
 		return packedFile{}, nil, err
 	}
@@ -382,18 +382,22 @@ func parsePackSource(path string, raw []byte, isEntry bool) (*ir.Workflow, error
 	return wf, nil
 }
 
-// readNoFollowSymlinks reads a file, refusing to follow symlinks at the leaf
-// OR at any intermediate path component between rootDir and path. This closes
-// a parent-component-symlink data-exfil vector in Pack: a source tree
-// containing `workflows/phases -> /etc` would otherwise let Pack embed
-// `/etc/foo.dip` as `workflows/phases/foo.dip` because Lstat on the leaf
-// reports a regular file, not a symlink.
+// ReadNoFollowSymlinks reads a file, refusing to follow symlinks at the leaf OR
+// at any intermediate path component between rootDir and path. Shared by the
+// Pack walker and the cross-file tool_access lint (cmd/dippin) so both refuse
+// symlinks identically. It closes a parent-component-symlink data-exfil vector:
+// a tree containing `sub -> /etc` would otherwise let a leaf `sub/foo.dip` read
+// `/etc/foo.dip`, because Lstat on the leaf reports a regular file, not a symlink.
 //
-// rootDir itself is treated as the trust anchor: it is an absolute path
-// supplied by the CLI, may itself be a user-specified symlink, and is not
-// re-validated. Components strictly between rootDir and path's leaf MUST be
-// directories that are not symlinks.
-func readNoFollowSymlinks(path, rootDir string) ([]byte, error) {
+// It does NOT perform the `..`-escape (containment) check — callers must run that
+// separately BEFORE calling this (the pack walker via resolveRefOnDisk, the lint
+// via ensureUnderRoot). rootDir is only the ancestor-scan boundary here.
+//
+// rootDir itself is treated as the trust anchor: it is an absolute path supplied
+// by the caller, may itself be a user-specified symlink, and is not re-validated.
+// Components strictly between rootDir and path's leaf MUST be directories that are
+// not symlinks.
+func ReadNoFollowSymlinks(path, rootDir string) ([]byte, error) {
 	if err := assertNoSymlinkAncestor(path, rootDir); err != nil {
 		return nil, err
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ dippin-lang/
 │   ├── bundle.go       # Bundle (Workflow, Identity, Manifest, ReadFile)
 │   ├── zipio.go        # Constrained zip reader (rejects forbidden features)
 │   ├── resolve.go      # Path canonicalization, Windows reserved names
-│   ├── helpers.go      # Hash verify, parse-and-link, walkSourceTree
+│   ├── helpers.go      # Hash verify, parse-and-link, walkSourceTree, ReadNoFollowSymlinks (shared no-follow read)
 │   └── errors.go       # BundleError sentinels
 │
 ├── scaffold/           # Template scaffolding for `dippin new`

--- a/docs/superpowers/plans/2026-06-08-issue-100-crossfile-symlink-hardening.md
+++ b/docs/superpowers/plans/2026-06-08-issue-100-crossfile-symlink-hardening.md
@@ -737,13 +737,13 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 Open `docs/architecture.md`, find the line describing `helpers.go` (around `:148`):
 
-```
+```text
 │   ├── helpers.go      # Hash verify, parse-and-link, walkSourceTree
 ```
 
 Append the shared read primitive to the responsibility list, e.g.:
 
-```
+```text
 │   ├── helpers.go      # Hash verify, parse-and-link, walkSourceTree, ReadNoFollowSymlinks (shared no-follow read)
 ```
 
@@ -790,5 +790,3 @@ Expected: all green. (`just check` fails locally on tree-sitter-generate — tha
 - **Scope — no new DIP, no build tags:** confirmed (no `validator` code edits; no `//go:build`). File directives untouched (out of scope by pack parity).
 - **Tests T1–T11:** T1=SymlinkedChildRefused (absorbs T5 policy via comment; T5 also kept explicit as BenignInRootSymlinkRefused), T2=RootEscapingChildRefused, T3=SubdirChildClimbsBackIntoRoot, T4=LegitSiblingAndSubdirResolve, T5=BenignInRootSymlinkRefused, T6=SymlinkedAncestorRefused, T7=RelativeEntryResolves, T8=AbsoluteRefReRooted, T9=SymlinkCycleRefused, T10=TestReadNoFollowSymlinks (dipx), T11=SymlinkRefusalAtDepth.
 - **Verification:** Task 7 (test-race, complexity, wasm, validate/lint-examples).
-</content>
-</invoke>

--- a/docs/superpowers/plans/2026-06-08-issue-100-crossfile-symlink-hardening.md
+++ b/docs/superpowers/plans/2026-06-08-issue-100-crossfile-symlink-hardening.md
@@ -1,0 +1,794 @@
+# Cross-File Resolver Symlink/Root-Escape Hardening (#100) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make DIP146's cross-file lint refuse symlinked / root-escaping child `.dip` refs — fail-soft (refusal → `postureUnresolved` → DIP143 retained), reaching parity with the pack walker.
+
+**Architecture:** Reuse two existing primitives — `ensureUnderRoot` (`cmd/dippin/pack_shadow.go`, lexical `..`-escape check, already in `package main`) and `dipx`'s `readNoFollowSymlinks` (Lstat-based leaf+ancestor symlink refusal) — exporting only the latter (one new public symbol). Compute a fixed absolute containment root (the entry file's directory) once and thread it unchanged through the recursive walk; route the child read through the two checks before parsing. No new DIP code, no build tags, no pack-path refactor.
+
+**Tech Stack:** Go; `just` recipes for build/test (never raw `go`); pre-commit hook is the CI gate.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-issue-100-design.md` (read it before starting).
+
+**Worktree:** Work entirely in `/home/clint/code/2389/dippin-lang/.claude/worktrees/fix+100-crossfile-symlink-hardening` on branch `fix/100-crossfile-symlink-hardening`. Stage explicit paths only (never `git add -A` — `./dippin`, `./wasm`, `site/static/*.wasm` are gitignored build artifacts). Every commit ends with the trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- **`dipx/helpers.go`** (modify) — rename `readNoFollowSymlinks` → `ReadNoFollowSymlinks` (export), generalize its doc comment, update its one caller at `:317`.
+- **`dipx/dipx_test.go`** (modify) — add `TestReadNoFollowSymlinks` (direct unit test of the newly-exported primitive).
+- **`cmd/dippin/pack_shadow.go`** (modify) — generalize `ensureUnderRoot`'s error message + doc comment (now shared).
+- **`cmd/dippin/crossfile_tool_access.go`** (modify) — replace `resolveBoundaryRefPath` with `resolveChildPath`; thread a fixed absolute `root` through the walk; route the read through `dipx.ReadNoFollowSymlinks`; swap the `os` import for `dipx`.
+- **`cmd/dippin/crossfile_tool_access_test.go`** (modify) — add the refusal + regression tests (T1, T2, T3, T4, T5, T6, T7, T8, T9, T11).
+- **`docs/architecture.md`** (modify) — one-line responsibility note on the `helpers.go` line.
+
+---
+
+## Task 1: Export the dipx no-follow read primitive (rename)
+
+**Files:**
+- Modify: `dipx/helpers.go:385-411` (doc comment + `func readNoFollowSymlinks`), `dipx/helpers.go:317` (caller)
+
+This is a pure rename + doc-comment generalization. The existing dipx tests (`TestPack_RejectsSymlink`, `TestPack_RejectsParentSymlink`) are the regression guard — they exercise this code via `Pack` and must stay green.
+
+- [ ] **Step 1: Update the caller at `helpers.go:317`**
+
+In `func (s *packWalkState) readAndRecord`, change:
+
+```go
+	raw, err := readNoFollowSymlinks(cur, s.rootDir)
+```
+
+to:
+
+```go
+	raw, err := ReadNoFollowSymlinks(cur, s.rootDir)
+```
+
+- [ ] **Step 2: Rename the function and generalize its doc comment (`helpers.go:385-396`)**
+
+Replace the doc comment + signature line (from `// readNoFollowSymlinks reads a file…` down through `func readNoFollowSymlinks(path, rootDir string) ([]byte, error) {`) with:
+
+```go
+// ReadNoFollowSymlinks reads a file, refusing to follow symlinks at the leaf OR
+// at any intermediate path component between rootDir and path. Shared by the
+// Pack walker and the cross-file tool_access lint (cmd/dippin) so both refuse
+// symlinks identically. It closes a parent-component-symlink data-exfil vector:
+// a tree containing `sub -> /etc` would otherwise let a leaf `sub/foo.dip` read
+// `/etc/foo.dip`, because Lstat on the leaf reports a regular file, not a symlink.
+//
+// It does NOT perform the `..`-escape (containment) check — callers must run that
+// separately BEFORE calling this (the pack walker via resolveRefOnDisk, the lint
+// via ensureUnderRoot). rootDir is only the ancestor-scan boundary here.
+//
+// rootDir itself is treated as the trust anchor: it is an absolute path supplied
+// by the caller, may itself be a user-specified symlink, and is not re-validated.
+// Components strictly between rootDir and path's leaf MUST be directories that are
+// not symlinks.
+func ReadNoFollowSymlinks(path, rootDir string) ([]byte, error) {
+```
+
+- [ ] **Step 3: Run the dipx tests to verify the rename is clean**
+
+Run: `just test-pkg dipx`
+Expected: PASS (all dipx tests, including `TestPack_RejectsSymlink` / `TestPack_RejectsParentSymlink`). No "undefined: readNoFollowSymlinks" or "declared and not used".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dipx/helpers.go
+git commit -m "refactor(dipx): export readNoFollowSymlinks as ReadNoFollowSymlinks
+
+Capitalize + generalize the no-follow read primitive's doc comment so the
+cross-file tool_access lint (#100) can share it with the Pack walker. Pure
+rename of merged #79/#85 code; behavior unchanged; sole caller updated.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Unit-test the exported primitive (T10)
+
+**Files:**
+- Modify: `dipx/dipx_test.go` (add `TestReadNoFollowSymlinks`; `package dipx` internal test — `ReadNoFollowSymlinks`, `ErrPathUnsafe`, `minimalDipSrc` are all in scope)
+
+- [ ] **Step 1: Write the test**
+
+Append to `dipx/dipx_test.go`:
+
+```go
+// TestReadNoFollowSymlinks pins the contract of the now-exported no-follow read
+// primitive: happy path reads, leaf-symlink refusal, ancestor-symlink refusal,
+// and the not-regular-file branch (the documented fail-soft path for a ref that
+// resolves to a directory, including the root dir itself).
+func TestReadNoFollowSymlinks(t *testing.T) {
+	root := t.TempDir()
+
+	good := filepath.Join(root, "good.dip")
+	if err := os.WriteFile(good, []byte(minimalDipSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := ReadNoFollowSymlinks(good, root)
+	if err != nil {
+		t.Fatalf("happy path: unexpected err %v", err)
+	}
+	if string(data) != minimalDipSrc {
+		t.Fatalf("happy path: content mismatch")
+	}
+
+	link := filepath.Join(root, "link.dip")
+	if err := os.Symlink(good, link); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	if _, err := ReadNoFollowSymlinks(link, root); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("leaf symlink: err = %v, want ErrPathUnsafe", err)
+	}
+
+	realdir := filepath.Join(root, "real")
+	if err := os.Mkdir(realdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realdir, "f.dip"), []byte(minimalDipSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	linkdir := filepath.Join(root, "linkdir")
+	if err := os.Symlink(realdir, linkdir); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	if _, err := ReadNoFollowSymlinks(filepath.Join(linkdir, "f.dip"), root); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("ancestor symlink: err = %v, want ErrPathUnsafe", err)
+	}
+
+	if _, err := ReadNoFollowSymlinks(realdir, root); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("not-regular-file (directory): err = %v, want ErrPathUnsafe", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `just test-pkg dipx`
+Expected: PASS (including the new `TestReadNoFollowSymlinks`). If `dipx_test.go` is missing an `errors`/`os`/`path/filepath` import, the build will fail — add it (these are almost certainly already imported; verify before adding).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dipx/dipx_test.go
+git commit -m "test(dipx): unit-test ReadNoFollowSymlinks (leaf/ancestor/not-regular)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Generalize `ensureUnderRoot` (now shared)
+
+**Files:**
+- Modify: `cmd/dippin/pack_shadow.go:16-29` (doc comment + error message)
+
+`ensureUnderRoot` becomes shared between the pack-shadow writer and the cross-file lint. Drop the `"pack-inline:"` prefix from its error (it now fires from two subsystems) and note the shared use. Behavior is unchanged; existing pack tests guard it.
+
+- [ ] **Step 1: Replace the doc comment + function body (`pack_shadow.go:16-29`)**
+
+Replace:
+
+```go
+// ensureUnderRoot rejects any absolute path that resolves outside rootDir.
+// Guards the shadow-tree writer against a malicious subgraph ref like
+// `subgraph: ../../../escape.dip`, which would otherwise cause
+// writeShadowFile to write outside the temp shadow dir (since
+// filepath.Join(shadowDir, "../../../escape.dip") escapes). dipx.Pack does
+// its own escape check, but it runs AFTER we've built the shadow tree —
+// too late to prevent the out-of-tree write.
+func ensureUnderRoot(absPath, rootDir string) error {
+	rel, err := filepath.Rel(rootDir, absPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("pack-inline: ref escapes source root: %s", absPath)
+	}
+	return nil
+}
+```
+
+with:
+
+```go
+// ensureUnderRoot rejects any absolute path that resolves outside rootDir, via
+// the same lexical `..`-component check the pack walker uses (resolveRefOnDisk).
+// Shared by two CLI subsystems: the pack shadow-tree writer (guarding against a
+// ref like `subgraph: ../../../escape.dip` that would make writeShadowFile write
+// out of the temp dir) and the cross-file tool_access lint (#100), which uses it
+// fail-soft to refuse root-escaping child refs. absPath MUST be absolute (the
+// callers absolutize before calling); a relative rootDir makes filepath.Rel error
+// and is reported as an escape.
+func ensureUnderRoot(absPath, rootDir string) error {
+	rel, err := filepath.Rel(rootDir, absPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("ref escapes source root: %s", absPath)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Run the dippin package tests**
+
+Run: `just test-pkg dippin`
+Expected: PASS. (No existing test asserts on the `"pack-inline:"` string — verify with `grep -rn "pack-inline" cmd/dippin` returning only the now-changed source if any; if a test asserts the old message, update that assertion.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/dippin/pack_shadow.go
+git commit -m "refactor(cli): generalize ensureUnderRoot for shared use (#100)
+
+Drop the pack-specific 'pack-inline:' error prefix and broaden the doc comment
+now that the cross-file tool_access lint reuses this escape check. Behavior
+unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Write the refusal tests (RED)
+
+**Files:**
+- Modify: `cmd/dippin/crossfile_tool_access_test.go` (add T1, T2, T6, T11)
+
+These four assert the *new* refusal behavior and therefore FAIL against current code (which follows symlinks / escaping refs and fires DIP146). They use the existing `writeWorkflows` / `crossDiags` / `countCode` helpers and existing fixture constants (`entryRestrictsRefs`, `childZeroIntent`). Symlink tests skip if `os.Symlink` is unsupported.
+
+- [ ] **Step 1: Add the four tests**
+
+Append to `cmd/dippin/crossfile_tool_access_test.go`:
+
+```go
+// childWithBoundary is a full-restrict child that itself delegates to `ref`,
+// so a refusal/resolution can be observed one hop below the entry.
+func childWithBoundary(ref string) string {
+	return `workflow Child
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  manager_loop Sup
+    subgraph_ref: ` + ref + `
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+}
+
+func hasPosture(classified map[ir.SourceLocation]childPosture, want childPosture) bool {
+	for _, p := range classified {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+// T1 — a boundary child ref that is a SYMLINK (even to a legitimate in-root .dip)
+// is refused: fail-soft -> postureUnresolved, DIP143 retained (supersedes==false),
+// no DIP146, no error. Also pins T5's policy: a benign in-root symlink target is
+// still refused unconditionally (do not "fix" into a false-positive exception).
+func TestCrossFile_SymlinkedChildRefused(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":     entryRestrictsRefs("child.dip"),
+		"realchild.dip": childZeroIntent,
+	})
+	if err := os.Symlink(filepath.Join(dir, "realchild.dip"), filepath.Join(dir, "child.dip")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (symlinked child refused), got %d", got)
+	}
+	for _, p := range classified {
+		if p != postureUnresolved {
+			t.Errorf("want postureUnresolved (DIP143 retained), got %v", p)
+		}
+	}
+}
+
+// T2 — a child ref that ESCAPES the entry-file containment root is refused
+// fail-soft. The entry lives in a subdir so its root is dir/sub; `../escape.dip`
+// resolves to dir/escape.dip, outside root but inside the temp tree (so current,
+// unhardened code WOULD read it and fire DIP146 — making this red-first).
+func TestCrossFile_RootEscapingChildRefused(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"sub/entry.dip": entryRestrictsRefs("../escape.dip"),
+		"escape.dip":    childZeroIntent,
+	})
+	diags, classified := crossDiags(t, dir, "sub/entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (root-escaping child refused), got %d", got)
+	}
+	for _, p := range classified {
+		if p != postureUnresolved {
+			t.Errorf("want postureUnresolved (DIP143 retained), got %v", p)
+		}
+	}
+}
+
+// T6 — a child reached through a SYMLINKED ANCESTOR DIRECTORY is refused
+// (the assertNoSymlinkAncestor vector), even though the leaf itself is a real file.
+func TestCrossFile_SymlinkedAncestorRefused(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":      entryRestrictsRefs("linkdir/child.dip"),
+		"realdir/child.dip": childZeroIntent,
+	})
+	if err := os.Symlink(filepath.Join(dir, "realdir"), filepath.Join(dir, "linkdir")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (symlinked ancestor refused), got %d", got)
+	}
+	for _, p := range classified {
+		if p != postureUnresolved {
+			t.Errorf("want postureUnresolved (DIP143 retained), got %v", p)
+		}
+	}
+}
+
+// T11 — refusal at DEPTH: entry -> child (real, full-restrict) -> grandchild via
+// a symlink. The child classifies normally (full-restrict, no DIP146); the
+// grandchild boundary is refused (postureUnresolved); recursion continues without
+// abort. Distinct code path from T1 (refusal mid-recursion).
+func TestCrossFile_SymlinkRefusalAtDepth(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":     entryRestrictsRefs("child.dip"),
+		"child.dip":     childWithBoundary("grandlink.dip"),
+		"realgrand.dip": childZeroIntent,
+	})
+	if err := os.Symlink(filepath.Join(dir, "realgrand.dip"), filepath.Join(dir, "grandlink.dip")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (grandchild symlink refused), got %d: %v", got, diags)
+	}
+	if !hasPosture(classified, postureFullRestrict) {
+		t.Errorf("want the child boundary classified full-restrict: %v", classified)
+	}
+	if !hasPosture(classified, postureUnresolved) {
+		t.Errorf("want the grandchild boundary classified unresolved: %v", classified)
+	}
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they FAIL**
+
+Run: `just test-pkg dippin 2>&1 | grep -E "SymlinkedChildRefused|RootEscapingChildRefused|SymlinkedAncestorRefused|SymlinkRefusalAtDepth|FAIL|ok"`
+Expected: all four FAIL — current code follows the symlink/escape and resolves the child, so `countCode(DIP146)` is `1`, not `0` (e.g. "want 0 DIP146 (symlinked child refused), got 1"). If any reports "skipped", symlinks are unsupported here — that's acceptable for the symlink cases, but `RootEscapingChildRefused` (no symlink) MUST fail.
+
+- [ ] **Step 3: Commit the red tests**
+
+```bash
+git add cmd/dippin/crossfile_tool_access_test.go
+git commit -m "test(cli): failing tests for cross-file symlink/escape refusal (#100)
+
+T1/T6/T11 (symlink leaf/ancestor/depth) and T2 (root escape) — currently RED:
+the unhardened resolver follows them and fires DIP146 instead of refusing.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Implement the hardening (GREEN)
+
+**Files:**
+- Modify: `cmd/dippin/crossfile_tool_access.go` (imports; `crossFileToolAccess`, `walkBoundaries`, `visitBoundary`, `maybeRecurse`, `resolveBoundaryChild`; replace `resolveBoundaryRefPath` with `resolveChildPath`)
+
+Thread a fixed absolute `root` through the walk and route the child read through `ensureUnderRoot` + `dipx.ReadNoFollowSymlinks`.
+
+- [ ] **Step 1: Swap the `os` import for `dipx`**
+
+In the import block, remove `"os"` (its only use, `os.ReadFile`, is being deleted) and add the dipx import. The block becomes:
+
+```go
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/2389-research/dippin-lang/dipx"
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/validator"
+)
+```
+
+- [ ] **Step 2: Derive the absolute root once and pass it into the walk**
+
+In `crossFileToolAccess`, change the call:
+
+```go
+	intentSeen := validator.WorkflowDeclaresToolAccess(entry)
+	walkBoundaries(entry, intentSeen, 0, visited, &diags, classified)
+```
+
+to:
+
+```go
+	intentSeen := validator.WorkflowDeclaresToolAccess(entry)
+	// root is the containment anchor for every child ref, captured ONCE from the
+	// entry's directory and threaded unchanged (never recomputed per-parent — see
+	// spec D2/C2). absOrClean makes it absolute so ensureUnderRoot's filepath.Rel
+	// can compare it against absolute child targets.
+	root := filepath.Dir(absOrClean(entryPath))
+	walkBoundaries(entry, intentSeen, 0, root, visited, &diags, classified)
+```
+
+- [ ] **Step 3: Thread `root` through `walkBoundaries`, `visitBoundary`, `maybeRecurse`**
+
+Change `walkBoundaries`'s signature and its `visitBoundary` call:
+
+```go
+func walkBoundaries(w *ir.Workflow, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+	for _, n := range w.Nodes {
+		_, ref := boundaryKindRef(n)
+		if ref == "" || n.Source.File == "" {
+			continue
+		}
+		visitBoundary(n, ref, intentSeen, depth, root, visited, diags, classified)
+	}
+}
+```
+
+Change `visitBoundary`'s signature and its two callees:
+
+```go
+func visitBoundary(n *ir.Node, ref string, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+	child, childPath := resolveBoundaryChild(n, ref, root)
+	if child == nil {
+		classified[n.Source] = postureUnresolved
+		return
+	}
+	posture := classifyChild(child)
+	classified[n.Source] = posture
+	if intentSeen && posture == postureZeroIntent {
+		*diags = append(*diags, boundaryDiag(n, ref))
+	}
+	maybeRecurse(child, childPath, intentSeen, depth, root, visited, diags, classified)
+}
+```
+
+Change `maybeRecurse`'s signature and its `walkBoundaries` call (root is a pure pass-through here):
+
+```go
+func maybeRecurse(child *ir.Workflow, childPath string, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+	key := canonicalKey(childPath)
+	if key == "" || visited[key] || depth+1 > crossFileMaxDepth {
+		return
+	}
+	visited[key] = true
+	childIntent := intentSeen || validator.WorkflowDeclaresToolAccess(child)
+	walkBoundaries(child, childIntent, depth+1, root, visited, diags, classified)
+}
+```
+
+- [ ] **Step 4: Replace `resolveBoundaryChild` and `resolveBoundaryRefPath` with the hardened pair**
+
+Replace both `resolveBoundaryChild` (`:89-103`) and `resolveBoundaryRefPath` (`:105-112`) with:
+
+```go
+// resolveBoundaryChild resolves ref relative to the boundary node's source file,
+// refusing root-escaping or symlinked targets, then parses the child workflow.
+// Fail-soft: ANY error (escape, symlink, read, parse) yields (nil, ""), routing
+// the boundary to postureUnresolved so the per-file DIP143 advisory is retained.
+// This is detection parity with the pack walker (Lstat-based, not the parser's
+// stronger O_NOFOLLOW open-once — the residual leaf TOCTOU matches pack's; a lint
+// emits only DIP codes, never file content). Callers (walkBoundaries) guarantee
+// ref != "" and n.Source.File != "".
+func resolveBoundaryChild(n *ir.Node, ref, root string) (*ir.Workflow, string) {
+	path, err := resolveChildPath(n.Source.File, ref, root)
+	if err != nil {
+		return nil, ""
+	}
+	data, err := dipx.ReadNoFollowSymlinks(path, root)
+	if err != nil {
+		return nil, ""
+	}
+	w, err := parseAndResolveDip(data, path)
+	if err != nil {
+		return nil, ""
+	}
+	return w, path
+}
+
+// resolveChildPath joins ref against parentFile's directory and refuses any result
+// that escapes root. Pack-identical (mirrors dipx's resolveRefOnDisk): filepath.Join
+// swallows the leading slash of an absolute ref, so abs refs are RE-ROOTED under
+// root, not read out-of-root. The filepath.Abs is load-bearing — at the entry level
+// parentFile (n.Source.File) may be relative while root is absolute, and
+// ensureUnderRoot's filepath.Rel needs both absolute. Do not simplify it away.
+func resolveChildPath(parentFile, ref, root string) (string, error) {
+	target := filepath.Clean(filepath.Join(filepath.Dir(parentFile), ref))
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureUnderRoot(abs, root); err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+```
+
+- [ ] **Step 5: Run the Task 4 refusal tests — now GREEN**
+
+Run: `just test-pkg dippin 2>&1 | grep -E "SymlinkedChildRefused|RootEscapingChildRefused|SymlinkedAncestorRefused|SymlinkRefusalAtDepth|FAIL|ok"`
+Expected: all four PASS (or symlink cases SKIP where unsupported; `RootEscapingChildRefused` PASSES). No FAIL. The full `dippin` package (existing cross-file tests included) is `ok` — they use plain in-root sibling/subdir refs and are unaffected.
+
+- [ ] **Step 6: Confirm no leftover references to the deleted function / import**
+
+Run: `grep -n "resolveBoundaryRefPath\|os\\.ReadFile" cmd/dippin/crossfile_tool_access.go`
+Expected: no output (function deleted, `os.ReadFile` gone).
+
+- [ ] **Step 7: Check complexity stays within budget**
+
+Run: `just complexity`
+Expected: no violations. (`resolveBoundaryChild` cyclo 4, `resolveChildPath` cyclo 3, threaded functions gain no branch — all ≤ 5.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/dippin/crossfile_tool_access.go
+git commit -m "feat(cli): refuse symlinked/root-escaping cross-file children (#100)
+
+Thread a fixed absolute containment root (the entry file's directory) through
+the DIP146 walk and route each child read through ensureUnderRoot (lexical
+..-escape refusal) + dipx.ReadNoFollowSymlinks (leaf+ancestor symlink refusal),
+replacing the unhardened os.ReadFile. Fail-soft: any refusal -> postureUnresolved
+-> DIP143 retained, no DIP146, no abort. Deletes the absolute-ref special-case
+(re-rooted, pack-identical). Detection parity with the pack walker; no tracker
+dependency.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Add the regression / coverage guards (GREEN)
+
+**Files:**
+- Modify: `cmd/dippin/crossfile_tool_access_test.go` (add T3, T4, T5, T7, T8, T9)
+
+These validate that correct behavior is preserved (legit children still resolve; relative entry works; abs refs re-root; symlink cycle terminates) and guard the lynchpin (absolute root, fixed not per-parent). They pass on the Task 5 implementation; T3 and T7 would fail under specific implementation bugs.
+
+- [ ] **Step 1: Add the six tests**
+
+Append to `cmd/dippin/crossfile_tool_access_test.go`:
+
+```go
+// T3 — HIGHEST-VALUE GUARD: a subdir child whose ref climbs back UP into the entry
+// root must still resolve. entry -> sub/child.dip (full-restrict) -> ../other.dip
+// (zero-intent, == root/other.dip, in-root). Correct (entry-anchored fixed root):
+// other resolves, DIP146 fires on the child->other edge => count 1. A BUGGY
+// per-parent-root recompute (root = dir(sub/child.dip) = root/sub) would refuse
+// ../other.dip (escapes root/sub) => count 0. So this fails under that bug.
+func TestCrossFile_SubdirChildClimbsBackIntoRoot(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":     entryRestrictsRefs("sub/child.dip"),
+		"sub/child.dip": childWithBoundary("../other.dip"),
+		"other.dip":     childZeroIntent,
+	})
+	diags, _ := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 1 {
+		t.Fatalf("want 1 DIP146 on the climb-back ../other.dip edge, got %d: %v", got, diags)
+	}
+}
+
+// T4 — legit sibling AND subdirectory children resolve normally; DIP146
+// supersession works exactly as before the hardening (regression guard).
+func TestCrossFile_LegitSiblingAndSubdirResolve(t *testing.T) {
+	sibling := writeWorkflows(t, map[string]string{
+		"entry.dip": entryRestrictsRefs("child.dip"),
+		"child.dip": childZeroIntent,
+	})
+	if got := countCode(firstDiags(t, sibling, "entry.dip"), validator.DIP146); got != 1 {
+		t.Fatalf("sibling: want 1 DIP146, got %d", got)
+	}
+	subdir := writeWorkflows(t, map[string]string{
+		"entry.dip":     entryRestrictsRefs("sub/child.dip"),
+		"sub/child.dip": childZeroIntent,
+	})
+	if got := countCode(firstDiags(t, subdir, "entry.dip"), validator.DIP146); got != 1 {
+		t.Fatalf("subdir: want 1 DIP146, got %d", got)
+	}
+}
+
+// T5 — policy pin: a symlink whose target is a perfectly legitimate in-root file
+// is STILL refused (all symlinks refused unconditionally, matching pack). Pins the
+// conservative policy so it is not later "fixed" into a false-positive exception.
+func TestCrossFile_BenignInRootSymlinkRefused(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":  entryRestrictsRefs("child.dip"),
+		"target.dip": childZeroIntent,
+	})
+	if err := os.Symlink(filepath.Join(dir, "target.dip"), filepath.Join(dir, "child.dip")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (benign in-root symlink still refused), got %d", got)
+	}
+	if !hasPosture(classified, postureUnresolved) {
+		t.Errorf("want postureUnresolved, got %v", classified)
+	}
+}
+
+// T7 — lynchpin guard (spec D2): a RELATIVE entry path must still resolve legit
+// children. crossDiags always builds an absolute entry path, so this drives the
+// pass with a relative path via os.Chdir. If root were left relative (no absOrClean),
+// ensureUnderRoot's filepath.Rel(relRoot, absChild) would error and refuse every
+// child => count 0. Not parallel-safe (mutates cwd); the file uses no t.Parallel.
+func TestCrossFile_RelativeEntryResolves(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip": entryRestrictsRefs("child.dip"),
+		"child.dip": childZeroIntent,
+	})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	w, err := loadWorkflow("entry.dip")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	diags, _ := crossFileToolAccess(w, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 1 {
+		t.Fatalf("want 1 DIP146 with a relative entry path, got %d", got)
+	}
+}
+
+// T8 — an absolute ref is re-rooted under the parent dir (filepath.Join swallows
+// the leading slash), not read out-of-root. /etc/passwd re-roots to <root>/etc/passwd
+// which does not exist => postureUnresolved (DIP143 retained). Documents re-rooting;
+// it does NOT assert literal absolute-path refusal.
+func TestCrossFile_AbsoluteRefReRooted(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip": entryRestrictsRefs("/etc/passwd"),
+	})
+	diags, classified := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (abs ref re-rooted, target absent), got %d", got)
+	}
+	for _, p := range classified {
+		if p != postureUnresolved {
+			t.Errorf("want postureUnresolved, got %v", p)
+		}
+	}
+}
+
+// T9 — a symlink that would form a cycle is refused at the first hop (so the cycle
+// is never entered) and the walk terminates. Termination of NON-symlink cycles is
+// covered by TestCrossFile_CycleTerminates / TestCrossFile_SelfReferenceTerminates;
+// this only asserts the refusal short-circuit does not hang.
+func TestCrossFile_SymlinkCycleRefused(t *testing.T) {
+	a := childWithBoundary("blink.dip") // a.dip -> blink.dip
+	dir := writeWorkflows(t, map[string]string{
+		"a.dip": a,
+	})
+	// blink.dip is a symlink back to a.dip (a would-be a->blink->a cycle).
+	if err := os.Symlink(filepath.Join(dir, "a.dip"), filepath.Join(dir, "blink.dip")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	diags, classified := crossDiags(t, dir, "a.dip")
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (symlink hop refused), got %d", got)
+	}
+	if !hasPosture(classified, postureUnresolved) {
+		t.Errorf("want the symlink boundary classified unresolved: %v", classified)
+	}
+}
+
+// firstDiags runs the pass and returns only the diagnostics (helper for cases that
+// don't inspect the classified map).
+func firstDiags(t *testing.T, dir, entry string) []validator.Diagnostic {
+	t.Helper()
+	diags, _ := crossDiags(t, dir, entry)
+	return diags
+}
+```
+
+- [ ] **Step 2: Run the new guards**
+
+Run: `just test-pkg dippin 2>&1 | grep -E "SubdirChildClimbsBackIntoRoot|LegitSiblingAndSubdirResolve|BenignInRootSymlinkRefused|RelativeEntryResolves|AbsoluteRefReRooted|SymlinkCycleRefused|FAIL|ok"`
+Expected: all PASS (symlink cases SKIP where unsupported). No FAIL.
+
+- [ ] **Step 3: Run the full dippin package once more**
+
+Run: `just test-pkg dippin`
+Expected: PASS — all existing + new cross-file tests green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/dippin/crossfile_tool_access_test.go
+git commit -m "test(cli): regression/lynchpin guards for #100 hardening
+
+T3 (subdir climbs back into root — guards per-parent-root recompute), T4 (legit
+sibling/subdir still resolve), T5 (benign in-root symlink still refused), T7
+(relative entry — guards absolute-root lynchpin), T8 (abs ref re-rooted), T9
+(symlink cycle refused/terminates).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Doc note + full verification
+
+**Files:**
+- Modify: `docs/architecture.md` (the `helpers.go` responsibility line)
+
+- [ ] **Step 1: Add the responsibility note**
+
+Open `docs/architecture.md`, find the line describing `helpers.go` (around `:148`):
+
+```
+│   ├── helpers.go      # Hash verify, parse-and-link, walkSourceTree
+```
+
+Append the shared read primitive to the responsibility list, e.g.:
+
+```
+│   ├── helpers.go      # Hash verify, parse-and-link, walkSourceTree, ReadNoFollowSymlinks (shared no-follow read)
+```
+
+(Match the existing comment style/width; this is a responsibility note, not an exhaustive export list.)
+
+- [ ] **Step 2: Run the full race suite**
+
+Run: `just test-race`
+Expected: PASS across all packages.
+
+- [ ] **Step 3: Confirm the example suites do not flip**
+
+Run: `just validate-examples && just lint-examples`
+Expected: both succeed; no example changes its diagnostics (all example subgraph/manager_loop refs are plain in-root relative paths — none are symlinked or escaping).
+
+- [ ] **Step 4: Confirm the wasm build stays green**
+
+Run: `just wasm`
+Expected: build OK (dipx is not in the wasm closure; the lint pass is `cmd/dippin`-only; `ReadNoFollowSymlinks` uses no `syscall`).
+
+- [ ] **Step 5: Commit the doc note**
+
+```bash
+git add docs/architecture.md
+git commit -m "docs: note ReadNoFollowSymlinks as a shared dipx responsibility (#100)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 6: Final full-suite gate (pre-commit parity)**
+
+Run: `just build && just vet && just test && just complexity && just validate-examples`
+Expected: all green. (`just check` fails locally on tree-sitter-generate — that's the known environment gotcha; the pre-commit hook on the next commit is the real CI gate and runs build/vet/golangci-lint/gofmt/tests/releasecheck/complexity/validate-examples.)
+
+---
+
+## Self-Review notes (traceability to spec)
+
+- **D1 (sharing):** Task 1 (export `ReadNoFollowSymlinks`), Task 3 (generalize `ensureUnderRoot`), Task 5 Step 4 (compose both). No combined function; no pack-path (`resolveRefOnDisk`) edit.
+- **D2 (fixed absolute root):** Task 5 Step 2 (`root := filepath.Dir(absOrClean(entryPath))`, threaded by value). Guarded by T7 (relative entry) and T3 (no per-parent recompute).
+- **D3 (resolution flow, no IsAbs):** Task 5 Step 4 (`resolveChildPath`, `resolveBoundaryRefPath` deleted). Abs re-rooting guarded by T8.
+- **D4 (fail-soft):** Task 5 Step 4 (all errors → `(nil, "")`); T1/T2/T6/T11 assert `postureUnresolved` + 0 DIP146 + no abort.
+- **D5 (cycle):** T9 (symlink hop refused, terminates); existing literal-ref cycle tests unchanged.
+- **Scope — no new DIP, no build tags:** confirmed (no `validator` code edits; no `//go:build`). File directives untouched (out of scope by pack parity).
+- **Tests T1–T11:** T1=SymlinkedChildRefused (absorbs T5 policy via comment; T5 also kept explicit as BenignInRootSymlinkRefused), T2=RootEscapingChildRefused, T3=SubdirChildClimbsBackIntoRoot, T4=LegitSiblingAndSubdirResolve, T5=BenignInRootSymlinkRefused, T6=SymlinkedAncestorRefused, T7=RelativeEntryResolves, T8=AbsoluteRefReRooted, T9=SymlinkCycleRefused, T10=TestReadNoFollowSymlinks (dipx), T11=SymlinkRefusalAtDepth.
+- **Verification:** Task 7 (test-race, complexity, wasm, validate/lint-examples).
+</content>
+</invoke>

--- a/docs/superpowers/specs/2026-06-08-issue-100-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-100-design.md
@@ -47,12 +47,31 @@ exported symbol:
 - **Escape check** — reuse `ensureUnderRoot(absPath, rootDir)` (`cmd/dippin/pack_shadow.go:23`),
   which already lives in `package main` and performs the identical lexical
   `rel == ".." || strings.HasPrefix(rel, ".."+sep)` containment check the pack walker
-  uses. No new escape helper; no fifth copy of the check.
+  uses (byte-for-byte the same predicate as `resolveRefOnDisk`, `helpers.go:360`). No new
+  escape helper; no fifth copy of the check. **`ensureUnderRoot` becomes shared** between
+  the pack-shadow writer and the cross-file lint, so two small follow-on edits are part of
+  this change: (1) drop the `"pack-inline:"` prefix from its error message (the message now
+  fires from two subsystems; even though the cross-file caller discards the error fail-soft,
+  the prefix would lie about origin for any future logging), and (2) add a one-line
+  "also used by the cross-file lint" note to its doc comment (currently pack-shadow-specific).
+  The function is **not** forked or relocated (relocation is out of scope — see "Scope").
 - **Symlink-refusing read** — export the existing `dipx.readNoFollowSymlinks` by
   capitalizing it to **`dipx.ReadNoFollowSymlinks(path, rootDir string) ([]byte, error)`**.
   It performs leaf-symlink refusal (`os.Lstat` + `os.ModeSymlink`) **and** ancestor-symlink
   refusal (`assertNoSymlinkAncestor`, which stays unexported). Its sole internal caller
-  (`packWalkState.readAndRecord`, `helpers.go:317`) is updated to the new name.
+  (`packWalkState.readAndRecord`, `helpers.go:317`) is updated to the new name (verified:
+  exactly one caller repo-wide; no test references the unexported name).
+
+  **Name rationale (kept over `ReadFileNoFollow`/`ReadWithinRoot`):** the plural
+  `…Symlinks` name accurately covers *both* the leaf and ancestor symlink refusal this
+  function performs (a singular `…NoFollow` would underpromise the ancestor walk). The
+  `rootDir` parameter is the ancestor-scan boundary, **not** a containment guarantee: this
+  function does **not** perform the `..`-escape check — that is `ensureUnderRoot`'s separate,
+  prior responsibility (§D3 "Ordering"). The doc comment must state this explicitly so a
+  caller never reads the name as "reads safely within root" and drops the `ensureUnderRoot`
+  call — that two-call contract is load-bearing for correctness. Renaming in place (vs. an
+  alias wrapper) is correct here: dipx is an internal module with no API-stability
+  constraint, so a wrapper would only double the symbol/doc surface.
 
 This was chosen over the alternatives:
 - **A single combined `dipx.ReadRefWithinRoot`** (originally proposed): rejected — it
@@ -78,10 +97,28 @@ boundary stays in `cmd/dippin`; the fail-soft caller discards the dipx error.
 
 ### D2 — Containment root: the entry file's directory, captured once
 
-`root = filepath.Dir(absEntryPath)`, computed **once** in `crossFileToolAccess` from
-`entryPath` and threaded **by value, unchanged**, through the recursion. This mirrors the
-pack walker exactly (`walkSourceTree`: `rootDir := filepath.Dir(entryAbs)`, constant for
-the whole walk).
+`root = filepath.Dir(absOrClean(entryPath))`, computed **once** in `crossFileToolAccess`
+from `entryPath` and threaded **by value, unchanged**, through the recursion. This mirrors
+the pack walker exactly (`walkSourceTree`: `rootDir := filepath.Dir(entryAbs)`, constant
+for the whole walk).
+
+**Lynchpin — root MUST be absolute.** `entryPath` arrives verbatim from the CLI and may be
+relative (e.g. `dippin validate examples/foo.dip`), and the parser stores `Source.File`
+verbatim too. `ensureUnderRoot` calls `filepath.Rel(root, absTarget)`, and
+`filepath.Rel` **errors when mixing a relative base with an absolute target** — which
+`ensureUnderRoot` maps to "escapes" → every legitimate child spuriously refused. So root
+must be absolutized first (the existing `absOrClean`, `crossfile_tool_access.go:168`, does
+exactly this and is already used by `canonicalKey`). Because the child target is also made
+absolute (§D3) against the same cwd, the two stay consistent. Two reviewers independently
+flagged this as the single highest-risk implementation detail; **T7 is its guard.**
+
+Threading note: `root` is added as a `string` parameter to `walkBoundaries`,
+`visitBoundary`, `maybeRecurse` (pure pass-through into `walkBoundaries`), and
+`resolveBoundaryChild`. This takes `walkBoundaries`/`visitBoundary` to 7 parameters — a
+mild readability smell but **lint-clean** (no `maxParams`/`gocritic`/`unparam` rule is
+enabled; `funlen` is length-only). Collapsing the walk's parameters into a state struct
+(as `packWalkState` does) is a reasonable future cleanup but **out of scope** here — adding
+one threaded param is the surgical change.
 
 **Critical implementation constraint (correctness C2):** the root must **not** be
 recomputed per-parent. A grandchild ref is resolved against *its parent's* source-file
@@ -98,8 +135,12 @@ The dedicated regression test (T3 below) pins this.
 
 ### D3 — Resolution flow (pack-identical; no `IsAbs` special-case)
 
-`resolveBoundaryRefPath`'s current `filepath.IsAbs(ref)` branch (returns the ref verbatim)
-is **deleted**. Resolution becomes pack-identical:
+`resolveBoundaryRefPath` (`crossfile_tool_access.go:107`, its only caller is
+`resolveBoundaryChild:93`, no test references it) is **replaced entirely** by
+`resolveChildPath` — not edited in place. Its current `filepath.IsAbs(ref)` branch (which
+returns the ref verbatim and is the actual vulnerability — `os.ReadFile("/etc/passwd")`
+reads out-of-root today) is gone, and the new function returns `(string, error)` rather
+than a bare string. Resolution becomes pack-identical:
 
 ```
 resolveChildPath(parentFile, ref, root) -> (abs string, err error):
@@ -130,7 +171,10 @@ path already proven under root.
 **Path absoluteness:** `resolveChildPath` returns an absolute path; it becomes the
 returned `childPath`, which seeds the next level's `n.Source.File` and the visited-set key
 — keeping all paths absolute and comparable across recursion levels, including when the
-entry was passed as a relative path (T6).
+entry was passed as a relative path (T7). At the entry level, `parentFile` (`n.Source.File`)
+may be **relative**, while `root` is absolute; the `filepath.Abs(target)` step is what
+reconciles them so `ensureUnderRoot`'s `Rel(absRoot, absTarget)` succeeds. An implementation
+comment should mark that `Abs` as load-bearing — do **not** "simplify" it away.
 
 ### D4 — Fail-soft (verified, unchanged contract)
 
@@ -179,6 +223,14 @@ termination guarantee and are unaffected.
   lint (this issue does not introduce that path). Bringing the *child-`.dip`-ref*
   resolution to pack parity is the complete deliverable; root-constraining file
   directives would be a separate, broader change.
+- **Escape-check de-duplication is deferred.** Reusing `ensureUnderRoot` leaves the lexical
+  `..`-escape predicate standing in four sites (`ensureUnderRoot` `pack_shadow.go:25`,
+  `resolveRefOnDisk` `helpers.go:360`, `resolveDir` `source.go:140`, and `collectRefPaths`
+  via `ensureUnderRoot`). This change reuses the closest existing copy (the in-`package main`
+  one) and does **not** unify the four — consolidating them, and possibly relocating
+  `ensureUnderRoot` out of `pack_shadow.go` into a shared home, would re-churn merged
+  #79/#85 security code for no behavioral gain. Named here so it is not mistaken for an
+  oversight.
 - **No build tags / no wasm impact.** `ReadNoFollowSymlinks` uses only portable stdlib
   (`os.Lstat`, `os.ModeSymlink`, `filepath.*`, `os.ReadFile`) — no `syscall`. dipx is not
   in the wasm dependency closure (only `validator` references it, from a test file), and
@@ -212,13 +264,22 @@ Each case is a failing test first:
 - **T1 — Symlinked child refused, fail-soft.** Boundary child ref is a symlink to a real
   in-root `.dip`. → `postureUnresolved`, DIP143 retained, **no DIP146**, no error, lint
   completes.
-- **T2 — Root-escaping child refused.** Child ref `../../outside.dip` (target physically
-  outside the entry root). → same fail-soft (refused, DIP143 retained, no DIP146, no
-  abort).
-- **T3 — Subdir child climbs back into root (the C2 regression guard).** `entry.dip →
-  sub/child.dip`, `sub/child.dip → ../other.dip` resolving to `root/other.dip` (in-root).
-  → **still resolves normally**; DIP146 supersession works as before. (Catches a
-  per-parent-root-recompute bug.) **Highest-value test.**
+- **T2 — Root-escaping child refused.** Child ref `../../outside.dip` whose target is
+  physically outside the entry root. **Harness note:** `writeWorkflows` writes everything
+  under one `t.TempDir()` and cannot place a file outside root — the test must create a
+  *second* dir (a sibling `t.TempDir()` / `os.MkdirTemp`) for the outside target, mirroring
+  `dipx_test.go`'s `TestPack_RejectsParentSymlink`. → fail-soft (refused, DIP143 retained,
+  no DIP146, no abort).
+- **T3 — Subdir child climbs back into root (the C2 regression guard). Highest-value test.**
+  `entry.dip → sub/child.dip`, and `sub/child.dip → ../other.dip` resolving to
+  `root/other.dip` (escapes `sub/` but stays under the entry `root`). The assertion must be
+  **concrete**, not "no crash": the path must carry tool_access **intent** and `other.dip`
+  must be **zero-intent**, so a correct run emits a specific **DIP146 count (== the expected
+  number)** / non-`postureUnresolved` classification on the `../other.dip` boundary. The
+  fixture is deliberately constructed so that a **buggy per-parent-root recompute** (root =
+  `dir(sub/child.dip)` = `root/sub`) **would refuse** `../other.dip` (it escapes `root/sub`)
+  — making the test *fail* under the bug and *pass* only with the fixed entry-anchored root.
+  A weaker "child resolved" assertion would pass under the bug and guard nothing.
 - **T4 — Legit sibling and subdirectory child (regression guard).** No symlink, within
   root, sibling and one-level-subdir variants. → resolves, DIP146 supersession unchanged.
 - **T5 — Benign in-root symlink refused (pins policy).** A symlink whose target is a real
@@ -228,9 +289,13 @@ Each case is a failing test first:
 - **T6 — Symlinked ancestor directory refused.** `entry.dip → linkdir/child.dip` where
   `linkdir` is a symlink to a real in-root directory. → refused (ancestor-symlink vector,
   mirrors the dipx parent-component test).
-- **T7 — Relative entry path.** Entry passed as a relative path. → `canonicalKey`/escape
-  keys still align so DIP143 supersession works for legit children (guards the
-  supersession-key normalization).
+- **T7 — Relative entry path (guards the root-must-be-absolute lynchpin, §D2).** Entry
+  passed as a *relative* path with a legit in-root child. → child still resolves; no
+  spurious refusal. **Harness note:** `crossDiags` always builds an absolute `entryPath`
+  (`filepath.Join(dir, entry)`), so it cannot exercise this — the test needs a relative
+  call path (`os.Chdir(dir)` with a `t.Cleanup` restoring cwd, then `loadWorkflow("entry.dip")`
+  + `crossFileToolAccess`). These tests must not run with `t.Parallel()` (the existing file
+  doesn't).
 - **T8 — Absolute ref re-rooted.** `subgraph_ref: /etc/passwd`. → re-rooted under the
   parent dir, target does not exist in-root → `postureUnresolved` (DIP143 retained).
   Asserts re-rooting + fail-soft, **not** literal absolute-path refusal.
@@ -238,8 +303,21 @@ Each case is a failing test first:
   symlink → `a.dip`. → first hop refused → `postureUnresolved`. Comment that termination
   is covered by the literal-ref cycle tests (T9 must not be relied on for termination).
 - **T10 — dipx unit test for `ReadNoFollowSymlinks`.** Happy path (in-root regular file
-  reads), leaf symlink refused (`ErrPathUnsafe`), ancestor symlink refused. Co-locate with
-  the existing dipx symlink tests (`dipx_test.go`), reusing their skip idiom.
+  reads), leaf symlink refused (`ErrPathUnsafe`), ancestor symlink refused, **and the
+  not-regular-file branch** (`helpers.go:407`) — e.g. a path resolving to a *directory* is
+  refused (`ErrPathUnsafe`). The not-regular-file branch is the documented fail-soft path
+  for a child ref that resolves to the root dir itself, so it
+  must be pinned by the new export's own unit test (an in-root ref resolving to a directory
+  — including the root dir itself, for which `ensureUnderRoot` returns `rel == "."` → nil,
+  passing the escape check — fails fast at the not-regular-file branch → fail-soft). Co-locate
+  in `dipx_test.go` (internal `package dipx`), mirroring `TestPack_RejectsSymlink` /
+  `TestPack_RejectsParentSymlink` and reusing their `os.Symlink`-skip idiom.
+- **T11 — Symlink refusal at depth (grandchild).** `entry.dip → child.dip` (real, in-root)
+  → `child.dip → sub/grand.dip` where `sub` or `grand.dip` is a symlink. → the *child*
+  classifies normally, the *grandchild* boundary is refused (`postureUnresolved`, DIP143
+  retained), and recursion continues without abort. Distinct code path from T1 (refusal
+  mid-recursion vs. at the entry's direct child) — the exact transitive vector this issue
+  closes.
 
 **Example-suite guard:** `just validate-examples` and `just lint-examples` must show **no
 example flipping** diagnostics.
@@ -251,7 +329,7 @@ tree-sitter-generate — CLI absent). Run:
 
 - `just test-pkg dipx` — pack escape/symlink tests still green after the rename; new
   `ReadNoFollowSymlinks` unit test (T10).
-- `just test-pkg dippin` — new cross-file tests (T1–T9).
+- `just test-pkg dippin` — new cross-file tests (T1–T9, T11).
 - `just test-race` — full suite under the race detector.
 - `just complexity` — `resolveChildPath` + `resolveBoundaryChild` stay under cyclo ≤5 /
   cognitive ≤7 (the extraction exists to keep both under cap; no `//nolint`).
@@ -261,22 +339,31 @@ tree-sitter-generate — CLI absent). Run:
 
 ## Doc updates
 
-- `docs/architecture.md` — the `helpers.go` exported-surface line gains
-  `ReadNoFollowSymlinks` (no-follow read primitive, now shared with the cross-file lint).
+- `docs/architecture.md:148` — this line describes `helpers.go`'s *responsibilities*
+  ("Hash verify, parse-and-link, walkSourceTree"), not an enumerated export list, so there
+  is no symbol list to amend; append a responsibility note (e.g. "+ shared no-follow read")
+  rather than treating it as an export inventory. The O_NOFOLLOW prose elsewhere
+  (`:320`) concerns the *parser*, not dipx, and stays untouched.
 - `ReadNoFollowSymlinks`'s doc comment — generalize from the Pack-specific framing to
-  "shared no-follow read primitive (pack walker + cross-file lint)"; keep the trust-anchor
-  note about `rootDir`.
+  "shared no-follow read primitive (pack walker + cross-file lint)"; **state that it does
+  not perform the `..`-escape check** (the caller's separate `ensureUnderRoot`
+  responsibility); keep the trust-anchor note about `rootDir`.
 
 ## Files touched
 
 - `dipx/helpers.go` — rename `readNoFollowSymlinks` → `ReadNoFollowSymlinks` (+ generalize
-  doc comment); update its one internal caller. `resolveRefOnDisk`/`assertNoSymlinkAncestor`
-  unchanged.
-- `cmd/dippin/crossfile_tool_access.go` — delete the `IsAbs` branch; add `resolveChildPath`
-  (Join+Clean+Abs+`ensureUnderRoot`); thread `root` (computed once in `crossFileToolAccess`)
-  through `walkBoundaries`/`visitBoundary`/`maybeRecurse`/`resolveBoundaryChild`; route the
-  read through `dipx.ReadNoFollowSymlinks`. Implementation comment citing the pack-parity /
-  TOCTOU rationale.
-- `cmd/dippin/crossfile_tool_access_test.go` — T1–T9.
-- `dipx/dipx_test.go` (or `helpers_test.go`) — T10.
-- `docs/architecture.md` — exported-surface line.
+  doc comment, incl. the "does not do the `..` check" note); update its one internal caller
+  (`:317`). `resolveRefOnDisk`/`assertNoSymlinkAncestor` unchanged.
+- `cmd/dippin/pack_shadow.go` — generalize `ensureUnderRoot`'s error message (drop
+  `"pack-inline:"` prefix) and add a one-line "also used by the cross-file lint" note to its
+  doc comment. Behavior unchanged.
+- `cmd/dippin/crossfile_tool_access.go` — **replace** `resolveBoundaryRefPath` with
+  `resolveChildPath` (Join+Clean+Abs+`ensureUnderRoot`, returns `(string, error)`, no `IsAbs`
+  branch); derive `root = filepath.Dir(absOrClean(entryPath))` once in `crossFileToolAccess`
+  and thread it through `walkBoundaries`/`visitBoundary`/`maybeRecurse`/`resolveBoundaryChild`;
+  route the read through `dipx.ReadNoFollowSymlinks`. Implementation comments citing the
+  pack-parity / TOCTOU rationale and marking the `filepath.Abs(target)` as load-bearing.
+- `cmd/dippin/crossfile_tool_access_test.go` — T1–T9, T11 (with the T2 second-dir and
+  T7 `os.Chdir` harness notes).
+- `dipx/dipx_test.go` — T10 (internal `package dipx`; no `helpers_test.go` exists today).
+- `docs/architecture.md:148` — responsibility note (not an export-list edit; see Doc updates).

--- a/docs/superpowers/specs/2026-06-08-issue-100-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-100-design.md
@@ -126,7 +126,7 @@ directory, but the escape check compares the resolved target against the *fixed 
 root*. Recomputing the root as `filepath.Dir(parentPath)` at each level would falsely
 refuse a legitimate layout such as:
 
-```
+```text
 root/entry.dip      ->  subgraph_ref: sub/child.dip
 root/sub/child.dip  ->  subgraph_ref: ../other.dip   # resolves to root/other.dip — INSIDE root
 ```
@@ -142,7 +142,7 @@ returns the ref verbatim and is the actual vulnerability — `os.ReadFile("/etc/
 reads out-of-root today) is gone, and the new function returns `(string, error)` rather
 than a bare string. Resolution becomes pack-identical:
 
-```
+```text
 resolveChildPath(parentFile, ref, root) -> (abs string, err error):
     target := filepath.Clean(filepath.Join(filepath.Dir(parentFile), ref))
     abs    := filepath.Abs(target)            # err -> fail-soft

--- a/docs/superpowers/specs/2026-06-08-issue-100-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-100-design.md
@@ -1,0 +1,282 @@
+# Issue #100 — Harden cross-file `tool_access` resolver: refuse symlinked / root-escaping children
+
+**Status:** Design approved (expert-squad reviewed)
+**Date:** 2026-06-08
+**Branch:** `fix/100-crossfile-symlink-hardening`
+**Deferred from:** #89 (PR #99), recorded in `docs/superpowers/specs/2026-06-05-issue-89-design.md` § "Path-safety posture (v1: termination-only)".
+
+## Problem
+
+DIP146's cross-file pass (`cmd/dippin/crossfile_tool_access.go`) resolves child `.dip`
+refs **lexically** (relative to the boundary node's source file) and reads them with a
+plain `os.ReadFile` (`resolveBoundaryChild`, ~:94). That read **follows symlinks** and
+**`..`-escaping refs** — strictly weaker than the pack walker (`dipx/helpers.go`), which
+already refuses symlinked and root-escaping refs (`readNoFollowSymlinks` +
+`resolveRefOnDisk`'s `ErrRefEscape`, hardened in #79/#85). v1 of DIP146 shipped
+**termination-only** hardening (an `EvalSymlinks`-keyed visited set + depth cap). This
+issue closes the residual parity gap: the cross-file lint must **refuse** symlinked /
+root-escaping children — **fail-soft**, as detection, not enforcement.
+
+## Risk posture (why this is defense-in-depth, not a live exploit)
+
+The cross-file pass is a local linter whose only output is DIP diagnostic codes — there
+is **no content exfiltration** (file bytes never appear in output), and a swapped-in
+non-`.dip` target fails to parse (→ fail-soft). The residual is the leaf
+Lstat-then-read TOCTOU window that the pack walker also carries (see Scope below). This
+is parity hardening with the pack walker, not a fix for an active vector. **Detection,
+not enforcement — not gated on the tracker runtime** (per the `never-gate-dippin-on-tracker`
+rule; the deliverable is author-time detection, exactly like the rest of DIP146).
+
+## Goal (precise)
+
+Bring the cross-file pass's **child `.dip` ref resolution** to parity with the pack
+walker: a child ref that (a) escapes the entry-file containment root or (b) is — or
+traverses — a symlink is **refused**, and the boundary is treated as
+**`postureUnresolved`** (skipped), which **retains the per-file DIP143 advisory** and
+emits **no DIP146**. Linting completes normally: no hard error, no abort, unchanged exit
+code. Legitimate sibling/subdirectory children continue to resolve exactly as today
+(DIP146 supersession unchanged).
+
+## Architecture decisions
+
+### D1 — Sharing mechanism: reuse, with a single new dipx export
+
+The change reuses two existing, already-tested primitives and adds exactly **one** new
+exported symbol:
+
+- **Escape check** — reuse `ensureUnderRoot(absPath, rootDir)` (`cmd/dippin/pack_shadow.go:23`),
+  which already lives in `package main` and performs the identical lexical
+  `rel == ".." || strings.HasPrefix(rel, ".."+sep)` containment check the pack walker
+  uses. No new escape helper; no fifth copy of the check.
+- **Symlink-refusing read** — export the existing `dipx.readNoFollowSymlinks` by
+  capitalizing it to **`dipx.ReadNoFollowSymlinks(path, rootDir string) ([]byte, error)`**.
+  It performs leaf-symlink refusal (`os.Lstat` + `os.ModeSymlink`) **and** ancestor-symlink
+  refusal (`assertNoSymlinkAncestor`, which stays unexported). Its sole internal caller
+  (`packWalkState.readAndRecord`, `helpers.go:317`) is updated to the new name.
+
+This was chosen over the alternatives:
+- **A single combined `dipx.ReadRefWithinRoot`** (originally proposed): rejected — it
+  conflates two concerns and would *duplicate* the escape check rather than reuse the
+  one already present in `package main`. (API reviewer I1/I2.)
+- **Option (b) — a new `internal/pathsafe` package**: rejected as over-engineering for a
+  marginal-risk follow-up; it would force churn on merged, well-tested #79/#85 security
+  code. (API reviewer M1.)
+- **Option (c) — re-implement in `cmd/dippin`**: rejected — it would create a *fifth*
+  copy of the escape check and a *second* copy of the symlink-refusal logic, re-creating
+  exactly the kind of drift that produced this parity gap.
+
+**Net effect:** the design touches the merged pack escape logic (`resolveRefOnDisk`)
+**not at all** — eliminating the only refactor risk to the #79/#85 pack path. The single
+behavioral primitive that crosses the package boundary (`ReadNoFollowSymlinks`) is shared
+by construction, so pack and the lint pass cannot drift on symlink refusal.
+
+**Layering:** `cmd/dippin` already imports `dipx` (cli.go, cmd_pack.go, cmd_unpack.go,
+cmd_inspect.go). `ReadNoFollowSymlinks` composes only `os`/`path/filepath` and dipx's own
+`BundleError` sentinels — no `validator`/`cost`/`formatter`/analysis import — so the
+loader-tier rule (CLAUDE.md "Architecture") is preserved. The `validator.Diagnostic`
+boundary stays in `cmd/dippin`; the fail-soft caller discards the dipx error.
+
+### D2 — Containment root: the entry file's directory, captured once
+
+`root = filepath.Dir(absEntryPath)`, computed **once** in `crossFileToolAccess` from
+`entryPath` and threaded **by value, unchanged**, through the recursion. This mirrors the
+pack walker exactly (`walkSourceTree`: `rootDir := filepath.Dir(entryAbs)`, constant for
+the whole walk).
+
+**Critical implementation constraint (correctness C2):** the root must **not** be
+recomputed per-parent. A grandchild ref is resolved against *its parent's* source-file
+directory, but the escape check compares the resolved target against the *fixed entry
+root*. Recomputing the root as `filepath.Dir(parentPath)` at each level would falsely
+refuse a legitimate layout such as:
+
+```
+root/entry.dip      ->  subgraph_ref: sub/child.dip
+root/sub/child.dip  ->  subgraph_ref: ../other.dip   # resolves to root/other.dip — INSIDE root
+```
+
+The dedicated regression test (T3 below) pins this.
+
+### D3 — Resolution flow (pack-identical; no `IsAbs` special-case)
+
+`resolveBoundaryRefPath`'s current `filepath.IsAbs(ref)` branch (returns the ref verbatim)
+is **deleted**. Resolution becomes pack-identical:
+
+```
+resolveChildPath(parentFile, ref, root) -> (abs string, err error):
+    target := filepath.Clean(filepath.Join(filepath.Dir(parentFile), ref))
+    abs    := filepath.Abs(target)            # err -> fail-soft
+    ensureUnderRoot(abs, root)                # lexical `..`-escape refusal; err -> fail-soft
+    return abs
+
+resolveBoundaryChild(n, ref, root) -> (*ir.Workflow, string):
+    abs  := resolveChildPath(n.Source.File, ref, root)   # err -> (nil, "")
+    data := dipx.ReadNoFollowSymlinks(abs, root)         # leaf+ancestor symlink refusal; err -> (nil, "")
+    w    := parseAndResolveDip(data, abs)                # err -> (nil, "")
+    return w, abs
+```
+
+**Absolute refs (security I1/I2):** under `filepath.Join` semantics, an absolute ref is
+**re-rooted** under the parent dir, not refused — `filepath.Join("/p/a", "/etc/passwd")`
+→ `/p/a/etc/passwd` (the leading `/` is swallowed). So an abs ref resolves *in-root* (and
+is read if it happens to exist there) or fails-soft on miss; it can never reach an
+out-of-root absolute path. This matches pack (whose `resolveRefOnDisk` has no `IsAbs`
+branch) and is the safe, unambiguous behavior. The design does **not** claim abs refs are
+"refused" — they are *re-rooted*. (`..`-based escapes within the ref string *are* refused,
+by `ensureUnderRoot` after `Clean` resolves the `..`.)
+
+**Ordering:** escape check **before** read, so `ReadNoFollowSymlinks` only ever sees a
+path already proven under root.
+
+**Path absoluteness:** `resolveChildPath` returns an absolute path; it becomes the
+returned `childPath`, which seeds the next level's `n.Source.File` and the visited-set key
+— keeping all paths absolute and comparable across recursion levels, including when the
+entry was passed as a relative path (T6).
+
+### D4 — Fail-soft (verified, unchanged contract)
+
+Every refusal funnels through `resolveBoundaryChild`'s existing `(nil, "")` return:
+`child == nil` → `visitBoundary` sets `classified[n.Source] = postureUnresolved` and
+returns (no recursion, no DIP146) → `applyCrossFileToolAccess` keeps DIP143 because
+`supersedes(postureUnresolved) == false`. `crossFileToolAccess` and
+`applyCrossFileToolAccess` have **no error return**; the three call sites
+(cmd_check.go:61, cmd_validate.go:76, cmd_watch.go:138) never inspect an error and derive
+exit codes solely from `valRes.HasErrors()`. A refusal therefore cannot change the exit
+code or abort. **The refusal must be expressed only as the fail-soft error return — never
+as a new posture or a propagated error.**
+
+### D5 — Symlink-cycle interaction (no termination regression)
+
+`resolveBoundaryChild` runs *before* `maybeRecurse`/`canonicalKey`, so a refused symlink
+is never keyed into the visited set and `EvalSymlinks` is only invoked for files that
+resolved. A symlink **leaf** cycle (`a.dip` is a symlink → `b.dip` → `a.dip`) is now
+refused at the first hop (→ fail-soft, no recursion) — terminating *earlier* than the
+visited set would have. A cycle through **non-symlink** files is unchanged, still
+terminated by the visited set. The existing literal-ref cycle tests
+(`TestCrossFile_CycleTerminates`, `TestCrossFile_SelfReferenceTerminates`) remain the
+termination guarantee and are unaffected.
+
+## Scope (YAGNI)
+
+- **No new DIP code.** This is resolver hardening; the fail-soft outcome reuses the
+  existing `postureUnresolved` → DIP143-retained path. No diagnostic, explanation, or
+  catalog change.
+- **Lstat parity with the pack walker, not the parser's `O_NOFOLLOW` open-once.** The
+  issue targets pack parity; the pack walker uses the Lstat-based `readNoFollowSymlinks`.
+  Adopting the parser's stronger open-once `O_NOFOLLOW` machinery (`parser/resolve.go`,
+  #79) would *exceed* pack and pull `syscall`/build-tag complexity into the lint path.
+  The residual leaf Lstat-then-read TOCTOU window is identical to pack's and acceptable
+  for a linter (no content exfiltration; an attacker with mid-lint write access to the
+  source tree could simply edit the `.dip`). The asymmetry with the parser (which loads
+  file bytes into the IR for execution-adjacent use, justifying its stronger guarantee)
+  is deliberate. The implementation comment should cite this rationale, mirroring
+  `parser/resolve.go`'s comments.
+- **File directives are out of scope — by pack-parity definition.** `parseAndResolveDip`
+  → `parser.ResolveFileDirectives` reads a child's `command_file:`/`prompt_file:`/
+  `system_prompt_file:` against the *child's own directory*. The pack walker likewise
+  root-constrains only subgraph/child-`.dip` refs (`collectRefPaths` → `ensureUnderRoot`),
+  **not** file directives, which it resolves against the source file's directory. File
+  directives are already #79 leaf-symlink-hardened and behave identically for single-file
+  lint (this issue does not introduce that path). Bringing the *child-`.dip`-ref*
+  resolution to pack parity is the complete deliverable; root-constraining file
+  directives would be a separate, broader change.
+- **No build tags / no wasm impact.** `ReadNoFollowSymlinks` uses only portable stdlib
+  (`os.Lstat`, `os.ModeSymlink`, `filepath.*`, `os.ReadFile`) — no `syscall`. dipx is not
+  in the wasm dependency closure (only `validator` references it, from a test file), and
+  the lint pass runs in `cmd/dippin` (never compiled to wasm). `just wasm` is unaffected.
+  Contrast #79's parser work, which *needed* a `unix`/`!unix` split solely because
+  `syscall.O_NOFOLLOW` is undefined off-unix.
+
+## Containment-root trust note
+
+The loose-file lint inherits the pack walker's stance: `rootDir` (the entry file's
+directory) is the **trust anchor** and is **not re-validated**. If `entryPath` itself is a
+symlink, or sits under a symlinked directory *above* the computed root, that ancestor is
+trusted — the user explicitly named the entry file, so trusting its directory is
+consistent. `assertNoSymlinkAncestor` validates components *strictly between* the root and
+the leaf.
+
+## Testing (TDD, real fixtures, parser-driven)
+
+Use the existing `writeWorkflows` (t.TempDir + `os.WriteFile`, supports subdirs via
+`MkdirAll`) and `crossDiags` (loadWorkflow + `crossFileToolAccess`) helpers in
+`cmd/dippin/crossfile_tool_access_test.go`. Symlink tests create the link in the test
+body with `os.Symlink` and **skip on error** using the dipx idiom
+(`if err := os.Symlink(...); err != nil { t.Skip("symlinks not supported on this platform") }`)
+— **not** a `runtime.GOOS == "windows"` guard (that guard exists in parser tests only
+because of `O_NOFOLLOW`'s Unix-only atomicity, which does not apply to the Lstat path).
+Assert on **diagnostic outcomes** (DIP146 count, posture), never on EvalSymlinks-resolved
+absolute paths, to avoid macOS `/var`→`/private/var` flakiness.
+
+Each case is a failing test first:
+
+- **T1 — Symlinked child refused, fail-soft.** Boundary child ref is a symlink to a real
+  in-root `.dip`. → `postureUnresolved`, DIP143 retained, **no DIP146**, no error, lint
+  completes.
+- **T2 — Root-escaping child refused.** Child ref `../../outside.dip` (target physically
+  outside the entry root). → same fail-soft (refused, DIP143 retained, no DIP146, no
+  abort).
+- **T3 — Subdir child climbs back into root (the C2 regression guard).** `entry.dip →
+  sub/child.dip`, `sub/child.dip → ../other.dip` resolving to `root/other.dip` (in-root).
+  → **still resolves normally**; DIP146 supersession works as before. (Catches a
+  per-parent-root-recompute bug.) **Highest-value test.**
+- **T4 — Legit sibling and subdirectory child (regression guard).** No symlink, within
+  root, sibling and one-level-subdir variants. → resolves, DIP146 supersession unchanged.
+- **T5 — Benign in-root symlink refused (pins policy).** A symlink whose target is a real
+  file *inside* root. → **refused** (all symlinks refused unconditionally, matching pack),
+  `postureUnresolved`, DIP143 retained. Pins the conservative policy so it is not later
+  "fixed" as a false positive.
+- **T6 — Symlinked ancestor directory refused.** `entry.dip → linkdir/child.dip` where
+  `linkdir` is a symlink to a real in-root directory. → refused (ancestor-symlink vector,
+  mirrors the dipx parent-component test).
+- **T7 — Relative entry path.** Entry passed as a relative path. → `canonicalKey`/escape
+  keys still align so DIP143 supersession works for legit children (guards the
+  supersession-key normalization).
+- **T8 — Absolute ref re-rooted.** `subgraph_ref: /etc/passwd`. → re-rooted under the
+  parent dir, target does not exist in-root → `postureUnresolved` (DIP143 retained).
+  Asserts re-rooting + fail-soft, **not** literal absolute-path refusal.
+- **T9 — Symlink cycle asserts refusal (not termination).** `a.dip` symlink → `b.dip`
+  symlink → `a.dip`. → first hop refused → `postureUnresolved`. Comment that termination
+  is covered by the literal-ref cycle tests (T9 must not be relied on for termination).
+- **T10 — dipx unit test for `ReadNoFollowSymlinks`.** Happy path (in-root regular file
+  reads), leaf symlink refused (`ErrPathUnsafe`), ancestor symlink refused. Co-locate with
+  the existing dipx symlink tests (`dipx_test.go`), reusing their skip idiom.
+
+**Example-suite guard:** `just validate-examples` and `just lint-examples` must show **no
+example flipping** diagnostics.
+
+## Verification
+
+The pre-commit hook is the real CI gate (`just check` fails locally on
+tree-sitter-generate — CLI absent). Run:
+
+- `just test-pkg dipx` — pack escape/symlink tests still green after the rename; new
+  `ReadNoFollowSymlinks` unit test (T10).
+- `just test-pkg dippin` — new cross-file tests (T1–T9).
+- `just test-race` — full suite under the race detector.
+- `just complexity` — `resolveChildPath` + `resolveBoundaryChild` stay under cyclo ≤5 /
+  cognitive ≤7 (the extraction exists to keep both under cap; no `//nolint`).
+- `just wasm` — confirm `GOOS=js` build stays green (expected unaffected; dipx not in the
+  closure).
+- `just validate-examples` / `just lint-examples` — no example flips.
+
+## Doc updates
+
+- `docs/architecture.md` — the `helpers.go` exported-surface line gains
+  `ReadNoFollowSymlinks` (no-follow read primitive, now shared with the cross-file lint).
+- `ReadNoFollowSymlinks`'s doc comment — generalize from the Pack-specific framing to
+  "shared no-follow read primitive (pack walker + cross-file lint)"; keep the trust-anchor
+  note about `rootDir`.
+
+## Files touched
+
+- `dipx/helpers.go` — rename `readNoFollowSymlinks` → `ReadNoFollowSymlinks` (+ generalize
+  doc comment); update its one internal caller. `resolveRefOnDisk`/`assertNoSymlinkAncestor`
+  unchanged.
+- `cmd/dippin/crossfile_tool_access.go` — delete the `IsAbs` branch; add `resolveChildPath`
+  (Join+Clean+Abs+`ensureUnderRoot`); thread `root` (computed once in `crossFileToolAccess`)
+  through `walkBoundaries`/`visitBoundary`/`maybeRecurse`/`resolveBoundaryChild`; route the
+  read through `dipx.ReadNoFollowSymlinks`. Implementation comment citing the pack-parity /
+  TOCTOU rationale.
+- `cmd/dippin/crossfile_tool_access_test.go` — T1–T9.
+- `dipx/dipx_test.go` (or `helpers_test.go`) — T10.
+- `docs/architecture.md` — exported-surface line.


### PR DESCRIPTION
## Summary

Closes #100. Brings DIP146's cross-file `tool_access` lint to **parity with the pack walker**: a child `.dip` ref that is a symlink (leaf or via a symlinked ancestor) or that escapes the entry-file containment root is now **refused**, instead of being read through a plain `os.ReadFile` that followed symlinks and `..`-escaping refs.

This is **detection, not enforcement** — no tracker dependency (the deliverable is author-time detection, like the rest of DIP146).

### Fail-soft (the load-bearing difference from pack)
Pack refuses **hard** (`ErrRefEscape`, aborts the bundle). The lint must refuse **soft**: a refused child → `postureUnresolved` (skip) → the per-file **DIP143 advisory is retained** (not superseded by DIP146) → linting completes with the **same exit code**, no abort. A legitimate sibling/subdir child resolves exactly as before.

### How dipx's hardened primitives are shared (and why the layering is legal)
- **Escape check:** reuse the existing in-`package main` `ensureUnderRoot` (`cmd/dippin/pack_shadow.go`) — the same lexical `..`-component check the pack walker uses. No new helper, no fifth copy.
- **Symlink refusal:** export **one** dipx symbol — `readNoFollowSymlinks` → `ReadNoFollowSymlinks` (leaf `Lstat`/`ModeSymlink` + ancestor refusal). `cmd/dippin` already imports `dipx` (CLI/loader-tier — allowed; `validator` must not). The merged #79/#85 pack escape logic (`resolveRefOnDisk`) is **not touched** — zero refactor risk to that path; pack and the lint now share the symlink primitive *by construction*, so they can't drift.

### The containment "root" for loose-file lint
There's no `workflows/` anchor, so the root is **the entry file's directory** — `filepath.Dir(filepath.Abs(entryPath))` — computed once and threaded **unchanged** through the recursion (mirrors pack's `walkSourceTree`). Recomputing per-parent would falsely refuse legit grandchildren (`sub/child.dip → ../other.dip` that stays under the entry root); the root must also be **absolute** (relative-vs-absolute `filepath.Rel` would error and refuse every child). Both invariants are pinned by dedicated tests (T3, T7) that were **empirically proven** (via source mutation) to be the *unique* guards for those bugs.

### Lstat parity, not the parser's O_NOFOLLOW (scope)
The pack walker uses the Lstat-based primitive; the parser's stronger open-once `O_NOFOLLOW` (#79) is for execution-adjacent `file:` directives. Matching pack = Lstat, which is **portable** — no `syscall`, **no build tags**, and `dipx` isn't in the wasm closure, so `just wasm` is unaffected (contrast #79, which needed a `unix`/`!unix` split). Absolute refs are **re-rooted** under the containment root by `filepath.Join` semantics (cannot reach an out-of-root absolute path), not "refused". File-directive resolution is **out of scope** (pack itself doesn't root-constrain those).

No new DIP code.

## Test Plan
- [x] 10 new tests, real on-disk fixtures (`t.TempDir` + `os.Symlink`, skip-on-unsupported): symlinked child / root-escape / symlinked-ancestor / refusal-at-depth (red→green); subdir-climbs-back-into-root, relative-entry, abs-ref re-root, benign-in-root-symlink, symlink-cycle (guards); dipx unit test for `ReadNoFollowSymlinks` (leaf/ancestor/not-regular).
- [x] `just test-race` green (24 packages); `just complexity` clean (no `//nolint`); `just validate-examples` / `just lint-examples` — no example flips; `just wasm` green.
- [x] Two adversarial expert-review passes on design + spec, and a final two-stage (spec + quality) + adversarial security/correctness review on the shipped code — no critical/important issues; T3/T7 mutation-proven.

Design spec: `docs/superpowers/specs/2026-06-08-issue-100-design.md`. Plan: `docs/superpowers/plans/2026-06-08-issue-100-crossfile-symlink-hardening.md`.

Note (pre-existing, unrelated): `TestCmdLint_ExtraModels_SuppressesDIP108` is non-idempotent under `-count>1` due to global validator state — reproduces on the base commit, not introduced here; CI uses `-count=1`. Worth a separate follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783536977&installation_id=131176874&pr_number=104&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F104&signature=901ae1338f5c462b073769cca5769f427af0b325a943c5f23ecc9cdd79b055e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened cross-file resolution to refuse symlinked or out-of-root child references, preventing unintended path traversal and preserving prior advisories.

* **New Features**
  * Added a shared no-follow file-read helper for safer cross-file reads and containment-aware resolution behavior.

* **Tests**
  * Added extensive regression tests covering symlink refusal, root-escape cases, recursion anchoring, and absolute/relative ref handling.

* **Documentation**
  * Updated architecture notes and added design/implementation plan detailing the hardening approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->