### PR TITLE
feat(validator): DIP149 ambiguous routing lint (#132)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Editor / agent integrations:
 ```sh
 dippin parse pipeline.dip          # JSON IR
 dippin validate pipeline.dip       # structural errors (DIP001-DIP010)
-dippin lint pipeline.dip           # validation + semantic warnings (DIP101-DIP147)
+dippin lint pipeline.dip           # validation + semantic warnings (DIP101-DIP149)
 dippin format pipeline.dip         # canonical formatting
 dippin doctor pipeline.dip         # A-F health report
 dippin cost pipeline.dip           # per-run cost estimate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistr
 
 ## Lint Rules
 
-57 diagnostic codes: DIP001-DIP010 (structural errors), DIP101-DIP147 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
+59 diagnostic codes: DIP001-DIP010 (structural errors), DIP101-DIP149 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ graph LR
 | Shell scripts | `tool_command="#!/bin/sh\nset -eu\nif..."` | Real multiline, real syntax |
 | Model config | Untyped `llm_model="..."` attribute | Typed `model:` field with validation |
 | Branching | `condition="context.x!=y && context.a==b"` | `when ctx.x != "y" and ctx.a == "b"` |
-| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP147) |
+| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP149) |
 | Node types | Shape overloading (`box`=agent, `hexagon`=human) | Explicit `agent`, `tool`, `human` keywords |
 | Composition | No import/include system | `subgraph` with ref (v2) |
 
@@ -131,7 +131,7 @@ Every analysis command (`validate`, `lint`, `doctor`, `parse`, `cost`, `coverage
 |---------|-------------|
 | `dippin parse <file>` | Parse and output IR as JSON |
 | `dippin validate <file>` | Structural validation (DIP001–DIP010) |
-| `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP147) |
+| `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP149) |
 | `dippin check [--format json\|text] <file>` | Parse+validate+lint in one shot (JSON default, for LLM tooling) |
 | `dippin fmt [--check] [--write] <file>` | Format to canonical style |
 | `dippin new [--name N] [--write F] <template>` | Generate a starter .dip from a template |
@@ -390,7 +390,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 | DIP008 | Duplicate node ID |
 | DIP009 | Duplicate edge |
 
-### Warnings (DIP101–DIP147 — selected; see [docs/validation.md](docs/validation.md) for the full catalog)
+### Warnings (DIP101–DIP149 — selected; see [docs/validation.md](docs/validation.md) for the full catalog)
 
 | Code | What it catches |
 |------|----------------|

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -192,10 +192,10 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-58 diagnostic codes across two categories:
+59 diagnostic codes across two categories:
 
 - **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
-- **DIP101–DIP148** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate
+- **DIP101–DIP149** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges)
 
 ---
 
@@ -565,7 +565,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP147) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP149) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |
@@ -694,6 +694,7 @@ The primary loop for authoring .dip files:
 | DIP145 | Graph budget default is negative | Use a positive cap, or omit the field / set `0` to mean no limit |
 | DIP146 | Referenced subgraph child restricts no agent's `tool_access` while a workflow on the path does (cross-file) | Set `tool_access` on the child's agents; native `dippin lint` resolves the child and supersedes DIP143 |
 | DIP147 | A `tool_access: none` agent `writes:` a context key that a downstream tool-bearing agent `reads:` (chain-attack / info-flow) | Confirm the restricted agent's input is trusted; if not, give the consumer `tool_access: none` too or insert a sanitizing step. Detection only — the runtime enforces |
+| DIP149 | A node has 2+ unconditional outgoing edges — which one fires is decided only by the lexical (alphabetical) tiebreak on target node ID | Keep at most one unconditional edge as the default fallback; guard the others with `when`. Restart/`loop` back-edges are exempt |
 
 ## Best Practices
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ dippin-lang/
 │
 ├── validator/          # Graph validation + semantic linting
 │   ├── codes.go        # Error code constants (DIP001–DIP010)
