### PR TITLE
feat(parser): single-quoted strings in edge attrs and when conditions (Closes #120)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -298,7 +298,7 @@ The lexer (`lexer.go`) converts source text into a flat token stream. Key featur
 
 - **Indentation tracking**: Maintains an indent stack. When indentation increases, emits `TokenIndent`. When it decreases, emits `TokenOutdent` (potentially multiple if skipping levels).
 - **Token types**: `Keyword`, `Identifier`, `Operator`, `Literal`, `Colon`, `Comma`, `Arrow` (`->`), `BackArrow` (`<-`), `LParen`, `RParen`, `Newline`, `EOF`.
-- **String handling**: The token literal (`TokenLiteral`, used in the `edges` section for edge attributes and `when` conditions) is double-quoted with `\"` and `\\` escapes. Single-line **field values** are taken via raw extraction (`RawValueText` → `unquoteRaw`) and additionally accept single-quoted (YAML-style) strings — literal apart from the `''` → `'` escape; the comment stripper keeps a `#` inside quotes and only drops a comment after the closing quote.
+- **String handling**: The token literal (`TokenLiteral`, used in the `edges` section for edge attributes and `when` conditions) accepts both double-quoted strings (`\"` and `\\` escapes) and single-quoted (YAML-style) strings — literal apart from the `''` → `'` escape. The token-stream comment stripper (`findUnquotedHash`) keeps a `#` inside either quote; a single quote is treated as a string delimiter only at a token-start boundary, so a prose apostrophe (e.g. in `goal: it's great # note`) does not protect a trailing comment. Single-line **field values** are taken via raw extraction (`RawValueText` → `unquoteRaw`) and accept the same two string forms.
 - **Comments**: `#` to end-of-line, stripped during lexing.
 
 ### Stage 2: Parser

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -281,11 +281,10 @@ convenient for regular expressions and other values full of backslashes:
 A trailing `# comment` after a closing quote is stripped, so a `#` *inside*
 quotes is kept verbatim (`marker_grep: '^a#b$' # note` stores `^a#b$`).
 
-> **Scope:** single quotes are supported for node and workflow **field values**
-> (the `key: value` form, e.g. `model:`, `marker_grep:`, node `label:`, `goal:`).
-> Edge-attribute positions in the `edges` section — an edge's `label:` /
-> `weight:` / `restart:` and `when` conditions — are read from the token stream,
-> which currently recognizes **double-quoted** strings only. Use `"..."` there.
+Single quotes work everywhere a string is accepted, including the token-stream
+positions in the `edges` section — an edge's `label:` and `when` conditions
+(e.g. `A -> B when ctx.reason = 'gave up' label: 'try again'`). As with field
+values, a single-quoted edge value normalizes to double-quoted output on `fmt`.
 
 ---
 

--- a/editors/tree-sitter-dippin/test/corpus/basic.txt
+++ b/editors/tree-sitter-dippin/test/corpus/basic.txt
@@ -445,3 +445,51 @@ workflow Gate
           (node_field (field_name (identifier)) (field_value (string)))))
       (edges_section
         (edge_entry (identifier) (identifier))))))
+
+================================================================================
+Single-quoted edge label and condition
+================================================================================
+
+workflow SQEdge
+  start: A
+  exit: B
+
+  agent A
+    prompt: go
+
+  agent B
+    prompt: stop
+
+  edges
+    A -> B  when ctx.reason = 'gave up'  label: 'try again'
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (workflow_decl
+    (identifier)
+    (workflow_body
+      (workflow_field (field_value (raw_inline)))
+      (workflow_field (field_value (raw_inline)))
+      (node_decl
+        (agent_node
+          (identifier)
+          (node_field (field_name (identifier)) (field_value (raw_inline)))))
+      (node_decl
+        (agent_node
+          (identifier)
+          (node_field (field_name (identifier)) (field_value (raw_inline)))))
+      (edges_section
+        (edge_entry
+          (identifier)
+          (identifier)
+          (edge_attr
+            (condition
+              (or_expr
+                (and_expr
+                  (compare_expr
+                    (operand (variable (identifier) (identifier)))
+                    (compare_op)
+                    (operand (string)))))))
+          (edge_attr
+            (field_value (string))))))))

