### PR TITLE
release: v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ## [Unreleased]
 
+## [v0.40.0] — 2026-06-11
+
 Carry + detection work pairing with downstream runtimes — no dippin behavior is gated on runtime readiness (per `never-gate-dippin-on-tracker`). Both attributes are carried through every `.dip` path; their semantics are owned by a paired runtime.
 
 ### Added

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,18 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.40.0] — 2026-06-11
+
+Carry + detection work pairing with downstream runtimes — no dippin behavior is gated on runtime readiness (per `never-gate-dippin-on-tracker`). Both attributes are carried through every `.dip` path; their semantics are owned by a paired runtime.
+
+### Added
+- `last_response_truncate` (agent node + `parallel` branch override, integer) — a character-count cap on the auto-injected `${ctx.last_response}` handoff, a **carry-only chain-attack mitigation** ([#56](https://github.com/2389-research/dippin-lang/issues/56), [#123](https://github.com/2389-research/dippin-lang/pull/123)). Carried through parse → IR → formatter → DOT export → migrate; `DIP148` (Warning) flags a negative value (`0`/unset = disabled). Carried, not interpreted — a paired runtime performs the truncation. Mitigates the `${ctx.last_response}` auto-injection vector of #56 when an enforcing runtime honors this field; `DIP147` (explicit-key handoff) is unaffected and there is no DIP147↔truncate interaction.
+- `override: true` / `override: false` edge attribute → `ir.Edge.Override` (bool) — **carried, not interpreted** (the same policy as `restart:`) ([#124](https://github.com/2389-research/dippin-lang/issues/124)). Parsed in any order alongside `when` / `label` / `weight` / `restart` (no longer silently swallowed), and round-tripped through the `.dip` formatter, DOT export, and migrate. No dippin-side semantics — a paired runtime maps it onward and owns the rule that `override` edges originate from `human` nodes. Same shape as the `params:` carry shipped in v0.39.0 ([#113](https://github.com/2389-research/dippin-lang/pull/113)).
+
+### Runtime pairing (requires an enforcing runtime)
+- Edge `override` unblocks the workflow-author syntax for [2389-research/tracker#271](https://github.com/2389-research/tracker/issues/271), whose engine half (the `validation_overridden` terminal status, `pipeline.Edge.Override`, sticky checkpoint persistence, `--fail-on-override`, lint TRK102) shipped in tracker v0.35.0. Once this is tagged, tracker maps `ir.Edge.Override` → `pipeline.Edge.Override` in `convertEdge`, adds the human-origin validation (tracker spec D11), and migrates the catalogued override edges (tracker#271 finisher).
+- `last_response_truncate` is carried + linted by dippin but the truncation is performed by the runtime — inert until a paired runtime reads it.
+
 ## [v0.39.0] — 2026-06-10
 
 Detection, carry, and correctness work — no paired runtime release required (per `never-gate-dippin-on-tracker`). `DIP147` and the `params:` carry are dippin-side detection / round-trip only; the single-quote fix is a parser correctness fix; the catalog refresh is data.


### PR DESCRIPTION
Cuts **v0.40.0** from the populated `[Unreleased]` section. Two carry-only features merged since v0.39.0, both carried through every `.dip` path and **not interpreted** (semantics owned by a paired runtime):

- **`last_response_truncate`** (agent node + `parallel` branch override) + **DIP148** — carry-only chain-attack mitigation ([#56](https://github.com/2389-research/dippin-lang/issues/56) / [#123](https://github.com/2389-research/dippin-lang/pull/123)).
- **`override`** edge attribute → `ir.Edge.Override` ([#124](https://github.com/2389-research/dippin-lang/issues/124) / [#125](https://github.com/2389-research/dippin-lang/pull/125)).

**Why now:** clean release boundary — `main` is exactly v0.39.0 + these two carry-only features. Tagging unblocks the **tracker#271 finisher** (tracker maps `ir.Edge.Override` → `pipeline.Edge.Override` only once dippin tags a release). Cutting this *before* Phase 0 edge-syntax work (#126+) keeps that behavior change in its own future release rather than bundled with unrelated carries.

### Changes
- `CHANGELOG.md`: `[Unreleased]` → `[v0.40.0] — 2026-06-11`, fresh empty `[Unreleased]` added.
- `site/content/changelog.md`: regenerated by pre-commit (in sync, do not hand-edit).

### Not included
- #137 (edge-syntax proposal doc) also merged since v0.39.0 but is intentionally **not** a changelog entry — design docs, no behavior change.

### Release steps after merge (maintainer)
`git tag -a v0.40.0 -m "v0.40.0" && git push origin v0.40.0` on `main` → triggers GoReleaser (`release.yml`). **Not tagged yet — awaiting go-ahead.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783804694&installation_id=131176874&pr_number=138&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F138&signature=698fee513a0f4a40b06c36dcf1a5498d1250c2e228d471f19d8d26bcb0a06649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->