-│   ├── lint_codes.go   # Warning code constants (DIP101–DIP148)
+│   ├── lint_codes.go   # Warning code constants (DIP101–DIP149)
 │   ├── diagnostic.go   # Diagnostic type, Result, Severity
 │   ├── validate.go     # 10 structural checks
 │   ├── lint.go         # Lint orchestration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,7 +124,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 
 ### lint
 
-Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP148).
+Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP149).
 
 ```bash
 dippin lint [--extra-models <spec>] <file>
@@ -132,7 +132,7 @@ dippin lint [--extra-models <spec>] <file>
 
 **Input**: `.dip` or `.dot` file
 
-**Checks**: All 57 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP148) are reported but don't affect the exit code.
+**Checks**: All 59 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP149) are reported but don't affect the exit code.
 
 **Output**: All diagnostics (errors and warnings) to stderr.
 

--- a/docs/edges.md
+++ b/docs/edges.md
@@ -141,6 +141,12 @@ When a node completes, the engine selects the next edge using this cascade (firs
 
 This means conditions always take precedence over labels, and labels over weights. The lexical fallback ensures deterministic behavior.
 
+> **Don't rely on the lexical tiebreak.** Priority 5 resolves ties by the
+> *spelling* of the target node ID, so renaming a target can silently change
+> which edge fires. When a node has two or more unconditional outgoing edges,
+> [DIP149](validation.md#dip149-ambiguous-routing) warns: keep at most one
+> unconditional edge as the default fallback and guard the rest with `when`.
+
 ---
 
 ## Failure Handling

--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -18,7 +18,7 @@ This starts the server on stdio (stdin/stdout), speaking JSON-RPC 2.0 per the LS
 
 | Feature | Description |
 |---------|-------------|
-| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP148 semantic) |
+| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP149 semantic) |
 | **Hover** | Tooltip showing node kind, model, provider, prompt preview, and field summary |
 | **Go-to-definition** | Jump from a node reference in an edge to the node's declaration |
 | **Autocomplete** | Node IDs in edges, field names within node blocks, keywords |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -111,7 +111,7 @@ if result.HasErrors() {
     }
 }
 
-// Semantic lint (DIP101–DIP148; DIP146 is CLI/cross-file only) — warnings
+// Semantic lint (DIP101–DIP149; DIP146 is CLI/cross-file only) — warnings
 lintResult := validator.Lint(workflow)
 for _, d := range lintResult.Diagnostics {
     fmt.Println(d.String())

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -190,7 +190,7 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-58 diagnostic codes across two categories:
+59 diagnostic codes across two categories:
 
 - **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
-- **DIP101–DIP148** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate
+- **DIP101–DIP149** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,9 +1,9 @@
 # Validation and Linting Reference
 
-Dippin registers 58 diagnostic codes split into two categories; this page gives a dedicated section to every code except `DIP138`, which is reserved and has no firing logic (57 documented sections):
+Dippin registers 59 diagnostic codes split into two categories; this page gives a dedicated section to every code except `DIP138`, which is reserved and has no firing logic (58 documented sections):
 
 - **Structural validation** (DIP001–DIP010): Errors that **must** be fixed. A workflow with any of these cannot execute.
-- **Semantic linting** (DIP101–DIP148): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
+- **Semantic linting** (DIP101–DIP149): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
 
 Run `dippin validate <file>` for structural checks only, or `dippin lint <file>` for both.
 
@@ -12,7 +12,7 @@ graph LR
     SRC[".dip file"] --> PARSE["Parser"]
     PARSE --> IR["IR"]
     IR --> VAL["Structural Validation<br>DIP001–DIP010<br>(errors)"]
-    IR --> LINT["Semantic Linting<br>DIP101–DIP148<br>(warnings)"]
+    IR --> LINT["Semantic Linting<br>DIP101–DIP149<br>(warnings)"]
     VAL --> DIAG["Diagnostics"]
     LINT --> DIAG
 ```
@@ -248,7 +248,7 @@ lints (DIP103/DIP120/DIP121/DIP122), so one bad condition no longer masks the re
 
 ---
 
