### PR TITLE
Release v0.38.0 — cross-file tool_access advisory completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ## [Unreleased]
 
+## [v0.38.0] — 2026-06-09
+
+Cross-file `tool_access` advisory completeness. Both changes are **dippin-side detection only** — they refine the `DIP146`/`DIP143` cross-file analysis shipped in v0.37.0 and require no paired runtime release (per `never-gate-dippin-on-tracker`, no dippin behavior is gated on runtime readiness).
+
+### Added
+- `DIP143` (Hint) **deep cross-file advisory** — the native `dippin lint` cross-file pass now emits `DIP143` for a **partial-audit** or **unresolvable** child found at **depth ≥ 1** (behind an already-audited intermediate), gated by path `tool_access` intent ([#102](https://github.com/2389-research/dippin-lang/issues/102)). Previously this fallback came only from the entry-file lint, so a partial/unresolvable gap more than one hop deep was silent — DIP146 already traversed transitively for *zero-intent* children, but the partial/unresolvable advisory did not. Reuses `DIP143` (no new code); the message distinguishes partial-audit (resolved — a tool-bearing agent lacks its own `tool_access`) from unresolvable (missing / unparseable / refused). Entry boundaries (depth 0) keep their existing `validator.Lint` `DIP143`. Emitted from `dippin lint`/`check`/`watch`; no wasm/validator-detection change.
+
+### Fixed
+- **Intent-aware cross-file re-walk** — a child reached **first** via a path with no `tool_access` intent and **later** via a restricting path was not re-walked under the restricting intent, so a zero-intent / partial-audit / unresolvable **grandchild** below the shared child was silently missed ([#109](https://github.com/2389-research/dippin-lang/issues/109)). The recursion guard is now intent-aware (re-walk once on a no-intent → intent upgrade; bounded and cycle-safe, with the entry file never re-walked). Pre-existing in `DIP146` since its introduction ([#89](https://github.com/2389-research/dippin-lang/issues/89)) and inherited by the #102 deep advisory; both now catch the mixed-intent shared-child shape regardless of traversal order.
+
+### Docs
+- Documented the deep `DIP143` advisory and the intent-aware cross-file traversal in the validation reference (`docs/validation.md` + the website validation page).
+
 ## [v0.37.0] — 2026-06-08
 
 Mixed release. The cross-file `tool_access` detection + resolver hardening and the DIP010 edge-condition error are **dippin-side detection only** (no paired runtime release required). The graph-level `on_failure` route and the declarable budget guards are an **authoring surface dippin carries + lints while a paired runtime enforces** — inert until the runtime reads them (per `never-gate-dippin-on-tracker`, no dippin behavior is gated on runtime readiness).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1178,7 +1178,7 @@ restriction on any agent, while a workflow on the path from the linted entry
 restricts tools. Unlike DIP143 (which cannot read the child), DIP146 reads and
 confirms the child, and traverses transitively. The traversal is intent-aware: a
 child reached through both a no-intent path and a restricting path is still checked
-under the restricting path (#109).
+under the restricting path ([#109](https://github.com/2389-research/dippin-lang/issues/109)).
 
 ```text
 hint[DIP146]: manager_loop "Supervise" delegates to subgraph "worker.dip", which declares no tool_access restriction on any agent; a workflow on this path restricts tools, but the restriction does not cross the subgraph boundary

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1176,7 +1176,9 @@ means *unlimited*, not "zero budget."
 child across the file boundary and finds it declares **no** `tool_access`
 restriction on any agent, while a workflow on the path from the linted entry
 restricts tools. Unlike DIP143 (which cannot read the child), DIP146 reads and
-confirms the child, and traverses transitively.
+confirms the child, and traverses transitively. The traversal is intent-aware: a
+child reached through both a no-intent path and a restricting path is still checked
+under the restricting path (#109).
 
 ```text
 hint[DIP146]: manager_loop "Supervise" delegates to subgraph "worker.dip", which declares no tool_access restriction on any agent; a workflow on this path restricts tools, but the restriction does not cross the subgraph boundary

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,19 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.38.0] — 2026-06-09
+
+Cross-file `tool_access` advisory completeness. Both changes are **dippin-side detection only** — they refine the `DIP146`/`DIP143` cross-file analysis shipped in v0.37.0 and require no paired runtime release (per `never-gate-dippin-on-tracker`, no dippin behavior is gated on runtime readiness).
+
+### Added
+- `DIP143` (Hint) **deep cross-file advisory** — the native `dippin lint` cross-file pass now emits `DIP143` for a **partial-audit** or **unresolvable** child found at **depth ≥ 1** (behind an already-audited intermediate), gated by path `tool_access` intent ([#102](https://github.com/2389-research/dippin-lang/issues/102)). Previously this fallback came only from the entry-file lint, so a partial/unresolvable gap more than one hop deep was silent — DIP146 already traversed transitively for *zero-intent* children, but the partial/unresolvable advisory did not. Reuses `DIP143` (no new code); the message distinguishes partial-audit (resolved — a tool-bearing agent lacks its own `tool_access`) from unresolvable (missing / unparseable / refused). Entry boundaries (depth 0) keep their existing `validator.Lint` `DIP143`. Emitted from `dippin lint`/`check`/`watch`; no wasm/validator-detection change.
+
+### Fixed
+- **Intent-aware cross-file re-walk** — a child reached **first** via a path with no `tool_access` intent and **later** via a restricting path was not re-walked under the restricting intent, so a zero-intent / partial-audit / unresolvable **grandchild** below the shared child was silently missed ([#109](https://github.com/2389-research/dippin-lang/issues/109)). The recursion guard is now intent-aware (re-walk once on a no-intent → intent upgrade; bounded and cycle-safe, with the entry file never re-walked). Pre-existing in `DIP146` since its introduction ([#89](https://github.com/2389-research/dippin-lang/issues/89)) and inherited by the #102 deep advisory; both now catch the mixed-intent shared-child shape regardless of traversal order.
+
+### Docs
+- Documented the deep `DIP143` advisory and the intent-aware cross-file traversal in the validation reference (`docs/validation.md` + the website validation page).
+
 ## [v0.37.0] — 2026-06-08
 
 Mixed release. The cross-file `tool_access` detection + resolver hardening and the DIP010 edge-condition error are **dippin-side detection only** (no paired runtime release required). The graph-level `on_failure` route and the declarable budget guards are an **authoring surface dippin carries + lints while a paired runtime enforces** — inert until the runtime reads them (per `never-gate-dippin-on-tracker`, no dippin behavior is gated on runtime readiness).

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -259,11 +259,13 @@ Fires when `max_retries` is set in defaults and the workflow has `restart: true`
 
 **Severity:** Hint
 
-A `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) node references a child `.dip` while this workflow declares a `tool_access` restriction — and `tool_access` does not cross the file boundary. The lint cannot read the child, so it reminds you to give the child's agents their own `tool_access`. (For the resolved cross-file check that *reads* the child, see DIP146.)
+A `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) node references a child `.dip` while this workflow declares a `tool_access` restriction — and `tool_access` does not cross the file boundary. The wasm/playground lint cannot read the child, so it reminds you to give the child's agents their own `tool_access`. (For the resolved cross-file check that *reads* the child, see DIP146.)
 
 ```text
 hint[DIP143]: manager_loop "Supervise" references subgraph "child.dip", defined in its own file; this workflow's tool_access restrictions do not extend across the subgraph boundary
 ```
+
+The native `dippin lint` cross-file pass also emits DIP143 for a **deep** (depth ≥ 1) child it resolved and found either **partial-audit** (some agents restricted, at least one tool-bearing agent without a `tool_access` of its own) or **unresolvable** (missing, unparseable, or refused) — boundaries the entry-only lint never sees. Like DIP146, it fires only when a workflow on the path declares `tool_access`.
 
 ### DIP144 — Agent node has no failure route
 
@@ -290,7 +292,7 @@ warning[DIP145]: workflow budget default max_cost_cents is -5; budgets cannot be
 
 **Severity:** Hint
 
-`dippin lint` resolves a `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) child across the file boundary and finds it declares **no** `tool_access` restriction on any agent, while a workflow on the path from the linted entry restricts tools. Unlike DIP143 (which cannot read the child), DIP146 reads and confirms the child and traverses transitively. Detection only — dippin flags the gap; runtime enforcement is separate.
+`dippin lint` resolves a `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) child across the file boundary and finds it declares **no** `tool_access` restriction on any agent, while a workflow on the path from the linted entry restricts tools. Unlike DIP143 (which cannot read the child), DIP146 reads and confirms the child and traverses transitively. The traversal is intent-aware: a child reached through both a no-intent path and a restricting path is still checked under the restricting path. Detection only — dippin flags the gap; runtime enforcement is separate.
 
 ```text
 hint[DIP146]: manager_loop "Supervise" delegates to subgraph "worker.dip", which declares no tool_access restriction on any agent; a workflow on this path restricts tools, but the restriction does not cross the subgraph boundary

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -265,7 +265,7 @@ A `manager_loop` (`subgraph_ref`) or `subgraph` (`ref`) node references a child 
 hint[DIP143]: manager_loop "Supervise" references subgraph "child.dip", defined in its own file; this workflow's tool_access restrictions do not extend across the subgraph boundary
 ```
 
-The native `dippin lint` cross-file pass also emits DIP143 for a **deep** (depth ≥ 1) child it resolved and found either **partial-audit** (some agents restricted, at least one tool-bearing agent without a `tool_access` of its own) or **unresolvable** (missing, unparseable, or refused) — boundaries the entry-only lint never sees. Like DIP146, it fires only when a workflow on the path declares `tool_access`.
+The native `dippin lint` cross-file pass also emits DIP143 for a **deep** (depth ≥ 1) child that is either **partial-audit** (resolved — some agents restricted, at least one tool-bearing agent without a `tool_access` of its own) or **unresolvable** (missing, unparseable, or refused) — boundaries the entry-only lint never sees. Like DIP146, it fires only when a workflow on the path declares `tool_access`.
 
 ### DIP144 — Agent node has no failure route
 


### PR DESCRIPTION
Cuts **v0.38.0**. Detection-only release that completes the cross-file `tool_access` advisory arc shipped in v0.37.0 (DIP146 + resolver hardening). No paired runtime release required.

## Bundles
- **#102** (merged #108) — deep `DIP143` advisory: the cross-file pass now emits `DIP143` for partial-audit / unresolvable children at **depth ≥ 1** (behind an already-audited intermediate), which the entry-only lint never saw.
- **#109** (merged #111) — intent-aware re-walk: fixes a pre-existing false negative where a child reached first via a no-intent path and later via a restricting path wasn't re-checked under intent (affected DIP146 and the deep DIP143).

Both are already on `main`; this PR is the release mechanics.

## Changes in this PR
- `CHANGELOG.md` — `[Unreleased]` → `## [v0.38.0] — 2026-06-09` with Added / Fixed / Docs entries.
- `site/content/validation.md` — surfaces the deep `DIP143` advisory + intent-aware traversal (the deferred docs(site) pass).
- `site/content/changelog.md` — regenerated from `CHANGELOG.md` by the pre-commit hook.

## Release steps after merge
Tag `v0.38.0` on `main` → GoReleaser publishes binaries + Homebrew tap. **Tagging awaits explicit go-ahead.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783616733&installation_id=131176874&pr_number=112&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F112&signature=11bf514e58064b653e13d46a58a49c63de68fbb982391d0c7f093a4a74392cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified validation docs on how cross-file tool-access restrictions are evaluated and traversed.
  * Expanded advisory descriptions to explain intent-aware traversal and deeper (depth ≥1) analysis scenarios.
  * Added v0.38.0 release notes documenting these validation updates.

* **Bug Fixes**
  * Fixed intent-aware traversal so mixed-intent shared children are re-evaluated, preventing missed advisories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->