### PR TITLE
parser: edge-attribute robustness — diagnose unknown attrs + colon-gated keyword termination (#126)

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -73,10 +73,17 @@ func (l *Lexer) NextToken() Token {
 }
 
 func (l *Lexer) PeekToken() Token {
-	if l.tokenIdx >= len(l.tokens) {
+	return l.PeekTokenN(0)
+}
+
+// PeekTokenN returns the token n positions ahead of the cursor without
+// consuming it. PeekTokenN(0) is equivalent to PeekToken.
+func (l *Lexer) PeekTokenN(n int) Token {
+	idx := l.tokenIdx + n
+	if idx >= len(l.tokens) {
 		return Token{Type: TokenEOF, Location: ir.SourceLocation{Line: l.line, Column: l.col}}
 	}
-	return l.tokens[l.tokenIdx]
+	return l.tokens[idx]
 }
 
 // lineIndent returns the number of leading whitespace bytes in a line.

--- a/parser/parse_edges.go
+++ b/parser/parse_edges.go
@@ -106,9 +106,12 @@ func (p *Parser) emitUnknownEdgeAttribute(attr Token) {
 		"unknown edge attribute %q at %d:%d",
 		attr.Value, attr.Location.Line, attr.Location.Column,
 	))
-	if p.lexer.PeekToken().Type == TokenColon {
-		p.lexer.NextToken() // consume ':'
-		p.lexer.NextToken() // consume value
+	if p.lexer.PeekToken().Type != TokenColon {
+		return
+	}
+	p.lexer.NextToken() // consume ':'
+	if t := p.lexer.PeekToken().Type; t != TokenNewline && t != TokenEOF {
+		p.lexer.NextToken() // consume value (only when present)
 	}
 }
 

--- a/parser/parse_edges.go
+++ b/parser/parse_edges.go
@@ -46,7 +46,7 @@ func (p *Parser) parseEdgeAttributes(edge *ir.Edge) {
 	}
 	for p.lexer.PeekToken().Type != TokenNewline && p.lexer.PeekToken().Type != TokenEOF {
 		attr := p.lexer.NextToken()
-		p.applyEdgeAttribute(edge, attr.Value)
+		p.applyEdgeAttribute(edge, attr)
 	}
 }
 
@@ -66,8 +66,8 @@ var edgeAttrKeywords = map[string]bool{
 }
 
 // applyEdgeAttribute applies a single edge attribute.