-## Semantic Lint Warnings (DIP101–DIP148)
+## Semantic Lint Warnings (DIP101–DIP149)
 
 ### DIP101: Node Only Reachable via Conditional Edges
 
@@ -1278,6 +1278,32 @@ field; a runtime enforces the truncation.
 
 ---
 
+### DIP149: Ambiguous routing
+
+**Severity**: Warning
+
+A node has two or more **unconditional** (no `when`) outgoing edges. Both are
+equally eligible, so which one fires is decided only by the routing cascade's
+[lexical tiebreak](edges.md#routing-priority) — alphabetical order of the target
+node ID. That is silent action-at-a-distance: renaming a target node can change
+which edge fires with no other change.
+
+```text
+warning[DIP149]: node "Route" has multiple unconditional outgoing edges; which one fires is decided only by the lexical tiebreak
+```
+
+**Trigger:** A node has 2+ outgoing edges with no condition. Restart back-edges
+(`restart: true` or the `loop` keyword) are excluded — they are a distinct
+re-execution channel, not a forward-routing competitor.
+
+**Fix:** Keep at most one unconditional edge per node as the default fallback;
+guard the others with a `when` condition, or remove the extra edge. A guarded
+edge plus a single unconditional fallback is the intended pattern and is **not**
+flagged. Conservative by design — duplicate same-variable/same-value guards are
+covered by [DIP103](#dip103-overlapping-or-contradictory-conditions) instead.
+
+---
+
 ## Running Validation
 
 ### Structural validation only
@@ -1294,7 +1320,7 @@ Runs DIP001–DIP010. Exit code 0 if all pass, 1 if any errors.
 dippin lint pipeline.dip
 ```
 
-Runs all DIP001–DIP010 errors and DIP101–DIP148 warnings. Exit code 1 only for errors; warnings alone exit 0.
+Runs all DIP001–DIP010 errors and DIP101–DIP149 warnings. Exit code 1 only for errors; warnings alone exit 0.
 
 ### JSON output for CI
 

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -383,7 +383,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP147) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP149) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |
@@ -512,6 +512,7 @@ The primary loop for authoring .dip files:
 | DIP145 | Graph budget default is negative | Use a positive cap, or omit the field / set `0` to mean no limit |
 | DIP146 | Referenced subgraph child restricts no agent's `tool_access` while a workflow on the path does (cross-file) | Set `tool_access` on the child's agents; native `dippin lint` resolves the child and supersedes DIP143 |
 | DIP147 | A `tool_access: none` agent `writes:` a context key that a downstream tool-bearing agent `reads:` (chain-attack / info-flow) | Confirm the restricted agent's input is trusted; if not, give the consumer `tool_access: none` too or insert a sanitizing step. Detection only — the runtime enforces |
+| DIP149 | A node has 2+ unconditional outgoing edges — which one fires is decided only by the lexical (alphabetical) tiebreak on target node ID | Keep at most one unconditional edge as the default fallback; guard the others with `when`. Restart/`loop` back-edges are exempt |
 
 ## Best Practices
 

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -152,6 +152,13 @@ func reachabilityExplanations() map[string]Explanation {
 			Fix:     "Add a `-> <node> when ctx.outcome = fail` edge, set fallback_target, add retry_target with max_retries, or declare a workflow-level on_failure.",
 			Example: "agent Implement\n  prompt: \"build it\"\nImplement -> Test  // DIP144: no route if Implement fails",
 		},
+		DIP149: {
+			Code:    DIP149,
+			Summary: "ambiguous routing: multiple unconditional outgoing edges",
+			Trigger: "A node has two or more unconditional (no `when`) outgoing edges, so which one fires is resolved only by the lexical tiebreak on target node IDs — renaming a target can silently change routing.",
+			Fix:     "Keep at most one unconditional edge per node as the default fallback; guard the others with a `when` condition, or remove the extra edge.",
+			Example: "agent Route\n  prompt: \"decide\"\nRoute -> A\nRoute -> B  // DIP149: A and B are both unconditional; the tiebreak alone picks one",
+		},
 	}
 }
 

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -5,7 +5,7 @@ import (
 	"github.com/2389-research/dippin-lang/simulate"
 )
 
-// Lint runs all semantic quality checks (DIP101–DIP148, except DIP146 — which
+// Lint runs all semantic quality checks (DIP101–DIP149, except DIP146 — which
 // the CLI's cross-file pass emits, not this function) on the workflow
 // and returns all diagnostics found. These are warnings, not errors —
 // the workflow can still execute, but the findings indicate likely bugs
@@ -78,6 +78,7 @@ func Lint(w *ir.Workflow) Result {
 	diags = append(diags, lintBudgetRanges(w)...)
 	diags = append(diags, lintChainAttack(w)...)
 	diags = append(diags, lintLastResponseTruncate(w)...)
+	diags = append(diags, lintAmbiguousRouting(w)...)
 
 	return Result{Diagnostics: diags}
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP148).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP149).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge
@@ -53,6 +53,7 @@ const (
 	DIP146 = "DIP146" // child subgraph re-grants tools the parent restricted (cross-file)
 	DIP147 = "DIP147" // restricted (tool_access:none) agent output flows into a tool-bearing agent (chain-attack / info-flow)
 	DIP148 = "DIP148" // last_response_truncate is negative
+	DIP149 = "DIP149" // ambiguous routing: 2+ unconditional outgoing edges resolved only by the lexical tiebreak
 )
 
 func init() {
@@ -105,4 +106,5 @@ func init() {
 	CodeDescription[DIP146] = "child subgraph re-grants tools the parent restricted (cross-file)"
 	CodeDescription[DIP147] = "restricted agent output flows into a tool-bearing agent (chain-attack)"
 	CodeDescription[DIP148] = "last_response_truncate is negative"
+	CodeDescription[DIP149] = "ambiguous routing: multiple unconditional outgoing edges"
 }

--- a/validator/lint_routing.go
+++ b/validator/lint_routing.go
@@ -1,0 +1,76 @@
+package validator
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// lintAmbiguousRouting checks DIP149: a node with two or more unconditional
+// (no `when`) outgoing forward edges. Such edges are equally eligible, so which
+// one fires is decided only by the cascade's lexical tiebreak on target node
+// IDs — renaming a target can silently change routing. The author should keep
+// at most one unconditional edge (the default fallback) and guard the rest.
+//
+// Conservative by design (favors false negatives):
+//   - Restart back-edges are excluded; they are a distinct re-execution channel,
+//     not a forward-routing competitor.
+//   - A guarded edge plus a single unconditional fallback is the intended
+//     pattern and is not flagged.
+//   - Duplicate same-variable/same-value guards are already covered by DIP103.
+//   - parallel / fan_in source nodes are excluded: their multiple unconditional
+//     outgoing edges are structural fan-out (synthesized by ir.EdgesFrom), all
+//     fired together rather than chosen by a tiebreak.
+//   - human source nodes are excluded: they route on the human's label choice,
+//     not the cascade tiebreak (see ir.OutcomeChannel's human-gate note).
+func lintAmbiguousRouting(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, n := range w.Nodes {
+		if isStructuralOrChoiceRouter(n.Kind) {
+			continue
+		}
+		if d, ok := checkAmbiguousRouting(n, w.EdgesFrom(n.ID)); ok {
+			diags = append(diags, d)
+		}
+	}
+	return diags
+}
+
+// isStructuralOrChoiceRouter reports whether a source node's outgoing edges are
+// resolved by something other than the cascade's unconditional-edge tiebreak:
+// parallel / fan_in fan-out (all edges fire) or a human choice gate (the human
+// picks). DIP149 does not apply to these.
+func isStructuralOrChoiceRouter(k ir.NodeKind) bool {
+	switch k {
+	case ir.NodeParallel, ir.NodeFanIn, ir.NodeHuman:
+		return true
+	}
+	return false
+}
+
+// checkAmbiguousRouting flags a node whose outgoing forward edges include two
+// or more unconditional ones.
+func checkAmbiguousRouting(n *ir.Node, edges []*ir.Edge) (Diagnostic, bool) {
+	if countUnconditionalForwardEdges(edges) < 2 {
+		return Diagnostic{}, false
+	}
+	return Diagnostic{
+		Code:     DIP149,
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("node %q has multiple unconditional outgoing edges; which one fires is decided only by the lexical tiebreak", n.ID),
+		Location: n.Source,
+		Help:     "keep at most one unconditional edge as the default fallback and guard the others with a `when` condition",
+	}, true
+}
+
+// countUnconditionalForwardEdges counts edges with no condition that are not
+// restart back-edges.
+func countUnconditionalForwardEdges(edges []*ir.Edge) int {
+	n := 0
+	for _, e := range edges {
+		if e.Condition == nil && !e.Restart {
+			n++
+		}
+	}
+	return n
+}

--- a/validator/lint_routing.go
+++ b/validator/lint_routing.go
@@ -18,11 +18,15 @@ import (
 //   - A guarded edge plus a single unconditional fallback is the intended
 //     pattern and is not flagged.
 //   - Duplicate same-variable/same-value guards are already covered by DIP103.
-//   - parallel / fan_in source nodes are excluded: their multiple unconditional
-//     outgoing edges are structural fan-out (synthesized by ir.EdgesFrom), all
-//     fired together rather than chosen by a tiebreak.
-//   - human source nodes are excluded: they route on the human's label choice,
-//     not the cascade tiebreak (see ir.OutcomeChannel's human-gate note).
+//   - parallel source nodes are excluded: their multiple unconditional outgoing
+//     edges are structural fan-out (synthesized by ir.EdgesFrom), all fired
+//     together rather than chosen by a tiebreak. (fan_in nodes are NOT excluded:
+//     ir.EdgesFrom synthesizes edges *into* a fan_in, never out of it, so a
+//     fan_in's own outgoing edges route by the ordinary cascade.)
+//   - human source nodes are excluded: a choice/yes_no gate routes on the
+//     human's label selection, not the cascade tiebreak (see ir.OutcomeChannel's
+//     human-gate note). This is conservative for non-choice modes (interview /
+//     freeform), which do route by the cascade — a deliberate false-negative.
 func lintAmbiguousRouting(w *ir.Workflow) []Diagnostic {
 	var diags []Diagnostic
 	for _, n := range w.Nodes {
@@ -38,11 +42,13 @@ func lintAmbiguousRouting(w *ir.Workflow) []Diagnostic {
 
 // isStructuralOrChoiceRouter reports whether a source node's outgoing edges are
 // resolved by something other than the cascade's unconditional-edge tiebreak:
-// parallel / fan_in fan-out (all edges fire) or a human choice gate (the human
-// picks). DIP149 does not apply to these.
+// parallel fan-out (all edges fire) or a human choice gate (the human picks).
+// DIP149 does not apply to these. fan_in is intentionally absent — its outgoing
+// edges route by the ordinary cascade (ir.EdgesFrom only synthesizes fan-out
+// edges for parallel nodes, never for fan_in).
 func isStructuralOrChoiceRouter(k ir.NodeKind) bool {
 	switch k {
-	case ir.NodeParallel, ir.NodeFanIn, ir.NodeHuman:
+	case ir.NodeParallel, ir.NodeHuman:
 		return true
 	}
 	return false

--- a/validator/lint_routing_test.go
+++ b/validator/lint_routing_test.go
@@ -1,0 +1,203 @@
+package validator
+
+import "testing"
+
+// TestLint_DIP149_TwoUnconditionalEdges: a node with two outgoing edges that
+// both have no condition is ambiguous — only the lexical tiebreak decides which
+// fires. DIP149 must warn.
+func TestLint_DIP149_TwoUnconditionalEdges(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: Done
+
+  agent A
+    prompt: "x"
+
+  agent B
+    prompt: "x"
+
+  agent C
+    prompt: "x"
+
+  agent Done
+    prompt: "x"
+
+  edges
+    A -> B
+    A -> C
+    B -> Done
+    C -> Done
+`
+	if !hasCode(lintSrc(t, src), DIP149) {
+		t.Errorf("expected DIP149 for two unconditional edges, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+// TestLint_DIP149_GuardedPlusSingleFallback: a guarded edge plus a single
+// unconditional fallback is the intended routing pattern. DIP149 must NOT warn.
+func TestLint_DIP149_GuardedPlusSingleFallback(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: Done
+
+  agent A
+    prompt: "x"
+
+  agent B
+    prompt: "x"
+
+  agent Done
+    prompt: "x"
+
+  edges
+    A -> B     when ctx.outcome = success
+    A -> Done
+    B -> Done
+`
+	if hasCode(lintSrc(t, src), DIP149) {
+		t.Errorf("DIP149 should not fire for a guarded edge plus single fallback, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+// TestLint_DIP149_SingleUnconditionalEdge: a node with exactly one outgoing
+// edge is never ambiguous. DIP149 must NOT warn.
+func TestLint_DIP149_SingleUnconditionalEdge(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: Done
+
+  agent A
+    prompt: "x"
+
+  agent Done
+    prompt: "x"
+
+  edges
+    A -> Done
+`
+	if hasCode(lintSrc(t, src), DIP149) {
+		t.Errorf("DIP149 should not fire for a single edge, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+// TestLint_DIP149_RestartBackEdgeNotCounted: an unconditional forward edge
+// alongside a restart back-edge is not a forward-routing ambiguity — the
+// restart edge is a distinct re-execution channel. DIP149 must NOT warn.
+func TestLint_DIP149_RestartBackEdgeNotCounted(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: Done
+
+  agent A
+    prompt: "x"
+
+  agent Done
+    prompt: "x"
+
+  edges
+    A -> Done
+    A -> A      restart: true
+`
+	if hasCode(lintSrc(t, src), DIP149) {
+		t.Errorf("DIP149 should not fire when the second edge is a restart back-edge, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+// TestLint_DIP149_ParallelFanOutNotFlagged: a parallel node's multiple
+// unconditional outgoing edges are structural fan-out (all targets run), not a
+// tiebreak-resolved choice. ir.EdgesFrom synthesizes them. DIP149 must NOT warn.
+func TestLint_DIP149_ParallelFanOutNotFlagged(t *testing.T) {
+	src := `workflow X
+  start: Fan
+  exit: Done
+
+  parallel Fan -> B, C
+
+  agent B
+    prompt: "x"
+
+  agent C
+    prompt: "x"
+
+  agent Done
+    prompt: "x"
+
+  edges
+    B -> Done
+    C -> Done
+`
+	if hasCode(lintSrc(t, src), DIP149) {
+		t.Errorf("DIP149 should not fire for a parallel fan-out node, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+// TestLint_DIP149_HumanChoiceGateNotFlagged: a human node (esp. mode: choice)
+// routes on the human's label selection, not the cascade tiebreak, so its
+// multiple unconditional outgoing edges are not ambiguous. DIP149 must NOT warn.
+func TestLint_DIP149_HumanChoiceGateNotFlagged(t *testing.T) {
+	src := `workflow X
+  start: Gate
+  exit: Done
+
+  human Gate
+    mode: choice
+    default: approve
+
+  agent B
+    prompt: "x"
+
+  agent C
+    prompt: "x"
+
+  agent Done
+    prompt: "x"
+
+  edges
+    Gate -> B
+    Gate -> C
+    B -> Done
+    C -> Done
+`
+	if hasCode(lintSrc(t, src), DIP149) {
+		t.Errorf("DIP149 should not fire for a human choice gate, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+// TestLint_DIP149_MessageNamesNode: the diagnostic must name the source node so
+// the author can find it, and carry a real source location.
+func TestLint_DIP149_MessageNamesNode(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: Done
+
+  agent A
+    prompt: "x"
+
+  agent B
+    prompt: "x"
+
+  agent C
+    prompt: "x"
+
+  agent Done
+    prompt: "x"
+
+  edges
+    A -> B
+    A -> C
+    B -> Done
+    C -> Done
+`
+	var found bool
+	for _, d := range lintSrc(t, src) {
+		if d.Code == DIP149 {
+			found = true
+			if d.Location.Line == 0 {
+				t.Errorf("DIP149 must carry a real source location, got Line=0")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected DIP149 diagnostic, got: %v", codes(lintSrc(t, src)))
+	}
+}

--- a/validator/lint_routing_test.go
+++ b/validator/lint_routing_test.go
@@ -163,6 +163,41 @@ func TestLint_DIP149_HumanChoiceGateNotFlagged(t *testing.T) {
 	}
 }
 
+// TestLint_DIP149_AmbiguousFanInFlagged: a fan_in's own outgoing edges route by
+// the ordinary cascade (ir.EdgesFrom synthesizes edges *into* a fan_in, never
+// out of it). Two unconditional outgoing edges from a fan_in are genuinely
+// ambiguous, so DIP149 MUST warn — fan_in is not a structural-router exemption.
+func TestLint_DIP149_AmbiguousFanInFlagged(t *testing.T) {
+	src := `workflow X
+  start: Fan
+  exit: Done
+
+  parallel Fan -> B, C
+
+  agent B
+    prompt: "x"
+
+  agent C
+    prompt: "x"
+
+  fan_in Join <- B, C
+
+  agent D
+    prompt: "x"
+
+  agent Done
+    prompt: "x"
+
+  edges
+    Join -> Done
+    Join -> D
+    D -> Done
+`
+	if !hasCode(lintSrc(t, src), DIP149) {
+		t.Errorf("expected DIP149 for a fan_in with two unconditional outgoing edges, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
 // TestLint_DIP149_MessageNamesNode: the diagnostic must name the source node so
 // the author can find it, and carry a real source location.
 func TestLint_DIP149_MessageNamesNode(t *testing.T) {


### PR DESCRIPTION
## Summary

Part of #127 (edge/routing syntax evolution), Phase 0. Adds **DIP149: ambiguous routing** — a Warning that fires when a node has two or more unconditional (no `when`) outgoing edges.

The routing cascade resolves ties between equally-eligible edges by the **alphabetical order of the target node ID** (tier 5, "Lexical"). That is silent action-at-a-distance: renaming a target node can change which edge fires with no other change. DIP149 makes that ambiguity visible so the author resolves it explicitly, and sets up the Phase 1 cascade-collapse where the lexical tier is removed.

## Detection (conservative — favors false negatives)

For each source node, count unconditional, **non-restart** outgoing edges; warn when there are 2+.

- **Restart / `loop` back-edges are excluded** — a distinct re-execution channel, not a forward-routing competitor.
- A guarded edge **+ a single unconditional fallback is the intended pattern** and is not flagged.
- Duplicate same-variable/same-value guards stay covered by **DIP103** (per the ticket: "or folds into DIP103").

## Acceptance criteria

- [x] Two unconditional edges from one node → warning
- [x] Duplicate guard (same var=value) → handled by DIP103
- [x] A guarded edge + single unconditional fallback → **no** warning
- [x] Parity test passes (`TestExplanationsCoverAllCodes`/`NoExtra`)
- [x] Surfaces in lint / check / watch / doctor (all call `validator.Lint`)

## Edit sites

- `validator/lint_routing.go` (new) + registered in `validator/lint.go`
- `validator/lint_codes.go` (const + `CodeDescription`), `validator/explanations.go` (full `Explanations[DIP149]`)
- `validator/lint_routing_test.go` (new, parser-driven, 5 tests)
- `docs/edges.md`, `docs/validation.md`, `docs/llm-reference.md`, `site/static/skill.md` + range strings; spec regenerated (`cmd/dippin/generated-spec.md`)

## Verification

`scripts/pre-commit` passes end-to-end (build, vet, golangci-lint 0 issues, gofmt, full `go test ./...`, releasecheck, cyclomatic ≤5, cognitive ≤7, examples validate).

Closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783887282&installation_id=131176874&pr_number=144&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F144&signature=569aabad0ebfc643f62f241c104545f5dfc4130361fde691749f46a2a6b2dec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->