### PR TITLE
fix(validator): scope extra-models out of the global registry (#105)

### DIFF
--- a/cmd/dippin/cmd_doctor.go
+++ b/cmd/dippin/cmd_doctor.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/2389-research/dippin-lang/cost"
 	"github.com/2389-research/dippin-lang/doctor"
-	"github.com/2389-research/dippin-lang/validator"
 )
 
 // CmdDoctor produces a health report card for a workflow.
@@ -14,10 +13,6 @@ func (c *CLI) CmdDoctor(args []string) ExitCode {
 	path, extraModels, code := parseLintArgs("doctor", "usage: dippin doctor [--extra-models spec] <file>", args, c)
 	if code != ExitCode(-1) {
 		return code
-	}
-
-	if extraModels != "" {
-		validator.RegisterExtraModels(extraModels)
 	}
 
 	w, err := loadWorkflow(path)
@@ -33,7 +28,7 @@ func (c *CLI) CmdDoctor(args []string) ExitCode {
 	// effect is minor (a DIP143 vs DIP146 hint is counted the same; only a
 	// fully-restricted child differs by one hint). `dippin lint`/`check`/`watch`
 	// carry the precise DIP146 behavior. (#89)
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.DiagnoseWithOptions(w, cost.DefaultPricing(), lintOptions(extraModels))
 	return c.renderDoctorReport(report)
 }
 

--- a/cmd/dippin/cmd_validate.go
+++ b/cmd/dippin/cmd_validate.go
@@ -48,16 +48,21 @@ func parseLintArgs(name, usage string, args []string, c *CLI) (path, extraModels
 	return fs.Arg(0), *em, ExitCode(-1)
 }
 
+// lintOptions builds scoped lint options from an --extra-models spec. An empty
+// spec yields default options (nil extra catalog).
+func lintOptions(extraModels string) validator.Options {
+	if extraModels == "" {
+		return validator.Options{}
+	}
+	return validator.Options{ExtraModels: validator.ParseExtraModels(extraModels)}
+}
+
 // CmdLint runs both structural validation and semantic linting.
 // Errors cause exit 1; warnings alone exit 0.
 func (c *CLI) CmdLint(args []string) ExitCode {
 	path, extraModels, code := parseLintArgs("lint", "usage: dippin lint [--extra-models spec] <file>", args, c)
 	if code != ExitCode(-1) {
 		return code
-	}
-
-	if extraModels != "" {
-		validator.RegisterExtraModels(extraModels)
 	}
 
 	w, err := loadWorkflow(path)
@@ -67,8 +72,9 @@ func (c *CLI) CmdLint(args []string) ExitCode {
 	}
 
 	// Run both validation and linting per spec — lint includes all checks.
+	// Extra models are passed as scoped options, never mutating global state.
 	valRes := validator.Validate(w)
-	lintRes := validator.Lint(w)
+	lintRes := validator.LintWithOptions(w, lintOptions(extraModels))
 
 	// Merge all diagnostics, then apply the native cross-file tool_access pass
 	// (DIP146) — it supersedes DIP143 for boundaries whose child it resolved.

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -51,10 +51,18 @@ type Suggestion struct {
 	Message  string `json:"message"`
 }
 
-// Diagnose produces a health Report for the given workflow.
+// Diagnose produces a health Report for the given workflow using default lint
+// options.
 func Diagnose(w *ir.Workflow, pricing cost.PricingTable) *Report {
+	return DiagnoseWithOptions(w, pricing, validator.Options{})
+}
+
+// DiagnoseWithOptions produces a health Report, threading per-invocation lint
+// options (e.g. a scoped extra-models catalog) into the lint pass so doctor's
+// DIP108 summary matches `dippin lint --extra-models`.
+func DiagnoseWithOptions(w *ir.Workflow, pricing cost.PricingTable, opts validator.Options) *Report {
 	valResult := validator.Validate(w)
-	lintResult := validator.Lint(w)
+	lintResult := validator.LintWithOptions(w, opts)
 	covReport := coverage.Analyze(w)
 	costReport := cost.Analyze(w, pricing)
 

--- a/site/content/blog/whats-new-v027.md
+++ b/site/content/blog/whats-new-v027.md
@@ -93,13 +93,14 @@ One quieter change worth noting. Cohere's documentation now lists `command-r-08-
 
 ## The escape hatch
 
-If you need a model we don't catalog yet — provider-specific betas, fine-tuned variants, a hosted gateway with custom IDs — register them at startup:
+If you need a model we don't catalog yet — provider-specific betas, fine-tuned variants, a hosted gateway with custom IDs — pass them per lint run via scoped options (the CLI exposes this as `--extra-models`):
 
 ```go
-validator.RegisterExtraModels("openai:my-custom-model;anthropic:claude-internal-2026")
+extra := validator.ParseExtraModels("openai:my-custom-model;anthropic:claude-internal-2026")
+result := validator.LintWithOptions(w, validator.Options{ExtraModels: extra})
 ```
 
-Unknown `provider:model` combos produce a DIP108 warning, not a hard error, so workflows still run — but adding the ID makes the warning go away and gets you accurate cost estimation.
+The catalog is scoped to that single call — nothing mutates package-level state, so extra models never leak across lint runs. Unknown `provider:model` combos produce a DIP108 warning, not a hard error, so workflows still run — but adding the ID makes the warning go away and gets you accurate cost estimation.
 
 ## Methodology
 

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -16,6 +16,21 @@ import (
 //	structureResult := validator.Validate(w)
 //	lintResult := validator.Lint(w)
 func Lint(w *ir.Workflow) Result {
+	return LintWithOptions(w, Options{})
+}
+
+// Options carries per-invocation lint configuration. It is passed by value so
+// each call is fully scoped — nothing here mutates package-level state, which
+// keeps lint runs from leaking into one another (e.g. across validate/doctor/lint).
+type Options struct {
+	// ExtraModels extends the known model catalog for the DIP108 check only.
+	// nil is treated as empty.
+	ExtraModels ExtraModels
+}
+
+// LintWithOptions runs all semantic quality checks like Lint, but with the given
+// per-invocation Options (currently a scoped extra-models catalog for DIP108).
+func LintWithOptions(w *ir.Workflow, opts Options) Result {
 	// Ensure condition ASTs are populated — the AST-dependent lint checks
 	// (DIP103/120/121/122) read edge Condition.Parsed.
 	//
@@ -42,7 +57,7 @@ func Lint(w *ir.Workflow) Result {
 	diags = append(diags, lintSuccessPath(w)...)
 	diags = append(diags, lintUndefinedVariables(w)...)
 	diags = append(diags, lintUnusedWrites(w)...)
-	diags = append(diags, lintModelProvider(w)...)
+	diags = append(diags, lintModelProvider(w, opts.ExtraModels)...)
 	diags = append(diags, lintNamespaceCollisions(w)...)
 	diags = append(diags, lintEmptyPrompts(w)...)
 	diags = append(diags, lintToolTimeout(w)...)

--- a/validator/lint_model.go
+++ b/validator/lint_model.go
@@ -158,22 +158,29 @@ func grokModels() map[string]bool {
 	}
 }
 
-// RegisterExtraModels extends the known model catalog with user-provided entries.
-// Format: "provider:model1,model2;provider2:model3"
-func RegisterExtraModels(spec string) {
+// ExtraModels is a user-supplied catalog of provider→model sets that extends the
+// known model catalog for a single lint invocation. It is passed via Options and
+// never mutates the package-level base catalog, so it cannot leak across calls.
+type ExtraModels map[string]map[string]bool
+
+// ParseExtraModels parses user-provided entries into a scoped ExtraModels catalog.
+// Format: "provider:model1,model2;provider2:model3". Malformed or empty entries
+// are silently skipped. The result is always safe to pass to LintWithOptions.
+func ParseExtraModels(spec string) ExtraModels {
+	extra := ExtraModels{}
 	for _, entry := range strings.Split(spec, ";") {
 		entry = strings.TrimSpace(entry)
 		if entry == "" {
 			continue
 		}
-		registerOneProvider(entry)
+		extra.addEntry(entry)
 	}
+	return extra
 }
 
-// registerOneProvider parses a single "provider:model1,model2" entry and adds
-// the models to the known catalog. Silently ignores entries with empty provider
-// or no valid model names.
-func registerOneProvider(entry string) {
+// addEntry parses a single "provider:model1,model2" entry into the catalog.
+// Silently ignores entries with empty provider or no valid model names.
+func (e ExtraModels) addEntry(entry string) {
 	parts := strings.SplitN(entry, ":", 2)
 	if len(parts) != 2 {
 		return
@@ -186,16 +193,16 @@ func registerOneProvider(entry string) {
 	if len(models) == 0 {
 		return
 	}
-	addModelsToProvider(provider, models)
+	e.addModels(provider, models)
 }
 
-// addModelsToProvider registers models under the given provider name.
-func addModelsToProvider(provider string, models []string) {
-	if knownModelProviders[provider] == nil {
-		knownModelProviders[provider] = make(map[string]bool)
+// addModels registers models under the given provider name in the catalog.
+func (e ExtraModels) addModels(provider string, models []string) {
+	if e[provider] == nil {
+		e[provider] = make(map[string]bool)
 	}
 	for _, m := range models {
-		knownModelProviders[provider][m] = true
+		e[provider][m] = true
 	}
 }
 
@@ -213,17 +220,17 @@ func parseModelNames(raw string) []string {
 }
 
 // lintModelProvider checks DIP108: model/provider combinations should be
-// in the known catalog. Unknown combinations may indicate typos.
-func lintModelProvider(w *ir.Workflow) []Diagnostic {
+// in the known catalog (base ∪ extra). Unknown combinations may indicate typos.
+func lintModelProvider(w *ir.Workflow, extra ExtraModels) []Diagnostic {
 	var diags []Diagnostic
 	for _, n := range w.Nodes {
-		diags = append(diags, checkNodeModelProvider(w, n)...)
+		diags = append(diags, checkNodeModelProvider(w, n, extra)...)
 	}
 	return diags
 }
 
 // checkNodeModelProvider validates the model/provider for a single node.
-func checkNodeModelProvider(w *ir.Workflow, n *ir.Node) []Diagnostic {
+func checkNodeModelProvider(w *ir.Workflow, n *ir.Node, extra ExtraModels) []Diagnostic {
 	cfg, ok := n.Config.(ir.AgentConfig)
 	if !ok {
 		return nil
@@ -232,7 +239,7 @@ func checkNodeModelProvider(w *ir.Workflow, n *ir.Node) []Diagnostic {
 	if model == "" || provider == "" {
 		return nil
 	}
-	return validateModelProvider(n, model, provider)
+	return validateModelProvider(n, model, provider, extra)
 }
 
 // resolveModelProvider resolves model and provider using node config and workflow defaults.
@@ -248,10 +255,10 @@ func resolveModelProvider(cfg ir.AgentConfig, w *ir.Workflow) (model, provider s
 	return
 }
 
-// validateModelProvider checks if a model/provider combination is known.
-func validateModelProvider(n *ir.Node, model, provider string) []Diagnostic {
-	providerModels, providerKnown := knownModelProviders[provider]
-	if !providerKnown {
+// validateModelProvider checks if a model/provider combination is known,
+// consulting the base catalog plus the scoped extra catalog.
+func validateModelProvider(n *ir.Node, model, provider string, extra ExtraModels) []Diagnostic {
+	if !providerKnown(provider, extra) {
 		return []Diagnostic{{
 			Code:     DIP108,
 			Severity: SeverityWarning,
@@ -260,7 +267,7 @@ func validateModelProvider(n *ir.Node, model, provider string) []Diagnostic {
 			Help:     fmt.Sprintf("known providers: %s", knownProviderList()),
 		}}
 	}
-	if !providerModels[model] {
+	if !modelKnown(provider, model, extra) {
 		return []Diagnostic{{
 			Code:     DIP108,
 			Severity: SeverityWarning,
@@ -270,6 +277,22 @@ func validateModelProvider(n *ir.Node, model, provider string) []Diagnostic {
 		}}
 	}
 	return nil
+}
+
+// providerKnown reports whether the provider appears in the base catalog or the
+// scoped extra catalog.
+func providerKnown(provider string, extra ExtraModels) bool {
+	if _, ok := knownModelProviders[provider]; ok {
+		return true
+	}
+	_, ok := extra[provider]
+	return ok
+}
+
+// modelKnown reports whether the model is registered for the provider in either
+// the base catalog or the scoped extra catalog.
+func modelKnown(provider, model string, extra ExtraModels) bool {
+	return knownModelProviders[provider][model] || extra[provider][model]
 }
 
 // knownProviderList returns a sorted comma-separated list of known providers.

--- a/validator/lint_model.go
+++ b/validator/lint_model.go
@@ -264,7 +264,7 @@ func validateModelProvider(n *ir.Node, model, provider string, extra ExtraModels
 			Severity: SeverityWarning,
 			Message:  fmt.Sprintf("node %q uses unknown provider %q", n.ID, provider),
 			Location: n.Source,
-			Help:     fmt.Sprintf("known providers: %s", knownProviderList()),
+			Help:     fmt.Sprintf("known providers: %s", knownProviderList(extra)),
 		}}
 	}
 	if !modelKnown(provider, model, extra) {
@@ -273,7 +273,7 @@ func validateModelProvider(n *ir.Node, model, provider string, extra ExtraModels
 			Severity: SeverityWarning,
 			Message:  fmt.Sprintf("node %q uses unknown model %q for provider %q", n.ID, model, provider),
 			Location: n.Source,
-			Help:     fmt.Sprintf("known models for %s: %s", provider, knownModelList(provider)),
+			Help:     fmt.Sprintf("known models for %s: %s", provider, knownModelList(provider, extra)),
 		}}
 	}
 	return nil
@@ -295,22 +295,37 @@ func modelKnown(provider, model string, extra ExtraModels) bool {
 	return knownModelProviders[provider][model] || extra[provider][model]
 }
 
-// knownProviderList returns a sorted comma-separated list of known providers.
-func knownProviderList() string {
-	providers := make([]string, 0, len(knownModelProviders))
+// knownProviderList returns a sorted comma-separated list of known providers,
+// merging the base catalog with the scoped extra catalog.
+func knownProviderList(extra ExtraModels) string {
+	seen := map[string]bool{}
 	for p := range knownModelProviders {
-		providers = append(providers, p)
+		seen[p] = true
 	}
-	sort.Strings(providers)
-	return strings.Join(providers, ", ")
+	for p := range extra {
+		seen[p] = true
+	}
+	return sortedJoin(seen)
 }
 
-// knownModelList returns a sorted comma-separated list of known models for a provider.
-func knownModelList(provider string) string {
-	models := knownModelProviders[provider]
-	list := make([]string, 0, len(models))
-	for m := range models {
-		list = append(list, m)
+// knownModelList returns a sorted comma-separated list of known models for a
+// provider, merging the base catalog with the scoped extra catalog.
+func knownModelList(provider string, extra ExtraModels) string {
+	seen := map[string]bool{}
+	for m := range knownModelProviders[provider] {
+		seen[m] = true
+	}
+	for m := range extra[provider] {
+		seen[m] = true
+	}
+	return sortedJoin(seen)
+}
+
+// sortedJoin returns the keys of seen as a sorted, comma-separated string.
+func sortedJoin(seen map[string]bool) string {
+	list := make([]string, 0, len(seen))
+	for k := range seen {
+		list = append(list, k)
 	}
 	sort.Strings(list)
 	return strings.Join(list, ", ")

--- a/validator/lint_test.go
+++ b/validator/lint_test.go
@@ -1316,14 +1316,9 @@ func TestLintDIP108NoModelOrProvider(t *testing.T) {
 	}
 }
 
-func TestRegisterExtraModels(t *testing.T) {
+func TestExtraModels_ScopedSuppressesDIP108(t *testing.T) {
 	const provider = "custom-corp"
 	const model = "custom-llm-v1"
-
-	// Cleanup: remove the test provider after the test.
-	t.Cleanup(func() {
-		delete(knownModelProviders, provider)
-	})
 
 	w := &ir.Workflow{
 		Name:  "custom_model",
@@ -1338,56 +1333,64 @@ func TestRegisterExtraModels(t *testing.T) {
 		},
 	}
 
-	// Before registration, DIP108 should fire.
-	result := Lint(w)
-	hasDIP108 := false
-	for _, d := range result.Diagnostics {
-		if d.Code == DIP108 {
-			hasDIP108 = true
-			break
-		}
-	}
-	if !hasDIP108 {
-		t.Error("expected DIP108 before RegisterExtraModels, but got none")
+	// Without extra models, DIP108 should fire.
+	if !hasCode(Lint(w).Diagnostics, DIP108) {
+		t.Error("expected DIP108 without extra models, but got none")
 	}
 
-	// Register the custom model.
-	RegisterExtraModels(provider + ":" + model)
-
-	// After registration, DIP108 should not fire.
-	result2 := Lint(w)
-	for _, d := range result2.Diagnostics {
-		if d.Code == DIP108 {
-			t.Errorf("unexpected DIP108 after RegisterExtraModels: %s", d.Message)
-		}
+	// With the custom model passed via scoped options, DIP108 should not fire.
+	opts := Options{ExtraModels: ParseExtraModels(provider + ":" + model)}
+	if hasCode(LintWithOptions(w, opts).Diagnostics, DIP108) {
+		t.Error("unexpected DIP108 with scoped extra models")
 	}
 }
 
-func TestRegisterExtraModels_MultipleProviders(t *testing.T) {
-	t.Cleanup(func() {
-		delete(knownModelProviders, "corp-a")
-		delete(knownModelProviders, "corp-b")
-	})
+func TestExtraModels_DoesNotLeakAcrossCalls(t *testing.T) {
+	const provider = "custom-corp"
+	const model = "custom-llm-v1"
 
-	RegisterExtraModels("corp-a:model-x,model-y;corp-b:model-z")
+	w := &ir.Workflow{
+		Name:  "custom_model",
+		Start: "A",
+		Exit:  "A",
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
+				Prompt:   "hello",
+				Model:    model,
+				Provider: provider,
+			}},
+		},
+	}
 
-	if !knownModelProviders["corp-a"]["model-x"] {
-		t.Error("expected corp-a:model-x to be registered")
-	}
-	if !knownModelProviders["corp-a"]["model-y"] {
-		t.Error("expected corp-a:model-y to be registered")
-	}
-	if !knownModelProviders["corp-b"]["model-z"] {
-		t.Error("expected corp-b:model-z to be registered")
+	// A scoped call registering the custom model must not leak into a later
+	// default Lint call — the registry stays non-global.
+	_ = LintWithOptions(w, Options{ExtraModels: ParseExtraModels(provider + ":" + model)})
+	if !hasCode(Lint(w).Diagnostics, DIP108) {
+		t.Error("expected DIP108 after a scoped call — extra models leaked into global state")
 	}
 }
 
-func TestRegisterExtraModels_EmptyAndMalformed(t *testing.T) {
-	// Should not panic or register garbage.
-	RegisterExtraModels("")
-	RegisterExtraModels(";;")
-	RegisterExtraModels("no-colon-here")
-	RegisterExtraModels("provider-only:")
+func TestParseExtraModels_MultipleProviders(t *testing.T) {
+	extra := ParseExtraModels("corp-a:model-x,model-y;corp-b:model-z")
+
+	if !extra["corp-a"]["model-x"] {
+		t.Error("expected corp-a:model-x to be parsed")
+	}
+	if !extra["corp-a"]["model-y"] {
+		t.Error("expected corp-a:model-y to be parsed")
+	}
+	if !extra["corp-b"]["model-z"] {
+		t.Error("expected corp-b:model-z to be parsed")
+	}
+}
+
+func TestParseExtraModels_EmptyAndMalformed(t *testing.T) {
+	// Should not panic or produce garbage entries.
+	for _, spec := range []string{"", ";;", "no-colon-here", "provider-only:"} {
+		if got := ParseExtraModels(spec); len(got) != 0 {
+			t.Errorf("ParseExtraModels(%q) = %v, want empty", spec, got)
+		}
+	}
 }
 
 func TestLintDIP112CycleDoesNotPanic(t *testing.T) {

--- a/validator/lint_test.go
+++ b/validator/lint_test.go
@@ -1316,11 +1316,10 @@ func TestLintDIP108NoModelOrProvider(t *testing.T) {
 	}
 }
 
-func TestExtraModels_ScopedSuppressesDIP108(t *testing.T) {
-	const provider = "custom-corp"
-	const model = "custom-llm-v1"
-
-	w := &ir.Workflow{
+// customModelWorkflow builds a single-agent workflow whose node uses the given
+// provider/model — the shared fixture for the scoped extra-models tests.
+func customModelWorkflow(provider, model string) *ir.Workflow {
+	return &ir.Workflow{
 		Name:  "custom_model",
 		Start: "A",
 		Exit:  "A",
@@ -1332,6 +1331,13 @@ func TestExtraModels_ScopedSuppressesDIP108(t *testing.T) {
 			}},
 		},
 	}
+}
+
+func TestExtraModels_ScopedSuppressesDIP108(t *testing.T) {
+	const provider = "custom-corp"
+	const model = "custom-llm-v1"
+
+	w := customModelWorkflow(provider, model)
 
 	// Without extra models, DIP108 should fire.
 	if !hasCode(Lint(w).Diagnostics, DIP108) {
@@ -1345,22 +1351,35 @@ func TestExtraModels_ScopedSuppressesDIP108(t *testing.T) {
 	}
 }
 
+func TestExtraModels_HelpListsScopedModels(t *testing.T) {
+	const provider = "custom-corp"
+	const goodModel = "custom-llm-v1"
+	const typoModel = "custom-llm-v2" // mistyped: not registered
+
+	// Provider is registered via extra-models with goodModel, but the node
+	// mistypes the model. The DIP108 help text must list the scoped model.
+	w := customModelWorkflow(provider, typoModel)
+	opts := Options{ExtraModels: ParseExtraModels(provider + ":" + goodModel)}
+
+	var help string
+	for _, d := range LintWithOptions(w, opts).Diagnostics {
+		if d.Code == DIP108 {
+			help = d.Help
+		}
+	}
+	if help == "" {
+		t.Fatal("expected a DIP108 diagnostic for the mistyped model")
+	}
+	if !strings.Contains(help, goodModel) {
+		t.Errorf("DIP108 help %q should list scoped model %q", help, goodModel)
+	}
+}
+
 func TestExtraModels_DoesNotLeakAcrossCalls(t *testing.T) {
 	const provider = "custom-corp"
 	const model = "custom-llm-v1"
 
-	w := &ir.Workflow{
-		Name:  "custom_model",
-		Start: "A",
-		Exit:  "A",
-		Nodes: []*ir.Node{
-			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{
-				Prompt:   "hello",
-				Model:    model,
-				Provider: provider,
-			}},
-		},
-	}
+	w := customModelWorkflow(provider, model)
 
 	// A scoped call registering the custom model must not leak into a later
 	// default Lint call — the registry stays non-global.


### PR DESCRIPTION
## Summary

Fixes #105. `validator.RegisterExtraModels` mutated a package-level model catalog, so `--extra-models` from one `lint`/`doctor` run leaked into every later validate/doctor/lint call in the same process. That made `TestCmdLint_ExtraModels_SuppressesDIP108` non-idempotent — green under `-count=1` (CI), red under `-count>=2`.

## Change

- Replace the mutating `RegisterExtraModels(spec)` with a pure `ParseExtraModels(spec) ExtraModels` and thread the result through a new `validator.Options` + `LintWithOptions` (and `doctor.DiagnoseWithOptions`). The DIP108 check now consults base ∪ scoped-extra; the package-level `knownModelProviders` catalog is never written.
- `Lint(w)` / `Diagnose(w, pricing)` keep their signatures and delegate with empty options, so `check`/`watch`/`wasm`/`simulate` callers and the 16 doctor test callers are untouched. CLI `lint`/`doctor` build scoped options via a shared `lintOptions` helper.
- Rewrote the three `validator` `TestRegisterExtraModels*` tests against the pure/scoped API and added a no-leak regression test.

## Verification

- `go test ./... -count=2 -race` — green (the original repro is fixed).
- `scripts/pre-commit` — all checks passed (build, vet, golangci-lint, gofmt, tests, releasecheck, cyclomatic ≤5, cognitive ≤7, example validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783887387&installation_id=131176874&pr_number=145&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F145&signature=319e25fb5a3a3b58b5fc28d0143612f965cc9b9c1e8e504ac4e98e47f992f6e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->