### PR TITLE
Add Opus 4.8 / Fable 5 / Mythos 5 to the model catalog + pricing (Closes #116)

### DIFF
--- a/cost/cost_test.go
+++ b/cost/cost_test.go
@@ -11,6 +11,28 @@ func testPricing() PricingTable {
 	return DefaultPricing()
 }
 
+// TestDefaultPricingNewAnthropicModels guards the #116 pricing refresh: the new
+// flagship IDs must be priced so `dippin cost` can estimate them. Mythos
+// Preview is intentionally absent (no published per-token price).
+func TestDefaultPricingNewAnthropicModels(t *testing.T) {
+	anthropic := DefaultPricing()["anthropic"]
+	want := map[string]ModelPrice{
+		"claude-opus-4-8": {InputPer1M: 5.00, OutputPer1M: 25.00},
+		"claude-fable-5":  {InputPer1M: 10.00, OutputPer1M: 50.00},
+		"claude-mythos-5": {InputPer1M: 10.00, OutputPer1M: 50.00},
+	}
+	for model, price := range want {
+		got, ok := anthropic[model]
+		if !ok {
+			t.Errorf("%s missing from anthropic pricing", model)
+			continue
+		}
+		if got != price {
+			t.Errorf("%s price = %+v, want %+v", model, got, price)
+		}
+	}
+}
+
 func TestSingleAgentNode(t *testing.T) {
 	w := &ir.Workflow{
 		Start: "a1",

--- a/cost/pricing.go
+++ b/cost/pricing.go
@@ -2,7 +2,7 @@ package cost
 
 // DefaultPricing returns a PricingTable with current model prices (USD per 1M tokens).
 //
-// Last verified: 2026-05-18
+// Last verified: 2026-06-10
 //
 // Sources:
 //
@@ -34,13 +34,19 @@ func DefaultPricing() PricingTable {
 	grok := grokPricing()
 	return PricingTable{
 		"anthropic": {
+			"claude-opus-4-8":   {InputPer1M: 5.00, OutputPer1M: 25.00},
 			"claude-opus-4-7":   {InputPer1M: 5.00, OutputPer1M: 25.00},
 			"claude-opus-4-6":   {InputPer1M: 5.00, OutputPer1M: 25.00},
 			"claude-sonnet-4-6": {InputPer1M: 3.00, OutputPer1M: 15.00},
 			"claude-haiku-4-5":  {InputPer1M: 1.00, OutputPer1M: 5.00},
+			// Fable 5 / Mythos 5 line (2026-06-09); base input/output rates
+			// only (cache/batch/fast-mode tiers are out of dippin's schema).
+			"claude-fable-5":    {InputPer1M: 10.00, OutputPer1M: 50.00},
+			"claude-mythos-5":   {InputPer1M: 10.00, OutputPer1M: 50.00},
 			"claude-sonnet-4-5": {InputPer1M: 3.00, OutputPer1M: 15.00},
 			"claude-opus-4-5":   {InputPer1M: 5.00, OutputPer1M: 25.00},
-			"claude-opus-4-1":   {InputPer1M: 15.00, OutputPer1M: 75.00},
+			// Deprecated; retires 2026-08-05 → claude-opus-4-8.
+			"claude-opus-4-1": {InputPer1M: 15.00, OutputPer1M: 75.00},
 			// Both deprecated 2026-04-14, retire 2026-06-15.
 			"claude-sonnet-4-0": {InputPer1M: 3.00, OutputPer1M: 15.00},
 			"claude-opus-4-0":   {InputPer1M: 15.00, OutputPer1M: 75.00},

--- a/validator/lint_model.go
+++ b/validator/lint_model.go
@@ -12,7 +12,7 @@ import (
 // This is a best-effort catalog — unknown combinations produce a warning,
 // not an error, since new models may be added at any time.
 //
-// Last verified: 2026-05-18
+// Last verified: 2026-06-10
 //
 // Sources:
 //
@@ -26,17 +26,25 @@ import (
 //	Cohere:     https://docs.cohere.com/docs/models
 var knownModelProviders = map[string]map[string]bool{
 	"anthropic": {
+		"claude-opus-4-8":   true,
 		"claude-opus-4-7":   true,
 		"claude-opus-4-6":   true,
 		"claude-sonnet-4-6": true,
 		"claude-haiku-4-5":  true,
+		// Fable 5 / Mythos 5 line (2026-06-09). Mythos 5 and the research
+		// preview are invite-only (Project Glasswing) but are real IDs —
+		// listed so approved users don't trip a spurious DIP108.
+		"claude-fable-5":        true,
+		"claude-mythos-5":       true,
+		"claude-mythos-preview": true,
 		// Legacy models still available via API.
 		"claude-sonnet-4-5": true,
 		"claude-opus-4-5":   true,
-		"claude-opus-4-1":   true,
+		// Deprecated; retires 2026-08-05 → claude-opus-4-8.
+		"claude-opus-4-1": true,
 		// Deprecated 2026-04-14, retires 2026-06-15 → claude-sonnet-4-6.
 		"claude-sonnet-4-0": true,
-		// Deprecated 2026-04-14, retires 2026-06-15 → claude-opus-4-7.
+		// Deprecated 2026-04-14, retires 2026-06-15 → claude-opus-4-8.
 		"claude-opus-4-0": true,
 		// Retired 2026-02-19 on first-party API; remains on Bedrock/Vertex AI.
 		"claude-haiku-3-5": true,

--- a/validator/lint_model_test.go
+++ b/validator/lint_model_test.go
@@ -1,0 +1,36 @@
+package validator
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestLintDIP108NewAnthropicModels guards the #116 catalog refresh: the
+// 2026-05/06 Anthropic IDs (incl. the invite-only Mythos line, which are real
+// IDs) must be recognized so approved users don't get spurious DIP108 warnings.
+func TestLintDIP108NewAnthropicModels(t *testing.T) {
+	models := []string{
+		"claude-opus-4-8",
+		"claude-fable-5",
+		"claude-mythos-5",
+		"claude-mythos-preview",
+	}
+	for _, model := range models {
+		src := fmt.Sprintf(`workflow w
+  start: A
+  exit: A
+
+  agent A
+    provider: anthropic
+    model: %s
+    prompt: go
+
+  edges
+    A -> A
+`, model)
+		diags := lintSrc(t, src)
+		if hasCode(diags, DIP108) {
+			t.Errorf("model %q tripped DIP108 (should be a known model): %v", model, codes(diags))
+		}
+	}
+}


### PR DESCRIPTION
Adds claude-opus-4-8, claude-fable-5, claude-mythos-5(+preview) to validator/lint_model.go catalog and cost/pricing.go (opus-4-8 $5/$25, fable-5 & mythos-5 $10/$50; mythos-preview catalog-only). Refreshes deprecation comments (opus-4-1 retires 2026-08-05; opus-4-0 migration -> opus-4-8) and bumps Last verified to 2026-06-10. Fixes spurious DIP108 + enables dippin cost for the new IDs. Tests: parser-driven DIP108-clean + DefaultPricing checks; verified end-to-end. Closes #116.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783700422&installation_id=131176874&pr_number=118&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F118&signature=86ded423c4d444606db22a650c2c6ffc45fbb632979ef52710caa924cde2a884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new Anthropic models: Claude Opus 4.8, Claude Fable 5, and Claude Mythos 5, including additional Opus, Sonnet, and Haiku variants.
  * Updated pricing data with per-1M token rates for newly supported models.

* **Tests**
  * Added test coverage verifying new Anthropic model support and pricing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->