### PR TITLE
docs(site): surface v0.37.0 codes + new defaults on the website

### DIFF
--- a/site/content/language.md
+++ b/site/content/language.md
@@ -58,6 +58,8 @@ The optional `defaults` block sets graph-level configuration that applies to all
     max_restarts: 5
     cache_tools: true
     compaction: summary
+    stall_timeout: 5m
+    on_failure: Escalate
 ```
 
 | Field | Type | Description |
@@ -70,6 +72,8 @@ The optional `defaults` block sets graph-level configuration that applies to all
 | `max_restarts` | Integer | Max loop restarts before pipeline failure (default: 5) |
 | `cache_tools` | Boolean | Whether to cache tool call results |
 | `compaction` | String | Context compaction mode for long pipelines |
+| `stall_timeout` | Duration | Abort/route when no forward progress is made for a wall-clock span (e.g. `30s`, `5m`); `0`/unset = no limit. Enforced by the runtime. |
+| `on_failure` | NodeID | Graph-level catch-all failure route — the runtime sends a failing node here when no more specific route (fail edge → bounded retry → `fallback_target`) matches. Carried + linted by dippin; enforced by the runtime. |
 
 ### Tool safety
 

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -99,6 +99,14 @@ These must be fixed for a workflow to be valid. Each causes exit code 1.
   = help: remove the duplicate edge</pre>
 </div>
 
+<div class="diag-card error">
+  <span class="diag-code">DIP010</span> — Unparseable Edge Condition
+  <p>Every edge <code>when</code> condition must parse into a valid expression. An unparseable condition — an unknown operator, or a tool-node field like <code>marker_grep</code> used in operator position — leaves the edge's routing undefined, so the workflow cannot execute. One diagnostic fires per bad edge; every parseable edge is still checked.</p>
+  <pre>error[DIP010]: edge A -&gt; Z: invalid condition "marker_grep \"^ok\"": unknown operator "^ok"
+  --&gt; pipeline.dip:14:5
+  = help: valid operators: = == != contains startswith endswith in</pre>
+</div>
+
 ## Semantic Warnings (DIP101-DIP146)
 
 These flag likely bugs or questionable patterns. Warnings alone exit 0.
@@ -246,3 +254,46 @@ These flag likely bugs or questionable patterns. Warnings alone exit 0.
 Fires when `max_retries` is set in defaults and the workflow has `restart: true` edges, but `max_restarts` is not set. These are commonly confused: `max_retries` controls per-node LLM retries, while `max_restarts` controls the global loop restart budget.
 
 **Fix:** Set `max_restarts` in defaults to control loop iterations, or add it alongside `max_retries` if both behaviors are intended.
+
+### DIP143 — Referenced subgraph does not inherit `tool_access`
+
+**Severity:** Hint
+
+A `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) node references a child `.dip` while this workflow declares a `tool_access` restriction — and `tool_access` does not cross the file boundary. The lint cannot read the child, so it reminds you to give the child's agents their own `tool_access`. (For the resolved cross-file check that *reads* the child, see DIP146.)
+
+```text
+hint[DIP143]: manager_loop "Supervise" references subgraph "child.dip", defined in its own file; this workflow's tool_access restrictions do not extend across the subgraph boundary
+```
+
+### DIP144 — Agent node has no failure route
+
+**Severity:** Warning
+
+An agent node has no way to handle failure — no `ctx.outcome = fail` edge, no `fallback_target`, no bounded retry (`retry_target` + `max_retries`), and no graph-level `on_failure`. Any one of those suppresses it; an unconditional/success edge does not.
+
+```text
+warning[DIP144]: agent node "Build" has no failure route (no fail edge, no fallback_target, no bounded retry, no graph on_failure)
+  = help: add `-> <node> when ctx.outcome = fail`, set fallback_target:, add retry_target with max_retries, or declare a workflow-level on_failure:
+```
+
+### DIP145 — Negative graph budget default
+
+**Severity:** Warning
+
+A graph budget default (`max_total_tokens`, `max_cost_cents`, `max_wall_time`, or `stall_timeout`) is set to a negative value. Budgets are non-negative; `0` (or unset) means **no limit**.
+
+```text
+warning[DIP145]: workflow budget default max_cost_cents is -5; budgets cannot be negative
+```
+
+### DIP146 — Child subgraph re-grants restricted tools (cross-file)
+
+**Severity:** Hint
+
+`dippin lint` resolves a `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) child across the file boundary and finds it declares **no** `tool_access` restriction on any agent, while a workflow on the path from the linted entry restricts tools. Unlike DIP143 (which cannot read the child), DIP146 reads and confirms the child and traverses transitively. Detection only — dippin flags the gap; runtime enforcement is separate.
+
+```text
+hint[DIP146]: manager_loop "Supervise" delegates to subgraph "worker.dip", which declares no tool_access restriction on any agent; a workflow on this path restricts tools, but the restriction does not cross the subgraph boundary
+```
+
+> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP146) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.


### PR DESCRIPTION
## Summary

After v0.37.0 shipped, the **generated/LLM-facing docs were current** (`generated-spec.md`, `site/static/skill.md`, `llms-full.txt`, `docs/*.md`, and the auto-generated changelog page all include DIP010/144/145/146 + `on_failure`/`stall_timeout`). But the **hand-curated website pages had drifted**:

- `site/content/validation.md` documented codes only through **DIP134** (diag-cards to DIP133 + one DIP134 prose entry), so the security-relevant **DIP143** (tool_access boundary) and **DIP146** (cross-file) — plus the new **DIP010 / DIP144 / DIP145** — were absent from the public validation page, even though its header advertises the full `DIP001–DIP010` / `DIP101–DIP146` ranges.
- `site/content/language.md`'s Defaults block didn't mention the new `on_failure` or `stall_timeout` fields.

This is pre-existing drift the v0.37.0 release widened; the authoritative/generated docs were already complete, so nothing was release-blocking.

## Changes
- **validation.md:** add a `DIP010` error card; add `DIP143` / `DIP144` / `DIP145` / `DIP146` prose entries (matching the existing DIP134 style) with faithful example messages lifted from the audited `docs/validation.md`; add a "full catalog" pointer (`dippin explain` / `generated-spec.md`) noting DIP135–DIP142 are documented there.
- **language.md:** document `on_failure` and `stall_timeout` in the Defaults block (example + field table), flagged as runtime-enforced.
- The "56 codes / 10 structural / 46 semantic" count is **accurate** (verified: 10 + 46) and left unchanged.

Out of scope: backfilling DIP135–DIP142 onto the curated page (separate completeness task; they're covered by the generated spec / `dippin explain`).

## Test Plan
- [x] Pre-commit suite green (docs-only; no code, gen-spec, or changelog inputs touched).
- [ ] Netlify deploy-preview renders the validation + language pages (Hugo not available locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783544532&installation_id=131176874&pr_number=107&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F107&signature=965dce78d2539aab9d1e220bb5b906c7b14473b4eba944447b098789c86a3b39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->