### PR TITLE
fix(coverage): treat startswith edges as covering printf-format markers (#141)

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -79,6 +79,7 @@ func analyzeToolNode(w *ir.Workflow, n *ir.Node) NodeCoverage {
 	}
 	edges := w.EdgesFrom(n.ID)
 	conditions, hasFallback := collectEdgeConditions(edges)
+	terms := collectEdgeConditionTerms(edges)
 
 	cov := NodeCoverage{
 		NodeID:          n.ID,
@@ -94,7 +95,7 @@ func analyzeToolNode(w *ir.Workflow, n *ir.Node) NodeCoverage {
 		cov.ExtractedOutputs = outputs
 	}
 
-	cov.MissingEdges = findMissingEdges(outputs, conditions)
+	cov.MissingEdges = findMissingEdges(outputs, terms)
 	cov.Status = determineStatus(cov)
 	return cov
 }
@@ -113,25 +114,47 @@ func determineStatus(cov NodeCoverage) string {
 	return "partial"
 }
 
-// findMissingEdges returns extracted outputs that have no matching edge condition.
-func findMissingEdges(outputs, conditions []string) []string {
-	condSet := toSet(conditions)
+// condTerm is a single edge comparison term (operator + value) used for
+// matching tool outputs. Unlike the flat EdgeConditions report field, it
+// preserves the operator so prefix predicates can be evaluated.
+type condTerm struct {
+	op    string
+	value string
+}
+
+// findMissingEdges returns extracted outputs that no edge term covers. An
+// output is covered when some `=`/`==` term equals it, or some `startswith`
+// term is a prefix of it. Other operators are conservatively ignored.
+func findMissingEdges(outputs []string, terms []condTerm) []string {
 	var missing []string
 	for _, o := range outputs {
-		if !condSet[o] {
+		if !outputCovered(o, terms) {
 			missing = append(missing, o)
 		}
 	}
 	return missing
 }
 
-// toSet converts a string slice to a map for O(1) lookups.
-func toSet(items []string) map[string]bool {
-	s := make(map[string]bool, len(items))
-	for _, item := range items {
-		s[item] = true
+// outputCovered reports whether any term covers the given output.
+func outputCovered(output string, terms []condTerm) bool {
+	for _, t := range terms {
+		if termCovers(t, output) {
+			return true
+		}
 	}
-	return s
+	return false
+}
+
+// termCovers reports whether a single term covers the output value.
+func termCovers(t condTerm, output string) bool {
+	switch t.op {
+	case "=", "==":
+		return t.value == output
+	case "startswith":
+		return strings.HasPrefix(output, t.value)
+	default:
+		return false
+	}
 }
 
 // echoFlags are echo invocations that should be skipped when extracting
@@ -322,6 +345,40 @@ func collectEdgeConditions(edges []*ir.Edge) (conditions []string, hasFallback b
 		conditions = appendConditionValues(conditions, e.Condition.Parsed)
 	}
 	return conditions, hasFallback
+}
+
+// collectEdgeConditionTerms extracts typed comparison terms (operator +
+// value) from edges, preserving the operator so prefix predicates can be
+// matched. The flat EdgeConditions report field is produced separately by
+// collectEdgeConditions.
+func collectEdgeConditionTerms(edges []*ir.Edge) []condTerm {
+	var terms []condTerm
+	for _, e := range edges {
+		if e.Condition == nil {
+			continue
+		}
+		terms = appendConditionTerms(terms, e.Condition.Parsed)
+	}
+	return terms
+}
+
+// appendConditionTerms walks a condition expression tree and collects each
+// comparison as a typed term.
+func appendConditionTerms(out []condTerm, expr ir.ConditionExpr) []condTerm {
+	switch e := expr.(type) {
+	case ir.CondCompare:
+		return append(out, condTerm{op: e.Op, value: e.Value})
+	case ir.CondAnd:
+		out = appendConditionTerms(out, e.Left)
+		return appendConditionTerms(out, e.Right)
+	case ir.CondOr:
+		out = appendConditionTerms(out, e.Left)
+		return appendConditionTerms(out, e.Right)
+	case ir.CondNot:
+		return appendConditionTerms(out, e.Inner)
+	default:
+		return out
+	}
 }
 
 // appendConditionValues extracts comparison values from a condition expression tree.

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -1,9 +1,11 @@
 package coverage
 
 import (
+	"os"
 	"testing"
 
 	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/parser"
 )
 
 // makeEdge creates a simple unconditional edge.
@@ -597,4 +599,57 @@ func slicesEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// --- issue #141: startswith coverage of printf-format markers ---
+
+// TestFindMissingEdges_Startswith asserts that a printf-format output
+// (`citations-fail-%s`) is treated as covered when a `startswith` term
+// matches its static prefix, while a bare equality term does not.
+func TestFindMissingEdges_Startswith(t *testing.T) {
+	outputs := []string{"citations-ok", "citations-fail-%s"}
+	terms := []condTerm{
+		{op: "=", value: "citations-ok"},
+		{op: "startswith", value: "citations-fail"},
+	}
+	missing := findMissingEdges(outputs, terms)
+	if len(missing) != 0 {
+		t.Errorf("expected no missing edges, got %v", missing)
+	}
+}
+
+// TestFindMissingEdges_StartswithNonPrefix asserts conservatism: a
+// `startswith` term that is NOT a prefix of the output leaves it missing.
+func TestFindMissingEdges_StartswithNonPrefix(t *testing.T) {
+	outputs := []string{"citations-fail-%s"}
+	terms := []condTerm{{op: "startswith", value: "roadmap-invalid"}}
+	missing := findMissingEdges(outputs, terms)
+	if len(missing) != 1 || missing[0] != "citations-fail-%s" {
+		t.Errorf("expected [citations-fail-%%s] missing, got %v", missing)
+	}
+}
+
+// TestCoverageStartswith_FixtureCovered parses the in-repo fixture and
+// asserts the printf-format marker is no longer reported missing and the
+// tool node is fully covered (issue #141).
+func TestCoverageStartswith_FixtureCovered(t *testing.T) {
+	src, err := os.ReadFile("../examples/coverage_startswith.dip")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	w, err := parser.NewParser(string(src), "coverage_startswith.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+
+	r := Analyze(w)
+	cov := r.Nodes["CheckCitations"]
+	for _, m := range cov.MissingEdges {
+		if m == "citations-fail-%s" {
+			t.Errorf("citations-fail-%%s should be covered by startswith edge, got missing=%v", cov.MissingEdges)
+		}
+	}
+	if cov.Status != "covered" {
+		t.Errorf("expected status covered, got %q (missing=%v)", cov.Status, cov.MissingEdges)
+	}
 }

--- a/examples/coverage_startswith.dip
+++ b/examples/coverage_startswith.dip
@@ -1,0 +1,32 @@
+# Regression for issue #141: a `startswith` edge predicate must count a
+# printf-format marker (e.g. `citations-fail-%s`) as covered, since its
+# static prefix matches the edge's `startswith` constant.
+workflow CoverageStartswith
+  goal: "Demonstrate that startswith edges cover printf-format stdout markers"
+  start: CheckCitations
+  exit: Done
+
+  tool CheckCitations
+    timeout: 2m
+    command:
+      set -eu
+      if true; then
+        printf 'citations-ok'
+      else
+        printf 'citations-fail-%s' "$ids"
+      fi
+
+  agent FixCitations
+    prompt: Repair the failing citations.
+
+  agent Dispatch
+    prompt: Proceed with the validated citations.
+
+  agent Done
+    prompt: Final report.
+
+  edges
+    CheckCitations -> Dispatch     when ctx.tool_stdout = citations-ok
+    CheckCitations -> FixCitations when ctx.tool_stdout startswith citations-fail
+    Dispatch -> Done
+    FixCitations -> Done


### PR DESCRIPTION
Fixes #141.

## Problem

`dippin coverage` (which drives the `dippin doctor` "tool node(s) with uncovered outputs" check) did exact-match of each tool-output literal against a flat set of edge-condition *values*, discarding the operator. A `... when ctx.tool_stdout startswith citations-fail` edge contributed only the bare literal `citations-fail`, which never exact-matched the printf-format output `citations-fail-%s`. The result was a false-positive "uncovered output" that capped doctor grades on otherwise-clean files using the `startswith`-cascade routing pattern.

## Fix

Carry the operator through. `appendConditionTerms`/`collectEdgeConditionTerms` collect each comparison as a typed `condTerm{op, value}`. `findMissingEdges` now does two-tier matching: an output is covered if some `=`/`==` term equals it (existing behavior) **or** some `startswith` term is a prefix of it (new). Conservative by design — only `startswith` is extended; `contains`/`endswith`/regex/`marker_grep` are left out to favor false negatives over crying wolf.

The public `EdgeConditions []string` report field is preserved unchanged (still the flat value list, asserted by the existing `TestCollectEdgeConditions_*` tests).

## Tests

- `examples/coverage_startswith.dip` — regression fixture (passes `dippin validate`; covered by the validate-examples pre-commit gate and `TestLintExamples`).
- `TestCoverageStartswith_FixtureCovered` — parses the fixture, asserts `citations-fail-%s` is no longer in `MissingEdges` and the node status is `covered`.
- `TestFindMissingEdges_Startswith` / `_StartswithNonPrefix` — unit coverage of the matcher (prefix match covers; non-prefix stays missing).

`scripts/pre-commit` passes end-to-end (build, vet, golangci-lint, gofmt, full test suite, release checks, cyclomatic/cognitive complexity, validate-examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783888082&installation_id=131176874&pr_number=147&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F147&signature=bf000fb7bc9d4a1d9ddb0482f7d492029f988a01eef4896ad06c388db699bcfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->