### PR TITLE
Release v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ## [Unreleased]
 
+## [v0.39.0] — 2026-06-10
+
 Detection, carry, and correctness work — no paired runtime release required (per `never-gate-dippin-on-tracker`). `DIP147` and the `params:` carry are dippin-side detection / round-trip only; the single-quote fix is a parser correctness fix; the catalog refresh is data.
 
 ### Added

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,18 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.39.0] — 2026-06-10
+
+Detection, carry, and correctness work — no paired runtime release required (per `never-gate-dippin-on-tracker`). `DIP147` and the `params:` carry are dippin-side detection / round-trip only; the single-quote fix is a parser correctness fix; the catalog refresh is data.
+
+### Added
+- `DIP147` (Hint) — **chain-attack detection**: a restricted agent's output is laundered through an **explicitly-keyed** context handoff into a downstream tool-bearing agent, re-granting capability the upstream node was denied ([#56](https://github.com/2389-research/dippin-lang/issues/56), [#115](https://github.com/2389-research/dippin-lang/pull/115)). Covers the explicit-key handoff vector only — a **partial** #56. The other laundering vectors remain open follow-ups: `${ctx.last_response}` auto-injection (and a `last_response_truncate:` mitigation), attribute, cross-file, and branch-override. Detection, not runtime enforcement.
+- `params:` on `parallel` / `fan_in` nodes are now carried through parse → IR → formatter round-trip ([#110](https://github.com/2389-research/dippin-lang/issues/110), [#113](https://github.com/2389-research/dippin-lang/pull/113)). Formatter round-trip only (not DOT export or migrate); a paired runtime owns any fan-in policy semantics.
+- **Model catalog + pricing refresh** for Anthropic's 2026-05/06 releases ([#116](https://github.com/2389-research/dippin-lang/issues/116)): `claude-opus-4-8`, `claude-fable-5`, `claude-mythos-5`, and `claude-mythos-preview` are recognized models (clearing a spurious `DIP108`), with `claude-opus-4-8` ($5/$25), `claude-fable-5` ($10/$50), and `claude-mythos-5` ($10/$50) priced so `dippin cost` can estimate them. Deprecation metadata refreshed (`claude-opus-4-1` retires 2026-08-05; `claude-opus-4-0` migration target → `claude-opus-4-8`). The richer cache/batch/fast-mode pricing schema is an explicit non-goal; tracker-side runtime support is a cross-repo follow-up.
+
+### Fixed
+- **Single-quoted scalar values are no longer corrupted** ([#114](https://github.com/2389-research/dippin-lang/issues/114)). The parser stripped only double quotes, so `marker_grep: '^(a|b)$'` was stored with the literal `'` chars — and the formatter then re-wrapped it in double quotes — silently breaking the runtime regex. Single quotes are now YAML-style (surrounding quotes stripped, `''` → `'`, backslashes literal), and a `#` inside `'...'` is no longer mistaken for a trailing comment. Fixed in the parser so every path (lint / pack / format / DOT / migrate / runtime) benefits; the tree-sitter grammar admits single-quoted strings too.
+
 ## [v0.38.0] — 2026-06-09
 
 Cross-file `tool_access` advisory completeness. Both changes are **dippin-side detection only** — they refine the `DIP146`/`DIP143` cross-file analysis shipped in v0.37.0 and require no paired runtime release (per `never-gate-dippin-on-tracker`, no dippin behavior is gated on runtime readiness).

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -1,8 +1,8 @@
 ---
 title: "Validation & Linting"
-description: "56 diagnostic codes for AI pipeline workflows. 10 structural errors and 46 semantic warnings catch bugs before runtime."
+description: "57 diagnostic codes for AI pipeline workflows. 10 structural errors and 47 semantic warnings catch bugs before runtime."
 section_label: "Diagnostics"
-subtitle: "56 diagnostic codes — 10 structural errors and 46 semantic warnings — to catch problems before runtime."
+subtitle: "57 diagnostic codes — 10 structural errors and 47 semantic warnings — to catch problems before runtime."
 ---
 
 ## Overview

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -11,7 +11,7 @@ Dippin provides two levels of analysis:
 
 **Structural validation** (DIP001-DIP010): Errors that must be fixed. A workflow with any of these cannot execute. Run with `dippin validate`.
 
-**Semantic linting** (DIP101-DIP146): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
+**Semantic linting** (DIP101-DIP147): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
 
 ### Diagnostic Format
 
@@ -107,7 +107,7 @@ These must be fixed for a workflow to be valid. Each causes exit code 1.
   = help: valid operators: = == != contains startswith endswith in</pre>
 </div>
 
-## Semantic Warnings (DIP101-DIP146)
+## Semantic Warnings (DIP101-DIP147)
 
 These flag likely bugs or questionable patterns. Warnings alone exit 0.
 
@@ -298,4 +298,14 @@ warning[DIP145]: workflow budget default max_cost_cents is -5; budgets cannot be
 hint[DIP146]: manager_loop "Supervise" delegates to subgraph "worker.dip", which declares no tool_access restriction on any agent; a workflow on this path restricts tools, but the restriction does not cross the subgraph boundary
 ```
 
-> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP146) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.
+### DIP147 — Restricted agent's output reaches a privileged prompt (chain attack)
+
+**Severity:** Hint
+
+A `tool_access: none` agent declares a context key in `writes:`, and a downstream tool-bearing agent (one that omits `tool_access`, so it holds the full catalog) declares that same key in `reads:`. `tool_access` bounds an agent's *tools*, not the *information* its output carries — so the restricted agent's output (potentially a laundered injection payload) reaches a privileged agent's prompt, re-granting capability the upstream node was denied. dippin flags the explicitly-keyed handoff the author wired by hand; the runtime enforces the bound. Detection only.
+
+```text
+hint[DIP147]: restricted agent "Summarize" (tool_access: none) writes context key "summary" that tool-bearing agent "Act" reads — its output reaches a privileged prompt
+```
+
+> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP147) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.


### PR DESCRIPTION
## v0.39.0 release

Renames `## [Unreleased]` → `## [v0.39.0] — 2026-06-10` and adds a fresh empty `[Unreleased]`. Also surfaces the new **DIP147** chain-attack code (Hint) on the hand-maintained `site/content/validation.md` (per the #100→#107 / #102→#108 release docs precedent). Pre-commit regenerated `site/content/changelog.md`.

### Contents (vs v0.38.0)
- **#114 / #117** — single-quoted scalar corruption fix (parser; P1, was breaking a real pipeline).
- **#116 / #118** — Opus 4.8 / Fable 5 / Mythos 5 catalog + pricing.
- **#110 / #113** — `params:` carry on `parallel`/`fan_in` (formatter round-trip).
- **#56 / #115** — DIP147 chain-attack detection (Hint, explicit-key vector; partial #56).

Detection / carry / correctness only — no paired runtime release required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783706642&installation_id=131176874&pr_number=121&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F121&signature=d8bce365d63e26ff24af1dbb4cdc7c4a89d6b9765b3d8f485a7d562578004adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published v0.39.0 release notes documenting bug fixes and feature enhancements.
  * Added chain-attack detection validation (DIP147) to prevent privilege escalation scenarios.
  * Enhanced parameter support for parallel and fan-in operations.
  * Updated AI model catalog with latest Anthropic models and pricing.
  * Fixed YAML parser handling of single-quoted values to preserve scalar content during round-trips.
  * Updated validation diagnostic documentation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->