-func (p *Parser) applyEdgeAttribute(edge *ir.Edge, attrName string) {
-	switch attrName {
+func (p *Parser) applyEdgeAttribute(edge *ir.Edge, attr Token) {
+	switch attr.Value {
 	case "when":
 		edge.Condition = &ir.Condition{Raw: p.readConditionRaw()}
 	case "label":
@@ -78,29 +78,49 @@ func (p *Parser) applyEdgeAttribute(edge *ir.Edge, attrName string) {
 		wt := p.lexer.NextToken()
 		edge.Weight = p.parseInt(wt.Value, "weight", wt.Location)
 	default:
-		p.applyEdgeBoolAttribute(edge, attrName)
+		p.applyEdgeBoolAttribute(edge, attr)
 	}
 }
 
 // applyEdgeBoolAttribute applies the boolean edge attributes (restart, override),
-// each of the form "<name>: true|false". Carried, not interpreted.
-func (p *Parser) applyEdgeBoolAttribute(edge *ir.Edge, attrName string) {
-	switch attrName {
+// each of the form "<name>: true|false". Carried, not interpreted. An
+// unrecognized attribute is diagnosed once rather than silently swallowed.
+func (p *Parser) applyEdgeBoolAttribute(edge *ir.Edge, attr Token) {
+	switch attr.Value {
 	case "restart":
 		p.expect(TokenColon)
 		edge.Restart = (p.lexer.NextToken().Value == "true")
 	case "override":
 		p.expect(TokenColon)
 		edge.Override = (p.lexer.NextToken().Value == "true")
+	default:
+		p.emitUnknownEdgeAttribute(attr)
 	}
 }
 
-// readConditionRaw reads tokens until a newline/EOF or a known edge attribute keyword.
+// emitUnknownEdgeAttribute records a located diagnostic for an unrecognized edge
+// attribute and consumes its optional ": value" payload, so the per-token
+// attribute loop diagnoses each unknown attribute exactly once.
+func (p *Parser) emitUnknownEdgeAttribute(attr Token) {
+	p.diagnostics = append(p.diagnostics, fmt.Sprintf(
+		"unknown edge attribute %q at %d:%d",
+		attr.Value, attr.Location.Line, attr.Location.Column,
+	))
+	if p.lexer.PeekToken().Type == TokenColon {
+		p.lexer.NextToken() // consume ':'
+		p.lexer.NextToken() // consume value
+	}
+}
+
+// readConditionRaw reads tokens until a newline/EOF or a known edge attribute
+// keyword. An attribute keyword only terminates the condition when it is
+// followed by ':' (the shape of an attribute); a bare keyword on the right-hand
+// side of a condition (e.g. "when ctx.reason = override") is part of the value.
 func (p *Parser) readConditionRaw() string {
 	var parts []string
 	for p.lexer.PeekToken().Type != TokenNewline && p.lexer.PeekToken().Type != TokenEOF {
 		pk := p.lexer.PeekToken()
-		if edgeAttrKeywords[pk.Value] {
+		if edgeAttrKeywords[pk.Value] && p.lexer.PeekTokenN(1).Type == TokenColon {
 			break
 		}
 		t := p.lexer.NextToken()

--- a/parser/parse_edges_test.go
+++ b/parser/parse_edges_test.go
@@ -1,0 +1,165 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildEdgeDip produces a minimal three-node workflow whose single edge line
+// is the given text (e.g. "A -> B bogus: true").
+func buildEdgeDip(edgeLine string) string {
+	return "workflow X\n" +
+		"  goal: \"Test edges\"\n" +
+		"  start: A\n" +
+		"  exit: C\n" +
+		"\n" +
+		"  agent A\n" +
+		"    prompt: \"Do A.\"\n" +
+		"\n" +
+		"  agent B\n" +
+		"    prompt: \"Do B.\"\n" +
+		"\n" +
+		"  agent C\n" +
+		"    prompt: \"Do C.\"\n" +
+		"\n" +
+		"  edges\n" +
+		"    " + edgeLine + "\n" +
+		"    B -> C\n"
+}
+
+// TestParseUnknownEdgeAttributeDiagnoses covers #126(a): an unrecognized edge
+// attribute must become a single located parse diagnostic, not be silently
+// swallowed, and must not fire once per token (name / ':' / value).
+func TestParseUnknownEdgeAttributeDiagnoses(t *testing.T) {
+	p := NewParser(buildEdgeDip("A -> B bogus: true"), "test.dip")
+	w, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected parse error for unknown edge attribute, got nil")
+	}
+	diags := p.Diagnostics()
+
+	count := 0
+	for _, d := range diags {
+		if strings.Contains(d, "bogus") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one diagnostic mentioning 'bogus', got %d: %v", count, diags)
+	}
+	joined := strings.Join(diags, "\n")
+	if !strings.Contains(joined, "unknown edge attribute") {
+		t.Errorf("expected an 'unknown edge attribute' diagnostic, got: %v", diags)
+	}
+	// Located: the diagnostic carries a line:column.
+	if !strings.Contains(joined, "16:") {
+		t.Errorf("expected diagnostic to carry the attribute's line (16), got: %v", diags)
+	}
+
+	// Subsequent edges still parse after the diagnostic.
+	found := false
+	for _, e := range w.Edges {
+		if e.From == "B" && e.To == "C" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected edge B -> C to still parse after unknown-attr diagnostic")
+	}
+}
+
+// TestParseUnknownBareEdgeAttributeDiagnosesOnce covers an unknown attribute
+// with no ": value" payload (a bare word), which must still fire exactly once.
+func TestParseUnknownBareEdgeAttributeDiagnosesOnce(t *testing.T) {
+	p := NewParser(buildEdgeDip("A -> B bogus"), "test.dip")
+	_, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected parse error for unknown bare edge attribute, got nil")
+	}
+	count := 0
+	for _, d := range p.Diagnostics() {
+		if strings.Contains(d, "bogus") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one diagnostic mentioning 'bogus', got %d: %v", count, p.Diagnostics())
+	}
+}
+
+// TestParseConditionWithBareKeywordRHS covers #126(b): a condition whose bare
+// unquoted right-hand value is an attribute keyword must NOT truncate the
+// condition. The keyword only terminates a condition when followed by ':'.
+func TestParseConditionWithBareKeywordRHS(t *testing.T) {
+	for _, kw := range []string{"override", "restart", "label", "weight"} {
+		t.Run(kw, func(t *testing.T) {
+			p := NewParser(buildEdgeDip("A -> B when ctx.reason = "+kw), "test.dip")
+			w, err := p.Parse()
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			var edge = w.Edges[0]
+			if edge.Condition == nil {
+				t.Fatalf("expected a condition on edge A->B, got nil")
+			}
+			want := "ctx.reason = " + kw
+			if edge.Condition.Raw != want {
+				t.Errorf("condition Raw = %q, want %q", edge.Condition.Raw, want)
+			}
+		})
+	}
+}
+
+// TestParseKeywordAttributesStillTerminateCondition guards the other side of
+// #126(b): a genuine attribute (keyword followed by ':') still terminates the
+// condition rather than being absorbed into it.
+func TestParseKeywordAttributesStillTerminateCondition(t *testing.T) {
+	p := NewParser(buildEdgeDip(`A -> B when ctx.x == "ok" label: approved weight: 5`), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	edge := w.Edges[0]
+	if edge.Condition == nil || edge.Condition.Raw != `ctx.x == "ok"` {
+		t.Errorf("condition = %+v, want Raw %q", edge.Condition, `ctx.x == "ok"`)
+	}
+	if edge.Label != "approved" {
+		t.Errorf("label = %q, want %q", edge.Label, "approved")
+	}
+	if edge.Weight != 5 {
+		t.Errorf("weight = %d, want 5", edge.Weight)
+	}
+}
+
+// TestExistingDipFilesStillParse covers #126(c): the new diagnostics must not
+// regress any currently-valid .dip file. Every examples/*.dip and
+// parser/testdata/*.dip must still parse without error.
+func TestExistingDipFilesStillParse(t *testing.T) {
+	dirs := []string{"../examples", "testdata"}
+	var files []string
+	for _, d := range dirs {
+		matches, err := filepath.Glob(filepath.Join(d, "*.dip"))
+		if err != nil {
+			t.Fatalf("glob %s: %v", d, err)
+		}
+		files = append(files, matches...)
+	}
+	if len(files) == 0 {
+		t.Fatal("no .dip files found to guard against regression")
+	}
+	for _, f := range files {
+		f := f
+		t.Run(filepath.Base(f), func(t *testing.T) {
+			src, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			p := NewParser(string(src), f)
+			if _, err := p.Parse(); err != nil {
+				t.Errorf("%s no longer parses: %v", f, err)
+			}
+		})
+	}
+}

--- a/parser/parse_edges_test.go
+++ b/parser/parse_edges_test.go
@@ -89,6 +89,35 @@ func TestParseUnknownBareEdgeAttributeDiagnosesOnce(t *testing.T) {
 	}
 }
 
+// TestParseUnknownEdgeAttributeMissingValue covers the no-value form
+// ("bogus:" with nothing after the colon): the diagnostic must fire once and
+// the parser must not consume the newline, so the following edge still parses.
+func TestParseUnknownEdgeAttributeMissingValue(t *testing.T) {
+	p := NewParser(buildEdgeDip("A -> B bogus:"), "test.dip")
+	w, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected parse error for unknown edge attribute, got nil")
+	}
+	count := 0
+	for _, d := range p.Diagnostics() {
+		if strings.Contains(d, "bogus") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one diagnostic mentioning 'bogus', got %d: %v", count, p.Diagnostics())
+	}
+	found := false
+	for _, e := range w.Edges {
+		if e.From == "B" && e.To == "C" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected edge B -> C to still parse after a value-less unknown attr")
+	}
+}
+
 // TestParseConditionWithBareKeywordRHS covers #126(b): a condition whose bare
 // unquoted right-hand value is an attribute keyword must NOT truncate the
 // condition. The keyword only terminates a condition when followed by ':'.


### PR DESCRIPTION
Closes #126. Prerequisite for the Phase 0 edge-syntax work (#127): #128–#132 each add an edge keyword/attribute, and this makes that surface safe.

## What

Two edge-attribute parser robustness fixes in `parser/parse_edges.go`, both **detection-only** (no runtime pairing):

**(a) Unknown edge attributes → located parse diagnostic.** Today `applyEdgeAttribute`'s switch silently no-ops on unknown names (the `override`-was-inert class from #124). The per-token attribute loop feeds `name` / `:` / `value` separately, so a naive `default:` would fire 3× per unknown attr. `emitUnknownEdgeAttribute` consumes the optional `": value"` payload so each unknown attribute diagnoses **exactly once**:

```
A -> B  bogus: true     # → unknown edge attribute "bogus" at 16:12
```

**(b) Colon-gated keyword termination.** `label`/`weight`/`restart`/`override` now only terminate a `when` condition when followed by `:`. A bare attribute word as a condition's right-hand value no longer truncates it:

```
A -> B  when ctx.reason = override     # condition now keeps "ctx.reason = override"
```

This is the documented pre-existing-class limitation from #124/#125. Adds `Lexer.PeekTokenN` for the one-token lookahead.

## Compatibility

Source-compatible but **not strictly non-breaking**: (a) can newly reject files with typo'd attributes. Intended; lands in its own release.

## Tests (TDD)

- `parser/parse_edges_test.go`:
  - unknown attr (`bogus: true`) → exactly one located diagnostic; subsequent edges still parse
  - unknown bare attr (no `: value`) → fires once
  - `when ctx.reason = <kw>` for each of override/restart/label/weight → condition preserved
  - genuine `label:`/`weight:` attributes still terminate the condition (guard)
  - regression: every `examples/*.dip` + `parser/testdata/*.dip` still parses clean

Full pre-commit gate passes (build/vet/golangci-lint/gofmt/race/cyclo≤5/cognit≤7/validate-examples/releasecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783805519&installation_id=131176874&pr_number=139&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F139&signature=5222d110dd0534387c10dac42421e341ea6f798b1f8a7ae2b63f3e8a797bc39e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->