### PR TITLE
Intent-aware re-walk of shared cross-file children (Closes #109)

### DIFF
--- a/cmd/dippin/crossfile_tool_access.go
+++ b/cmd/dippin/crossfile_tool_access.go
@@ -37,9 +37,16 @@ const (
 func crossFileToolAccess(entry *ir.Workflow, entryPath string) ([]validator.Diagnostic, map[ir.SourceLocation]childPosture) {
 	var diags []validator.Diagnostic
 	classified := map[ir.SourceLocation]childPosture{}
-	visited := map[string]bool{}
+	// walkedWithIntent records, per visited child file, whether its boundaries were
+	// walked under intentSeen=true. A child first walked WITHOUT intent is re-walked
+	// once if later reached WITH intent — intent is monotonic (OR-threaded down), so
+	// each node flips false->true at most once (see maybeRecurse). The entry is seeded
+	// as walked-with-intent=true so a cycle back to it never re-walks the linted file's
+	// own boundaries: those are validator.Lint's domain (DIP143 at depth 0), and
+	// re-walking them at depth>=1 would spuriously emit a deep advisory (#109).
+	walkedWithIntent := map[string]bool{}
 	if key := canonicalKey(entryPath); key != "" {
-		visited[key] = true
+		walkedWithIntent[key] = true
 	}
 	intentSeen := validator.WorkflowDeclaresToolAccess(entry)
 	// root is the containment anchor for every child ref, captured ONCE from the
@@ -50,18 +57,18 @@ func crossFileToolAccess(entry *ir.Workflow, entryPath string) ([]validator.Diag
 	// in the fallback case a relative root simply fails the Rel check and refuses,
 	// which is the safe (fail-soft) direction.
 	root := filepath.Dir(absOrClean(entryPath))
-	walkBoundaries(entry, intentSeen, 0, root, visited, &diags, classified)
+	walkBoundaries(entry, intentSeen, 0, root, walkedWithIntent, &diags, classified)
 	return diags, classified
 }
 
 // walkBoundaries inspects each subgraph/manager_loop boundary in w.
-func walkBoundaries(w *ir.Workflow, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+func walkBoundaries(w *ir.Workflow, intentSeen bool, depth int, root string, walkedWithIntent map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
 	for _, n := range w.Nodes {
 		_, ref := boundaryKindRef(n)
 		if ref == "" || n.Source.File == "" {
 			continue
 		}
-		visitBoundary(n, ref, intentSeen, depth, root, visited, diags, classified)
+		visitBoundary(n, ref, intentSeen, depth, root, walkedWithIntent, diags, classified)
 	}
 }
 
@@ -69,7 +76,7 @@ func walkBoundaries(w *ir.Workflow, intentSeen bool, depth int, root string, vis
 // when the path shows intent and the child is zero-intent (or a deep DIP143
 // advisory when the child is partial/unresolved — see deepBoundaryDiag), then
 // recurses.
-func visitBoundary(n *ir.Node, ref string, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+func visitBoundary(n *ir.Node, ref string, intentSeen bool, depth int, root string, walkedWithIntent map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
 	child, childPath := resolveBoundaryChild(n, ref, root)
 	posture := postureUnresolved // resolveBoundaryChild fail-soft: nil child => unresolved
 	if child != nil {
@@ -80,7 +87,7 @@ func visitBoundary(n *ir.Node, ref string, intentSeen bool, depth int, root stri
 		*diags = append(*diags, *d)
 	}
 	if child != nil {
-		maybeRecurse(child, childPath, intentSeen, depth, root, visited, diags, classified)
+		maybeRecurse(child, childPath, intentSeen, depth, root, walkedWithIntent, diags, classified)
 	}
 }
 
@@ -109,17 +116,34 @@ func deepAdvisory(intentSeen bool, posture childPosture, depth int) bool {
 	return intentSeen && depth >= 1 && (posture == posturePartial || posture == postureUnresolved)
 }
 
-// maybeRecurse descends into a child's own boundaries unless it was already
-// visited (cycle guard) or the depth cap is reached. The child is marked visited
-// before recursing (pre-order) so cycles terminate.
-func maybeRecurse(child *ir.Workflow, childPath string, intentSeen bool, depth int, root string, visited map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
+// maybeRecurse descends into a child's own boundaries unless the depth cap is reached
+// or the child has already been walked under intent at least as strong as this path's.
+// The child is recorded (pre-order) before recursing so cycles terminate. A child first
+// walked WITHOUT intent is re-walked ONCE when later reached WITH intent, so a grandchild
+// gap behind a child shared by a no-intent and an intent path is not missed (#109). Intent
+// is monotonic, so walkedWithIntent[key] flips false->true at most once: <=1 re-walk per
+// node, <=2N walkBoundaries calls total — bounded, and the depth cap still applies.
+func maybeRecurse(child *ir.Workflow, childPath string, intentSeen bool, depth int, root string, walkedWithIntent map[string]bool, diags *[]validator.Diagnostic, classified map[ir.SourceLocation]childPosture) {
 	key := canonicalKey(childPath)
-	if key == "" || visited[key] || depth+1 > crossFileMaxDepth {
+	childIntent := intentSeen || validator.WorkflowDeclaresToolAccess(child)
+	if !shouldWalk(key, childIntent, depth, walkedWithIntent) {
 		return
 	}
-	visited[key] = true
-	childIntent := intentSeen || validator.WorkflowDeclaresToolAccess(child)
-	walkBoundaries(child, childIntent, depth+1, root, visited, diags, classified)
+	walkedWithIntent[key] = childIntent
+	walkBoundaries(child, childIntent, depth+1, root, walkedWithIntent, diags, classified)
+}
+
+// shouldWalk reports whether a child boundary should be (re-)walked: it must resolve to a
+// key, stay within the depth cap, and not already have been walked under intent at least
+// as strong as childIntent. The only re-walk it permits is the first false->true intent
+// upgrade (#109); a node already walked with intent, or re-reached with no new intent, is
+// skipped — which is what terminates cycles and self-references.
+func shouldWalk(key string, childIntent bool, depth int, walkedWithIntent map[string]bool) bool {
+	if key == "" || depth+1 > crossFileMaxDepth {
+		return false
+	}
+	walked, seen := walkedWithIntent[key]
+	return !seen || (!walked && childIntent)
 }
 
 // resolveBoundaryChild resolves ref relative to the boundary node's source file,

--- a/cmd/dippin/crossfile_tool_access_test.go
+++ b/cmd/dippin/crossfile_tool_access_test.go
@@ -907,6 +907,177 @@ func TestCrossFile_DiamondOntoPartialChild(t *testing.T) {
 	}
 }
 
+// --- #109: intent-aware re-walk of a child shared by a no-intent and an intent path ---
+
+// mixedIntentDiamond builds: entry -> P1 (no intent) -> shared (agentless) -> leaf, AND
+// entry -> P2 (restricts) -> shared. The intent path (P2) reaches `shared` only AFTER the
+// no-intent path (P1) has already walked it, so before #109 the file-keyed visited set
+// suppressed re-walking shared's boundaries under intentSeen=true and the leaf stayed
+// silent. p1First controls entry node order (which path is walked first).
+func mixedIntentDiamond(t *testing.T, leaf string, p1First bool) string {
+	t.Helper()
+	noIntentMid := `workflow P1
+  start: Go
+  exit: Sup
+
+  human Go
+    mode: freeform
+
+  manager_loop Sup
+    subgraph_ref: shared.dip
+    max_cycles: 3
+
+  edges
+    Go -> Sup
+`
+	restrictMid := `workflow P2
+  start: Lock
+  exit: Sup
+
+  agent Lock
+    prompt: "x"
+    tool_access: none
+
+  manager_loop Sup
+    subgraph_ref: shared.dip
+    max_cycles: 3
+
+  edges
+    Lock -> Sup
+`
+	shared := `workflow Shared
+  start: Go
+  exit: Sup
+
+  human Go
+    mode: freeform
+
+  manager_loop Sup
+    subgraph_ref: leaf.dip
+    max_cycles: 3
+
+  edges
+    Go -> Sup
+`
+	first, second := "p1.dip", "p2.dip"
+	if !p1First {
+		first, second = "p2.dip", "p1.dip"
+	}
+	entry := `workflow Entry
+  start: A
+  exit: B
+
+  subgraph A
+    ref: ` + first + `
+
+  subgraph B
+    ref: ` + second + `
+
+  edges
+    A -> B
+`
+	return writeWorkflows(t, map[string]string{
+		"entry.dip":  entry,
+		"p1.dip":     noIntentMid,
+		"p2.dip":     restrictMid,
+		"shared.dip": shared,
+		"leaf.dip":   leaf,
+	})
+}
+
+// TestCrossFile_MixedIntentDiamondPartial — the core #109 repro. The intent path reaches
+// the shared child second; the deep partial leaf below it must still fire one DIP143.
+func TestCrossFile_MixedIntentDiamondPartial(t *testing.T) {
+	dir := mixedIntentDiamond(t, childPartial, true /*no-intent path first*/)
+	diags, _ := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP143); got != 1 {
+		t.Fatalf("want 1 deep DIP143 (intent path must re-walk shared), got %d: %v", got, diags)
+	}
+}
+
+// TestCrossFile_MixedIntentDiamondZeroIntent — proves the fix also closes the pre-existing
+// DIP146 false negative (a zero-intent grandchild below the shared child).
+func TestCrossFile_MixedIntentDiamondZeroIntent(t *testing.T) {
+	dir := mixedIntentDiamond(t, childZeroIntent, true)
+	diags, _ := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP146); got != 1 {
+		t.Fatalf("want 1 DIP146 (intent path must re-walk shared), got %d: %v", got, diags)
+	}
+}
+
+// TestCrossFile_MixedIntentDiamondOrderIndependent — the result must not depend on which
+// path the DFS happens to visit first.
+func TestCrossFile_MixedIntentDiamondOrderIndependent(t *testing.T) {
+	for _, p1First := range []bool{true, false} {
+		dir := mixedIntentDiamond(t, childPartial, p1First)
+		diags, _ := crossDiags(t, dir, "entry.dip")
+		if got := countCode(diags, validator.DIP143); got != 1 {
+			t.Fatalf("p1First=%v: want 1 deep DIP143 regardless of order, got %d", p1First, got)
+		}
+	}
+}
+
+// TestCrossFile_MixedIntentDiamondNoIntentSilent — if NEITHER path restricts, the re-walk
+// never triggers and the deep partial leaf stays silent (the gate still holds).
+func TestCrossFile_MixedIntentDiamondNoIntentSilent(t *testing.T) {
+	// Replace the restricting P2 with a second no-intent mid by pointing both at p1-style.
+	noIntentMid := `workflow P
+  start: Go
+  exit: Sup
+
+  human Go
+    mode: freeform
+
+  manager_loop Sup
+    subgraph_ref: shared.dip
+    max_cycles: 3
+
+  edges
+    Go -> Sup
+`
+	shared := `workflow Shared
+  start: Go
+  exit: Sup
+
+  human Go
+    mode: freeform
+
+  manager_loop Sup
+    subgraph_ref: leaf.dip
+    max_cycles: 3
+
+  edges
+    Go -> Sup
+`
+	entry := `workflow Entry
+  start: A
+  exit: B
+
+  subgraph A
+    ref: p1.dip
+
+  subgraph B
+    ref: p2.dip
+
+  edges
+    A -> B
+`
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip":  entry,
+		"p1.dip":     noIntentMid,
+		"p2.dip":     noIntentMid,
+		"shared.dip": shared,
+		"leaf.dip":   childPartial,
+	})
+	diags, _ := crossDiags(t, dir, "entry.dip")
+	if got := countCode(diags, validator.DIP143); got != 0 {
+		t.Fatalf("want 0 DIP143 (no intent on any path), got %d: %v", got, diags)
+	}
+	if got := countCode(diags, validator.DIP146); got != 0 {
+		t.Fatalf("want 0 DIP146 (no intent on any path), got %d", got)
+	}
+}
+
 // firstDiags runs the pass and returns only the diagnostics (helper for cases that
 // don't inspect the classified map).
 func firstDiags(t *testing.T, dir, entry string) []validator.Diagnostic {

--- a/docs/superpowers/specs/2026-06-09-issue-109-design.md
+++ b/docs/superpowers/specs/2026-06-09-issue-109-design.md
@@ -32,7 +32,7 @@ existing depth cap still bounds depth. Termination is preserved.
 
 ### Re-walk predicate (`maybeRecurse`)
 
-```
+```go
 childIntent := intentSeen || WorkflowDeclaresToolAccess(child)
 if walked, seen := walkedWithIntent[key]; seen && (walked || !childIntent) {
     return            // already walked WITH intent, or no new intent to add

--- a/docs/superpowers/specs/2026-06-09-issue-109-design.md
+++ b/docs/superpowers/specs/2026-06-09-issue-109-design.md
@@ -1,0 +1,79 @@
+# Issue #109 — intent-aware re-walk in the cross-file tool_access pass
+
+**Status:** design approved · follow-up to [#102](https://github.com/2389-research/dippin-lang/issues/102) (PR #108); surfaced by Codex review on #108. Fixes a **pre-existing** false negative shared by DIP146 (since #89) and inherited by the #102 deep DIP143.
+
+## Problem
+
+`crossFileToolAccess` (`cmd/dippin/crossfile_tool_access.go`) guards recursion with a
+`visited` set keyed by **child file path**, and threads `intentSeen` down the DFS
+(`childIntent := intentSeen || WorkflowDeclaresToolAccess(child)`). When the same
+intermediate child is reached **first via a no-intent path** and **later via an
+intent-bearing path**, the second traversal hits `visited[key]` and returns without
+re-walking that child's boundaries under the stronger `intentSeen = true`. So a
+zero-intent / partial-audit / unresolvable grandchild *below* the shared child stays
+silent even though a restricting path to it exists.
+
+Empirically confirmed (entry → P1[no intent] → shared → leaf; entry → P2[restricts] →
+shared, P2 second in node order):
+
+- `leaf = partial` ⇒ deep DIP143 = 0 (should be 1)
+- `leaf = zero-intent` ⇒ DIP146 = 0 (should be 1) — proving this is the shared,
+  pre-existing traversal behavior, not new to #102.
+
+## Approach: intent-aware visited set
+
+Replace the boolean "visited" with "walked-with-intent": the map value records whether a
+node's boundaries were walked under `intentSeen = true`. Re-walk a node **once** when it
+was first walked without intent and is later reached with intent.
+
+Intent is **monotonic** down the DFS (only OR-ed in, never removed), so each node flips
+`false → true` at most once: ≤1 re-walk per node, ≤2·N `walkBoundaries` calls total. The
+existing depth cap still bounds depth. Termination is preserved.
+
+### Re-walk predicate (`maybeRecurse`)
+
+```
+childIntent := intentSeen || WorkflowDeclaresToolAccess(child)
+if walked, seen := walkedWithIntent[key]; seen && (walked || !childIntent) {
+    return            // already walked WITH intent, or no new intent to add
+}
+walkedWithIntent[key] = childIntent
+walkBoundaries(child, childIntent, depth+1, ...)
+```
+
+### Load-bearing subtlety: never re-walk the entry file
+
+A cycle back to the entry (`entry[no intent] → child[restricts] → entry`) would otherwise
+re-walk the entry's own boundaries at depth ≥ 1 and spuriously emit a **deep** DIP143 for
+an entry-file boundary — but entry-file boundaries are `validator.Lint`'s domain (DIP143 at
+depth 0). Fix: **seed `walkedWithIntent[entryKey] = true`** (was `visited[entryKey] = true`).
+Because `walked == true` is terminal in the predicate, the entry is never re-walked,
+regardless of cycles. The entry is still walked once normally at depth 0 with its real
+intent. This keeps the #102 `depth >= 1` deep-advisory gate correct under cycles.
+
+## Why no double-emit
+
+Emission (DIP146 / deep DIP143) is gated on `intentSeen`. A no-intent walk never emits; a
+node is walked **with** intent at most once. So any boundary emits at most once — the
+re-walk surfaces previously-missed gaps without duplicating existing ones. The per-boundary
+diamond cardinality (one hint per referencing boundary node) is unchanged: it comes from
+`walkBoundaries` iterating the parent's nodes, not from the child's visited status.
+
+## Scope / non-goals
+
+- One production file: `cmd/dippin/crossfile_tool_access.go` (rename `visited` →
+  `walkedWithIntent`, change the seed + `maybeRecurse` predicate). No new DIP code, no
+  validator change, no wasm impact (cmd/dippin is native-only).
+- Detection, not enforcement — no tracker dependency.
+- This changes DIP146 + deep DIP143 to fire in the mixed-intent-diamond shape they
+  previously missed; `validate-examples` / `lint-examples` must show no unexpected flip.
+
+## Tests (TDD, real `.dip` fixtures)
+
+1. Mixed-intent diamond, **no-intent path first**, shared → partial leaf ⇒ deep DIP143 = 1
+   (the #109 repro; currently 0).
+2. Same shape, shared → zero-intent leaf ⇒ DIP146 = 1 (currently 0; proves the DIP146 fix).
+3. Order-independence: same with the intent path first ⇒ identical result (1).
+4. Regression: existing cycle / self-reference / diamond / depth-cap tests stay green
+   (termination + no double-emit).
+5. No-intent everywhere ⇒ still silent (the re-walk only triggers under added intent).


### PR DESCRIPTION
Closes #109. Follow-up to #102 (PR #108); surfaced by Codex review on that PR.

## The false negative

The cross-file `tool_access` pass guarded recursion with a **file-keyed boolean** `visited` set. When the same intermediate child is reached **first via a no-intent path** and **later via an intent-bearing path**, the second traversal hits `visited[key]` and returns *without* re-walking that child's boundaries under `intentSeen = true`. So a zero-intent / partial-audit / unresolvable **grandchild** below the shared child stayed silent even though a restricting path to it exists.

Pre-existing in **DIP146** (since #89), inherited by the #102 **deep DIP143**. Repro (entry → P1[no intent] → shared → leaf; entry → P2[restricts] → shared, P2 second in node order):
- `leaf = partial` ⇒ deep DIP143 = 0 (should be 1)
- `leaf = zero-intent` ⇒ DIP146 = 0 (should be 1)

## Fix: intent-aware visited set

`visited` (bool "seen") → `walkedWithIntent` (value = "walked under `intentSeen = true`"). A node first walked **without** intent is re-walked **once** when later reached **with** intent. Intent is monotonic (OR-threaded down the DFS), so each node flips `false → true` at most once: **≤1 re-walk per node, ≤2N walks total** — termination and the depth cap are preserved. The re-walk decision is `shouldWalk`: `!seen || (!walked && childIntent)`.

### Load-bearing subtlety: never re-walk the entry file
A cycle back to the entry (`entry[no intent] → child[restricts] → entry`) would otherwise re-walk the entry's own boundaries at depth ≥ 1 and spuriously emit a **deep** DIP143 for an entry-file boundary — but those are `validator.Lint`'s domain (DIP143 at depth 0). Fix: seed `walkedWithIntent[entryKey] = true`; since `walked == true` is terminal, the entry is never re-walked, regardless of cycles.

### No double-emit
Emission is gated on `intentSeen`: the no-intent walk never emits, and a node is walked **with** intent at most once → each boundary emits at most once. The per-boundary diamond cardinality is unchanged (it comes from iterating the parent's nodes, not the child's visited status) — `TestCrossFile_DiamondTwoFindings` still expects exactly 2.

## Tests (TDD, real `.dip` fixtures)
- `MixedIntentDiamondPartial` — the #109 repro; deep DIP143 now = 1.
- `MixedIntentDiamondZeroIntent` — proves the DIP146 FN is also closed (= 1).
- `MixedIntentDiamondOrderIndependent` — result independent of sibling node order.
- `MixedIntentDiamondNoIntentSilent` — no intent on any path ⇒ still silent (gate holds).
- All existing cycle / self-reference / diamond / depth-cap tests stay green.

## Scope
`cmd/dippin` only (native) — **no validator change, no new DIP code, no wasm impact**. Detection, not enforcement. `validate-examples` / `lint-examples` show **no example flip**. An adversarial review verified termination, no-double-emit, the entry-seed, depth-cap, order-independence, and `classified`-map correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783615861&installation_id=131176874&pr_number=111&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F111&signature=1be1922b6587e0323ca5e9791ed8acc692011da8dd601772dcd778b07291a020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-file traversal so tool-access boundary diagnostics correctly surface when shared intermediate workflows are reached via paths with differing intent, eliminating missed reports.

* **Tests**
  * Added tests covering mixed-intent workflow patterns, order-independent traversal, and scenarios ensuring correct diagnostics when intent is absent.

* **Documentation**
  * Added a design spec describing the intent-aware re-walk behavior and regression test plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->