--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -448,6 +448,53 @@ func TestFormatLoopRoundtrip(t *testing.T) {
 	}
 }
 
+// TestFormatSingleQuotedEdgeRoundtrip: single-quoted edge `label:` and `when`
+// condition values (with spaces and an internal `#`) parse to their literal
+// content, normalize to double-quoted output on format, and survive a
+// parse -> format -> parse round-trip with the formatter staying idempotent (#120).
+func TestFormatSingleQuotedEdgeRoundtrip(t *testing.T) {
+	input := `workflow SQRT
+  start: A
+  exit: B
+
+  agent A
+    prompt: "Do A."
+
+  agent B
+    prompt: "Do B."
+
+  edges
+    A -> B  when ctx.reason = 'gave up #1'  label: 'try again'
+`
+	w1, err := parser.NewParser(input, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("first parse failed: %v", err)
+	}
+	if got := w1.Edges[0].Label; got != "try again" {
+		t.Fatalf("label = %q, want %q", got, "try again")
+	}
+	if got := w1.Edges[0].Condition.Raw; got != `ctx.reason = "gave up #1"` {
+		t.Fatalf("condition Raw = %q, want %q", got, `ctx.reason = "gave up #1"`)
+	}
+
+	formatted := Format(w1)
+	assertContains(t, formatted, `label: "try again"`)
+	assertContains(t, formatted, `ctx.reason = "gave up #1"`)
+
+	w2, err := parser.NewParser(formatted, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("second parse failed: %v\nformatted:\n%s", err, formatted)
+	}
+	if w2.Edges[0].Label != "try again" || w2.Edges[0].Condition.Raw != `ctx.reason = "gave up #1"` {
+		t.Errorf("values not preserved: label=%q raw=%q", w2.Edges[0].Label, w2.Edges[0].Condition.Raw)
+	}
+
+	reformatted := Format(w2)
+	if formatted != reformatted {
+		t.Errorf("formatter not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, reformatted)
+	}
+}
+
 // TestFormatLoopValueQuotedFromParsed guards the round-trip hazard: a condition
 // whose literal value is the reserved flag word `loop` (e.g. `when ctx.x =
 // "loop"`) loses its quotes in the parsed AST (CondCompare.Value == "loop"), which

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -105,19 +105,90 @@ func isBlankOrComment(line string) bool {
 	return len(trimmed) == 0 || trimmed[0] == '#'
 }
 
-// findUnquotedHash scans a string for a # character that is not inside double quotes.
+// findUnquotedHash scans a token-stream line for a # that starts a trailing
+// comment — one not inside a quoted string. Double quotes toggle on every `"`.
+// A single quote is a string delimiter only at a token-start boundary (see
+// opensSingleQuote); a `'` mid-word is a prose apostrophe and is ignored, so a
+// value like `goal: it's great # note` still strips its comment. Inside a
+// single-quoted string a doubled single quote is a literal escape, not a close.
 // Returns the index of the # or -1 if not found.
 func findUnquotedHash(s string) int {
-	inQuote := false
+	var quote byte // 0 = none, '"' or '\'' = inside that quote
 	for i := 0; i < len(s); i++ {
-		if s[i] == '"' {
-			inQuote = !inQuote
+		if quote != 0 {
+			i, quote = advanceInQuote(s, i, quote)
+			continue
 		}
-		if !inQuote && s[i] == '#' {
+		if s[i] == '#' {
 			return i
 		}
+		quote = quoteOpenedAt(s, i)
 	}
 	return -1
+}
+
+// quoteOpenedAt reports which quote (if any) the character at index i opens when
+// we are outside any quote: `"` always opens; `'` opens only at a token-start
+// boundary (see opensSingleQuote) so a prose apostrophe is not a delimiter.
+// Returns 0 when no quote is opened.
+func quoteOpenedAt(s string, i int) byte {
+	switch {
+	case s[i] == '"':
+		return '"'
+	case s[i] == '\'' && opensSingleQuote(s, i):
+		return '\''
+	default:
+		return 0
+	}
+}
+
+// advanceInQuote consumes one character at index i while inside the given quote,
+// returning the index of the last byte consumed and the new quote state (0 when
+// the quote closes). A `"`-string closes on the next `"`; a `'`-string closes on
+// a lone `'` but treats a doubled single quote as a literal escape that stays inside.
+func advanceInQuote(s string, i int, quote byte) (int, byte) {
+	if quote == '"' {
+		return advanceInDoubleQuote(s, i)
+	}
+	return advanceInSingleQuote(s, i)
+}
+
+// advanceInDoubleQuote closes a `"`-string on a `"`, otherwise stays inside.
+func advanceInDoubleQuote(s string, i int) (int, byte) {
+	if s[i] == '"' {
+		return i, 0
+	}
+	return i, '"'
+}
+
+// advanceInSingleQuote closes a `'`-string on a lone `'`, but treats a doubled
+// single quote as a literal escape that stays inside.
+func advanceInSingleQuote(s string, i int) (int, byte) {
+	if s[i] != '\'' {
+		return i, '\''
+	}
+	if i+1 < len(s) && s[i+1] == '\'' {
+		return i + 1, '\'' // doubled '' escape: skip both, stay inside
+	}
+	return i, 0 // closing quote
+}
+
+// opensSingleQuote reports whether the `'` at index i begins a single-quoted
+// token rather than being a prose apostrophe. It opens a token only at a
+// token-start boundary: start of content, or right after whitespace or a token
+// delimiter (`:`, `=`, `(`, `,`, or the `>` of `->`). A `'` after a word
+// character (e.g. the apostrophe in `it's`) is prose; a prose value's
+// apostrophe is always mid-word, never glued to a delimiter.
+func opensSingleQuote(s string, i int) bool {
+	if i == 0 {
+		return true
+	}
+	switch s[i-1] {
+	case ' ', '\t', ':', '=', '(', ',', '>':
+		return true
+	default:
+		return false
+	}
 }
 
 // stripComment removes a trailing comment from a line, but only if # is preceded by
@@ -427,14 +498,22 @@ func (l *Lexer) tryLexOperator(line string, i int, loc ir.SourceLocation) (int, 
 	return i + 1, true
 }
 
-// tryLexQuotedString handles double-quoted string literals with escape sequences.
+// tryLexQuotedString handles quoted string literals. Double quotes process
+// backslash escapes; single quotes are YAML-style literals where the only escape
+// is a doubled single quote collapsing to one `'` (no backslash processing).
 func (l *Lexer) tryLexQuotedString(line string, i int, loc ir.SourceLocation) (int, bool) {
-	if line[i] != '"' {
+	switch line[i] {
+	case '"':
+		content, newI := readQuotedContent(line, i+1)
+		l.tokens = append(l.tokens, Token{Type: TokenLiteral, Value: content, Location: loc})
+		return newI, true
+	case '\'':
+		content, newI := readSingleQuotedContent(line, i+1)
+		l.tokens = append(l.tokens, Token{Type: TokenLiteral, Value: content, Location: loc})
+		return newI, true
+	default:
 		return i, false
 	}
-	content, newI := readQuotedContent(line, i+1)
-	l.tokens = append(l.tokens, Token{Type: TokenLiteral, Value: content, Location: loc})
-	return newI, true
 }
 
 // readQuotedContent reads characters from line[start:] until an unescaped closing quote.
@@ -447,6 +526,28 @@ func readQuotedContent(line string, start int) (string, int) {
 	}
 	if i < len(line) {
 		i++ // skip closing quote
+	}
+	return content.String(), i
+}
+
+// readSingleQuotedContent reads characters from line[start:] until the closing
+// single quote, collapsing a doubled single quote to one literal `'`. Returns the
+// content string and the position after the closing quote.
+func readSingleQuotedContent(line string, start int) (string, int) {
+	var content strings.Builder
+	i := start
+	for i < len(line) {
+		if line[i] == '\'' {
+			if i+1 < len(line) && line[i+1] == '\'' {
+				content.WriteByte('\'')
+				i += 2
+				continue
+			}
+			i++ // skip closing quote
+			break
+		}
+		content.WriteByte(line[i])
+		i++
 	}
 	return content.String(), i
 }

--- a/parser/single_quote_token_test.go
+++ b/parser/single_quote_token_test.go
@@ -1,0 +1,164 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- Lexer: single-quoted strings become one TokenLiteral (#120) ---
+
+func TestLexSingleQuotedString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []TokenType
+	}{
+		{
+			name:  "single quoted with spaces",
+			input: `'hello world'`,
+			want:  []TokenType{TokenLiteral, TokenNewline, TokenEOF},
+		},
+		{
+			name:  "single quoted glued after identifier and colon",
+			input: `label: 'My Label'`,
+			want:  []TokenType{TokenIdentifier, TokenColon, TokenLiteral, TokenNewline, TokenEOF},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewLexer(tt.input, "test.dip")
+			var got []TokenType
+			for {
+				tok := l.NextToken()
+				got = append(got, tok.Type)
+				if tok.Type == TokenEOF {
+					break
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("token count = %d (%v), want %d (%v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("token[%d] = %v, want %v (full %v)", i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+// TestLexSingleQuotedContent verifies the stored literal value: surrounding
+// quotes stripped, a doubled single quote collapsed to one, no backslash processing.
+func TestLexSingleQuotedContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain", `'hello world'`, "hello world"},
+		{"doubled escape", `'it''s here'`, "it's here"},
+		{"empty", `''`, ""},
+		{"literal backslash", `'a \d+ b'`, `a \d+ b`},
+		{"internal hash", `'a # b'`, "a # b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewLexer(tt.input, "test.dip")
+			tok := l.NextToken()
+			if tok.Type != TokenLiteral {
+				t.Fatalf("first token = %v, want TokenLiteral", tok.Type)
+			}
+			if tok.Value != tt.want {
+				t.Fatalf("value = %q, want %q", tok.Value, tt.want)
+			}
+		})
+	}
+}
+
+// --- Comment stripping: # inside a single-quoted token is literal,
+//     but a prose apostrophe must NOT protect a trailing comment (#120). ---
+
+func TestStripCommentSingleQuoteToken(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// A # inside a single-quoted TOKEN is content, not a comment.
+		{"hash in single-quoted label", `    A -> B label: 'a # b'`, `    A -> B label: 'a # b'`},
+		{"hash in single-quoted condition", `    A -> B when ctx.x = 'a # b'`, `    A -> B when ctx.x = 'a # b'`},
+		{"trailing comment after closing quote", `    A -> B label: 'a b' # note`, `    A -> B label: 'a b' `},
+		// Colon-glued single quote (no space after `:`) still opens a token.
+		{"hash in colon-glued label", `    A -> B label:'a # b'`, `    A -> B label:'a # b'`},
+		// REGRESSION GUARD: a prose apostrophe must not protect the comment.
+		{"prose apostrophe still strips comment", `  goal: it's great # note`, `  goal: it's great `},
+		{"prose apostrophe no comment", `  goal: it's great`, `  goal: it's great`},
+		// '' doubled-quote escape inside a token keeps the # literal.
+		{"doubled quote then hash", `    A -> B label: 'it''s # x'`, `    A -> B label: 'it''s # x'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripComment(tt.in); got != tt.want {
+				t.Fatalf("stripComment(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- End-to-end: edge label and when condition accept single-quoted values. ---
+
+func TestParseEdgeSingleQuotedLabel(t *testing.T) {
+	p := NewParser(buildEdgeDip("A -> B label: 'a # b'"), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if got := w.Edges[0].Label; got != "a # b" {
+		t.Fatalf("label = %q, want %q", got, "a # b")
+	}
+}
+
+func TestParseEdgeSingleQuotedCondition(t *testing.T) {
+	p := NewParser(buildEdgeDip("A -> B when ctx.reason = 'gave up'"), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v (%v)", err, p.Diagnostics())
+	}
+	got := w.Edges[0].Condition
+	// A single-quoted condition operand normalizes to a double-quoted literal
+	// in the raw condition text (matches existing TokenLiteral handling).
+	if got == nil || got.Raw != `ctx.reason = "gave up"` {
+		t.Fatalf("condition = %+v, want Raw %q", got, `ctx.reason = "gave up"`)
+	}
+}
+
+func TestParseEdgeSingleQuotedDoubledEscape(t *testing.T) {
+	p := NewParser(buildEdgeDip("A -> B label: 'it''s done'"), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if got := w.Edges[0].Label; got != "it's done" {
+		t.Fatalf("label = %q, want %q", got, "it's done")
+	}
+}
+
+// TestParseEdgeSingleQuotedHelpersAgree guards that prose values with
+// apostrophes elsewhere in the same workflow still strip trailing comments.
+func TestParseProseApostropheStillStripsComment(t *testing.T) {
+	src := "workflow X\n" +
+		"  goal: it's great # trailing note\n" +
+		"  start: A\n" +
+		"  exit: A\n" +
+		"\n" +
+		"  agent A\n" +
+		"    prompt: \"Do A.\"\n"
+	p := NewParser(src, "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if !strings.HasPrefix(w.Goal, "it's great") || strings.Contains(w.Goal, "#") {
+		t.Fatalf("goal = %q, want it's great with the comment stripped", w.Goal)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #117. That PR added YAML-style single-quoted strings to single-line **field values** but deliberately left them out of the **token-stream** positions in the `edges` section — edge `label:` and `when` conditions — because the per-line comment stripper couldn't tell a delimiter quote from a prose apostrophe. This PR closes that gap.

Single quotes now work everywhere `$.string` is accepted, and normalize to double-quoted output on `fmt` (same as #117).

## Changes

- **parser/lexer.go**
  - `tryLexQuotedString` now lexes a single-quoted string into one `TokenLiteral` via `readSingleQuotedContent` — a doubled single quote is the only escape (collapses to one), with no backslash processing. Double-quote handling is byte-for-byte unchanged.
  - `findUnquotedHash` (the token-stream comment stripper) tracks both quote kinds. A single quote is treated as a string delimiter **only at a token-start boundary** (start of content, or right after whitespace / `:` `=` `(` `,` `>`); a `'` after a word character is a prose apostrophe. So a `#` inside a single-quoted token is literal content, while `goal: it's great # note` still strips its trailing comment.
- **editors/tree-sitter-dippin** — added a corpus case for a single-quoted edge label + `when` condition. The shared `$.string` rule already admits single quotes in both positions, so **no `grammar.js` change / regen** was needed; `tree-sitter test` is 10/10.
- **docs** — syntax.md / architecture.md updated to reflect the now-uniform support.

## Why the comment-stripping rework is safe (the deferred risk)

The ticket warned this was deferred because a naive single-quote-aware stripper would regress apostrophes in prose values. The boundary check resolves it: a prose value's apostrophe is always mid-word (e.g. the `'` in `it's` follows `t`), never glued to a delimiter, so it never opens a quoted span. Both directions are covered by tests, and a red-green check confirms the new tests fail against the pre-fix lexer.

## Tests

- Lexer: single-quoted tokenization; content with spaces, doubled-quote escape, empty `''`, literal backslashes, internal `#`.
- Comment stripper: `#` inside single-quoted label/condition preserved (incl. colon-glued and doubled-quote escape); prose apostrophe + trailing comment still strips.
- Parser end-to-end: edge `label:` and `when` condition single-quoted values.
- Formatter: parse → format → parse round-trip proving single quotes normalize to double quotes and survive, formatter idempotent.
- Tree-sitter: corpus case for single-quoted edge label + condition.

`scripts/pre-commit` passes end-to-end (build / vet / golangci-lint / gofmt / race tests / releasecheck / complexity ≤5/≤7 / validate-examples).

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783887657&installation_id=131176874&pr_number=146&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F146&signature=8c78e298d93caa35f6d49665d949c4d6fc12f1394f323b51802aece01fe6205e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->