### PR TITLE
fix(playground): correct lint JSON shape and initial syntax highlighting

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -40,10 +40,35 @@ func jsLint(_ js.Value, args []js.Value) interface{} {
 	valRes := validator.Validate(w)
 	lintRes := validator.Lint(w)
 	all := append(valRes.Diagnostics, lintRes.Diagnostics...)
-	if all == nil {
-		all = []validator.Diagnostic{}
+	return toJSON(toLintDiags(all))
+}
+
+// lintDiag is the JSON shape of a diagnostic returned to the playground. It
+// matches the CLI's camelCase contract with a string severity — see checkDiag
+// in cmd/dippin/cmd_check.go — rather than the raw validator.Diagnostic, whose
+// PascalCase fields and numeric Severity the playground JS cannot read.
+type lintDiag struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+	Line     int    `json:"line,omitempty"`
+	Fix      string `json:"fix,omitempty"`
+}
+
+// toLintDiags converts validator diagnostics to the playground JSON shape. It
+// always returns a non-nil slice so a clean workflow marshals to "[]".
+func toLintDiags(diags []validator.Diagnostic) []lintDiag {
+	out := make([]lintDiag, 0, len(diags))
+	for _, d := range diags {
+		out = append(out, lintDiag{
+			Code:     d.Code,
+			Severity: d.Severity.String(),
+			Message:  d.Message,
+			Line:     d.Location.Line,
+			Fix:      d.Fix,
+		})
 	}
-	return toJSON(all)
+	return out
 }
 
 func jsFormat(_ js.Value, args []js.Value) interface{} {

--- a/site/layouts/_default/playground.html
+++ b/site/layouts/_default/playground.html
@@ -88,8 +88,15 @@ function syncScroll() {
   highlightEl.scrollTop = editorEl.scrollTop;
   highlightEl.scrollLeft = editorEl.scrollLeft;
 }
-// Initial highlight.
-syncHighlight();
+// Initial highlight. highlight.js is loaded at the end of <body>, after this
+// inline script runs, so dippinHighlight isn't defined yet — defer the first
+// highlight to DOMContentLoaded or the default source renders invisible
+// (transparent textarea over an empty overlay) until the first keystroke.
+if (window.dippinHighlight) {
+  syncHighlight();
+} else {
+  document.addEventListener("DOMContentLoaded", syncHighlight);
+}
 
 // Tab key inserts 2 spaces instead of changing focus.
 editorEl.addEventListener("keydown", function(e) {


### PR DESCRIPTION
Fixes two distinct playground bugs reported on dippin.org. Both are source-only; Netlify regenerates `dippin.wasm` and the page on deploy.

## Bug 1 — Lint crash (`Failed to load WASM` + `can't access property "replace"`)

`cmd/wasm/main.go`'s `jsLint` marshalled the raw `validator.Diagnostic`, which has **no JSON tags** → PascalCase keys (`Code`, `Message`) and a **numeric** `Severity`. The playground JS reads `d.code` / `d.severity` / `d.message` (camelCase, string severity), so all were `undefined` and `escapeHtml(undefined)` threw.

The default workflow emits a DIP144 warning, so it fired immediately. On load, the auto `runLint()` runs **inside** the WASM-load `.then`, so the crash was caught by that `.catch` and mislabeled *"Failed to load WASM"* — which is why it first looked like a WASM-loading failure. Parse/Format were unaffected (they don't read those fields).

**Fix:** map diagnostics to a camelCase / string-severity DTO matching the CLI's existing `checkDiag` contract (`cmd/dippin/cmd_check.go`). Output is now `{"code":"DIP144","severity":"warning","message":"…","line":6}`; clean workflows still yield `[]`.

## Bug 2 — Source code invisible (black-on-black) until first keystroke

`baseof.html` loads `highlight.js` at the **end of `<body>`**, after the playground's inline script runs its initial `syncHighlight()`. At that point `window.dippinHighlight` is `undefined`, so the call no-ops and the highlight overlay stays empty over a `color: transparent` textarea — the default source is invisible until `oninput` re-highlights.

**Fix:** defer the initial highlight to `DOMContentLoaded` (fires after the body-end script executes), with an `if (window.dippinHighlight)` fast path.

## Verification
- Rebuilt `GOOS=js GOARCH=wasm` wasm, ran it under Node with the matched `wasm_exec.js`: lint of the default source returns the camelCase/string-severity shape; a clean workflow returns `[]`.
- Full pre-commit gate passed (build, vet, golangci-lint, gofmt, race test suite, releasecheck, cyclo/cognit, validate-examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783880555&installation_id=131176874&pr_number=142&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F142&signature=cdefcfeb89deeae6c04f316ae7894afe0ee9aa6be905923039046b7cd3bf47c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->