### PR TITLE
docs: sync website + editors + grammar to v0.41.0 surface

### DIFF
--- a/docs/GRAMMAR.ebnf
+++ b/docs/GRAMMAR.ebnf
@@ -322,8 +322,8 @@ STRING          = '"' { string_char } '"'
 string_char     = ? any character except '"' and '\' ?
                 | '\' ( '"' | '\' ) ;
 
-(* Single-quoted strings are literal: backslashes are not escapes.  *)
-(* The only escape is a doubled '' which produces one '. (YAML-style) *)
+(* Single-quoted strings are literal: backslashes are not escapes.   *)
+(* The only escape is a doubled '' which produces a single ' (YAML-style). *)
 single_string_char = ? any character except "'" ?
                 | "'" "'" ;
 

--- a/docs/GRAMMAR.ebnf
+++ b/docs/GRAMMAR.ebnf
@@ -316,10 +316,16 @@ IDENTIFIER      = ( letter | digit ) { letter | digit | "_" | "-" | "." | "/" } 
 (* (enforced by ir.IsOutcomeToken). A "." / "/" / quoted value needs a `when`. *)
 OUTCOME_TOKEN   = ( letter | digit ) { letter | digit | "_" | "-" } ;
 
-STRING          = '"' { string_char } '"' ;
+STRING          = '"' { string_char } '"'
+                | "'" { single_string_char } "'" ;
 
 string_char     = ? any character except '"' and '\' ?
                 | '\' ( '"' | '\' ) ;
+
+(* Single-quoted strings are literal: backslashes are not escapes.  *)
+(* The only escape is a doubled '' which produces one '. (YAML-style) *)
+single_string_char = ? any character except "'" ?
+                | "'" "'" ;
 
 INTEGER         = digit { digit } ;
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -255,7 +255,7 @@ dippin fmt [--check] [--write] [--migrate] <file>
 |------|-------------|
 | `--check` | Don't output anything. Exit 1 if the file is not already in canonical format. Useful for CI checks. |
 | `--write` | Write the formatted output back to the source file in-place. |
-| `--migrate` | Re-emit the file in its current format version. Reuses the parse → format machinery; today a no-op v1→v1 identity pass — the foundation for future format-version migrations (v1→v2 transforms land later). |
+| `--migrate` | Re-emit the file in its current format version. It still formats to canonical form (it reuses the `fmt` machinery, so a non-canonical v1 file is reformatted); the v1→v1 migration itself is an identity pass today — no version transform — and is the foundation for future format-version migrations (v1→v2 transforms land later). |
 
 **Default behavior** (no flags): Print the canonically formatted output to stdout.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -246,7 +246,7 @@ dippin new review-loop --write /tmp/test.dip && dippin validate /tmp/test.dip
 Format a `.dip` file to canonical form.
 
 ```bash
-dippin fmt [--check] [--write] <file>
+dippin fmt [--check] [--write] [--migrate] <file>
 ```
 
 **Flags**:
@@ -255,6 +255,7 @@ dippin fmt [--check] [--write] <file>
 |------|-------------|
 | `--check` | Don't output anything. Exit 1 if the file is not already in canonical format. Useful for CI checks. |
 | `--write` | Write the formatted output back to the source file in-place. |
+| `--migrate` | Re-emit the file in its current format version. Reuses the parse → format machinery; today a no-op v1→v1 identity pass — the foundation for future format-version migrations (v1→v2 transforms land later). |
 
 **Default behavior** (no flags): Print the canonically formatted output to stdout.
 

--- a/editors/tree-sitter-dippin/queries/highlights.scm
+++ b/editors/tree-sitter-dippin/queries/highlights.scm
@@ -26,6 +26,10 @@
   "not"
 ] @keyword.operator
 
+; Format version declaration
+(version_decl
+  "dip" @keyword)
+
 ; Comparison operators
 (compare_op) @operator
 
@@ -55,6 +59,12 @@
   "weight" @property)
 (edge_attr
   "restart" @property)
+(edge_attr
+  "override" @property)
+(edge_attr
+  "on" @keyword.operator)
+(edge_attr
+  "loop" @keyword)
 
 ; Identifiers in declarations
 (workflow_decl

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "dippin-lang",
   "displayName": "Dippin",
   "description": "Language support for Dippin (.dip) AI pipeline workflow files",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "2389-research",
   "repository": {
     "type": "git",

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -218,6 +218,10 @@
         {
           "match": "''",
           "name": "constant.character.escape.dippin"
+        },
+        {
+          "match": "\\$\\{[^}]+\\}",
+          "name": "variable.other.interpolation.dippin"
         }
       ]
     }

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -4,6 +4,7 @@
   "scopeName": "source.dippin",
   "patterns": [
     { "include": "#comment" },
+    { "include": "#version" },
     { "include": "#workflow" },
     { "include": "#node-declaration" },
     { "include": "#section-keyword" },
@@ -16,6 +17,14 @@
     "comment": {
       "match": "#.*$",
       "name": "comment.line.number-sign.dippin"
+    },
+
+    "version": {
+      "match": "^(dip)\\s+(\\d+)\\b",
+      "captures": {
+        "1": { "name": "keyword.control.version.dippin" },
+        "2": { "name": "constant.numeric.integer.dippin" }
+      }
     },
 
     "workflow": {
@@ -88,6 +97,14 @@
           "name": "keyword.control.when.dippin"
         },
         {
+          "match": "\\b(on)\\b",
+          "name": "keyword.control.on.dippin"
+        },
+        {
+          "match": "\\b(loop)\\b",
+          "name": "keyword.control.loop.dippin"
+        },
+        {
           "match": "\\b(restart)\\s*:",
           "captures": {
             "1": { "name": "keyword.other.edge-attr.dippin" }
@@ -145,7 +162,7 @@
           }
         },
         {
-          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|marker_grep|command_file|prompt_file|system_prompt_file|route_required|output_limit|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|tool_access|class|reads|writes)\\s*(:)",
+          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|marker_grep|command_file|prompt_file|system_prompt_file|route_required|output_limit|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|tool_access|override|class|reads|writes)\\s*(:)",
           "captures": {
             "1": { "name": "entity.name.tag.field.dippin" },
             "2": { "name": "punctuation.separator.key-value.dippin" }

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -213,6 +213,7 @@
       "begin": "'",
       "end": "'",
       "name": "string.quoted.single.dippin",
+      "applyEndPatternLast": 1,
       "patterns": [
         {
           "match": "''",

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -210,7 +210,7 @@
     },
 
     "string-single": {
-      "begin": "'",
+      "begin": "(?<!\\w)'",
       "end": "'",
       "name": "string.quoted.single.dippin",
       "applyEndPatternLast": 1,

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -116,6 +116,12 @@
             "1": { "name": "keyword.other.edge-attr.dippin" }
           }
         },
+        {
+          "match": "\\b(override)\\s*:",
+          "captures": {
+            "1": { "name": "keyword.other.edge-attr.dippin" }
+          }
+        },
         { "include": "#condition" }
       ]
     },
@@ -162,7 +168,7 @@
           }
         },
         {
-          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|marker_grep|command_file|prompt_file|system_prompt_file|route_required|output_limit|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|tool_access|override|class|reads|writes)\\s*(:)",
+          "match": "^\\s*(label|model|provider|mode|default|ref|subgraph_ref|timeout|poll_interval|max_cycles|fidelity|reasoning_effort|goal_gate|auto_status|max_turns|max_retries|marker_grep|command_file|prompt_file|system_prompt_file|route_required|output_limit|base_delay|retry_policy|retry_target|fallback_target|max_restarts|restart_target|cache_tools|compaction|stop_condition|steer_condition|steer_context|tool_access|class|reads|writes)\\s*(:)",
           "captures": {
             "1": { "name": "entity.name.tag.field.dippin" },
             "2": { "name": "punctuation.separator.key-value.dippin" }

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -11,7 +11,8 @@
     { "include": "#parallel-fanin" },
     { "include": "#edge" },
     { "include": "#field" },
-    { "include": "#string" }
+    { "include": "#string" },
+    { "include": "#string-single" }
   ],
   "repository": {
     "comment": {
@@ -204,6 +205,18 @@
         {
           "match": "\\$\\{[^}]+\\}",
           "name": "variable.other.interpolation.dippin"
+        }
+      ]
+    },
+
+    "string-single": {
+      "begin": "'",
+      "end": "'",
+      "name": "string.quoted.single.dippin",
+      "patterns": [
+        {
+          "match": "''",
+          "name": "constant.character.escape.dippin"
         }
       ]
     }

--- a/editors/zed-dippin/extension.toml
+++ b/editors/zed-dippin/extension.toml
@@ -1,6 +1,6 @@
 id = "dippin"
 name = "Dippin"
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
 authors = ["2389 Research"]
 description = "Dippin workflow language support with syntax highlighting and LSP."
@@ -9,7 +9,7 @@ repository = "https://github.com/2389-research/dippin-lang"
 [grammars.dippin]
 repository = "https://github.com/2389-research/dippin-lang"
 path = "editors/tree-sitter-dippin"
-commit = "686b7e4962b5c6528f5bb52d5bc86d172fca357d"
+commit = "10cc50feec20ab87895eb4ccd93a245c9c893250"
 
 [language_servers.dippin-lsp]
 languages = ["Dippin"]

--- a/editors/zed-dippin/languages/dippin/highlights.scm
+++ b/editors/zed-dippin/languages/dippin/highlights.scm
@@ -15,6 +15,7 @@
   "conditional"
   "parallel"
   "fan_in"
+  "manager_loop"
 ] @type
 
 ; Edge / condition keywords
@@ -24,6 +25,10 @@
   "or"
   "not"
 ] @keyword.operator
+
+; Format version declaration
+(version_decl
+  "dip" @keyword)
 
 ; Comparison operators
 (compare_op) @operator
@@ -54,6 +59,12 @@
   "weight" @property)
 (edge_attr
   "restart" @property)
+(edge_attr
+  "override" @property)
+(edge_attr
+  "on" @keyword.operator)
+(edge_attr
+  "loop" @keyword)
 
 ; Identifiers in declarations
 (workflow_decl
@@ -71,6 +82,8 @@
 (parallel_node
   (identifier) @function)
 (fan_in_node
+  (identifier) @function)
+(manager_loop_node
   (identifier) @function)
 
 ; Edge source/target

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -72,7 +72,7 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 <div class="cmd-card">
   <h3>fmt</h3>
   <div class="cmd-usage">dippin fmt [--check] [--write] [--migrate] &lt;file&gt;</div>
-  <p>Format a <code>.dip</code> file to canonical form. 2-space indentation, standard field ordering, deterministic and idempotent output. Use <code>--check</code> for CI (exit 1 if unformatted) or <code>--write</code> for in-place formatting. <code>--migrate</code> re-emits a file in its current format version — today a no-op v1→v1 identity pass, scaffolding for future version migrations.</p>
+  <p>Format a <code>.dip</code> file to canonical form. 2-space indentation, standard field ordering, deterministic and idempotent output. Use <code>--check</code> for CI (exit 1 if unformatted) or <code>--write</code> for in-place formatting. <code>--migrate</code> re-emits a file in its current format version, still formatting it to canonical form; the v1→v1 migration itself is an identity pass today — no version transform — and scaffolding for future version migrations.</p>
 </div>
 
 <div class="cmd-card">

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -56,7 +56,7 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 <div class="cmd-card">
   <h3>lint</h3>
   <div class="cmd-usage">dippin lint [--extra-models &lt;spec&gt;] &lt;file&gt;</div>
-  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP146). All 55 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
+  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP149). All 59 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
   <dl>
     <dt><code>--extra-models "provider:model1,model2;provider2:model3"</code></dt>
     <dd>Extend the DIP108 model catalog at runtime for private or newly-released models.</dd>

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -71,8 +71,8 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 
 <div class="cmd-card">
   <h3>fmt</h3>
-  <div class="cmd-usage">dippin fmt [--check] [--write] &lt;file&gt;</div>
-  <p>Format a <code>.dip</code> file to canonical form. 2-space indentation, standard field ordering, deterministic and idempotent output. Use <code>--check</code> for CI (exit 1 if unformatted) or <code>--write</code> for in-place formatting.</p>
+  <div class="cmd-usage">dippin fmt [--check] [--write] [--migrate] &lt;file&gt;</div>
+  <p>Format a <code>.dip</code> file to canonical form. 2-space indentation, standard field ordering, deterministic and idempotent output. Use <code>--check</code> for CI (exit 1 if unformatted) or <code>--write</code> for in-place formatting. <code>--migrate</code> re-emits a file in its current format version — today a no-op v1→v1 identity pass, scaffolding for future version migrations.</p>
 </div>
 
 <div class="cmd-card">

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -25,6 +25,8 @@ Every `.dip` file contains exactly one workflow. The top-level structure has up 
 
 Dippin uses indentation-sensitive syntax (like Python). Use 2 spaces or tabs consistently. The canonical formatter always outputs 2-space indentation.
 
+A `.dip` file may optionally declare its **format version** on the first line, before the `workflow` declaration — e.g. `dip 2`. With no declaration the version defaults to **1**, and the formatter only emits the `dip N` line for versions greater than 1 (a v1 file never gains one). The version is parsed before the workflow body so future format versions can change edge syntax wholesale; `dippin fmt --migrate` re-emits a file in its current format version, which today is a no-op identity pass for v1.
+
 ## Workflow Header
 
 The workflow declaration is the first line, followed by required and optional header fields:
@@ -268,7 +270,7 @@ Conditional nodes accept only common fields (`label`, `class`, `reads`, `writes`
 The `edges` block defines connections between nodes. Each edge is a single line:
 
 ```
-<FromID> -> <ToID> [when <condition>] [label: <text>] [weight: <int>] [restart: true]
+<FromID> -> <ToID> [on <token> | when <condition>] [label: <text>] [weight: <int>] [loop]
 ```
 
 ### Basic and Conditional Edges
@@ -285,22 +287,39 @@ The `edges` block defines connections between nodes. Each edge is a single line:
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
+| `on <token>` | Token | Shorthand for an equality guard against the source node's outcome channel — agent (`ctx.outcome`) or tool + `marker_grep` (`ctx.tool_marker`) |
 | `when <expr>` | Condition | Boolean guard — edge only traversed if true |
 | `label: <text>` | String | Human-readable label (used for human gate choices) |
 | `weight: <int>` | Integer | Priority hint — higher wins among competing edges |
-| `restart: true` | Boolean | Marks this as a back-edge (loop restart) |
+| `loop` | Flag | Bare keyword marking a back-edge (loop restart). Legacy `restart: true` is an accepted synonym that `dippin fmt` rewrites to `loop` |
 
-### Restart Edges
+### Outcome Shorthand (`on`)
 
-Restart edges create controlled loops. When followed, the engine increments a restart counter (max controlled by `max_restarts`), clears downstream nodes, resets retry budgets, and resumes from the target.
+The most common condition is an equality test against the source node's *natural outcome channel*. `on <token>` is shorthand for exactly that:
 
 ```
-    Task -> Start when ctx.outcome = fail label: "retry" restart: true
+    Review -> Approve  on success      # = when ctx.outcome = success
+    Review -> Reject   on fail         # = when ctx.outcome = fail
+    Tests  -> Ship     on tests_green  # = when ctx.tool_marker = tests_green
 ```
+
+The channel comes from the source node's kind: **agent** nodes use `ctx.outcome`; **tool** nodes that declare `marker_grep` use `ctx.tool_marker`. `on` is pure sugar — it produces the identical condition, is non-breaking, and `dippin fmt` rewrites eligible `when` edges into `on` form. Sources without an outcome channel — human gates, `conditional` nodes, and tools without `marker_grep` — have no `on` channel; use `when` there, as well as for anything that isn't a single equality (`and`/`or`, `contains`, `!=`, etc.).
+
+### Loop Edges
+
+A `loop` edge creates a controlled back-edge. When followed, the engine increments a restart counter (max controlled by `max_restarts`), clears downstream nodes, resets retry budgets, and resumes from the target.
+
+```
+    Validate -> Implement when ctx.outcome = fail loop
+```
+
+`loop` is a bare keyword; the legacy `restart: true` still parses and `dippin fmt` rewrites it to `loop`. Because `loop` is a reserved bare keyword, write `when ctx.x = "loop"` (quoted) for the literal value on a condition's right-hand side.
 
 ## Conditions
 
 Conditions appear on edges after the `when` keyword. All operators perform string comparison.
+
+String values in conditions and `label:` may be **unquoted** (`success`), **double-quoted** (`"needs review"`, supporting `\"` and `\\` escapes), or **single-quoted** (YAML-style literal, where `''` is the only escape — handy for regex-like values: `'^(green|red)$'`). A single-quoted edge value normalizes to double quotes on `dippin fmt`.
 
 ### Comparison Operators
 

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -292,6 +292,7 @@ The `edges` block defines connections between nodes. Each edge is a single line:
 | `label: <text>` | String | Human-readable label (used for human gate choices) |
 | `weight: <int>` | Integer | Priority hint — higher wins among competing edges |
 | `loop` | Flag | Bare keyword marking a back-edge (loop restart). Legacy `restart: true` is an accepted synonym that `dippin fmt` rewrites to `loop` |
+| `override: true` | Boolean | Carried, not interpreted by dippin — marks a human-authored validation override for a paired runtime to act on |
 
 ### Outcome Shorthand (`on`)
 

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -25,7 +25,7 @@ Every `.dip` file contains exactly one workflow. The top-level structure has up 
 
 Dippin uses indentation-sensitive syntax (like Python). Use 2 spaces or tabs consistently. The canonical formatter always outputs 2-space indentation.
 
-A `.dip` file may optionally declare its **format version** on the first line, before the `workflow` declaration — e.g. `dip 2`. With no declaration the version defaults to **1**, and the formatter only emits the `dip N` line for versions greater than 1 (a v1 file never gains one). The version is parsed before the workflow body so future format versions can change edge syntax wholesale; `dippin fmt --migrate` re-emits a file in its current format version, which today is a no-op identity pass for v1.
+A `.dip` file may optionally declare its **format version** on the first line, before the `workflow` declaration — e.g. `dip 2`. With no declaration the version defaults to **1**, and the formatter only emits the `dip N` line for versions greater than 1 (a v1 file never gains one). The version is parsed before the workflow body so future format versions can change edge syntax wholesale; `dippin fmt --migrate` re-emits a file in its current format version, still formatting it to canonical form — today the v1→v1 migration itself is an identity pass with no version transform.
 
 ## Workflow Header
 

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -1,8 +1,8 @@
 ---
 title: "Validation & Linting"
-description: "57 diagnostic codes for AI pipeline workflows. 10 structural errors and 47 semantic warnings catch bugs before runtime."
+description: "59 diagnostic codes for AI pipeline workflows. 10 structural errors and 49 semantic warnings catch bugs before runtime."
 section_label: "Diagnostics"
-subtitle: "57 diagnostic codes — 10 structural errors and 47 semantic warnings — to catch problems before runtime."
+subtitle: "59 diagnostic codes — 10 structural errors and 49 semantic warnings — to catch problems before runtime."
 ---
 
 ## Overview
@@ -11,7 +11,7 @@ Dippin provides two levels of analysis:
 
 **Structural validation** (DIP001-DIP010): Errors that must be fixed. A workflow with any of these cannot execute. Run with `dippin validate`.
 
-**Semantic linting** (DIP101-DIP147): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
+**Semantic linting** (DIP101-DIP149): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
 
 ### Diagnostic Format
 
@@ -107,7 +107,7 @@ These must be fixed for a workflow to be valid. Each causes exit code 1.
   = help: valid operators: = == != contains startswith endswith in</pre>
 </div>
 
-## Semantic Warnings (DIP101-DIP147)
+## Semantic Warnings (DIP101-DIP149)
 
 These flag likely bugs or questionable patterns. Warnings alone exit 0.
 
@@ -308,4 +308,24 @@ A `tool_access: none` agent declares a context key in `writes:`, and a downstrea
 hint[DIP147]: restricted agent "Summarize" (tool_access: none) writes context key "summary" that tool-bearing agent "Act" reads — its output reaches a privileged prompt
 ```
 
-> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP147) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.
+### DIP148 — Negative `last_response_truncate`
+
+**Severity:** Warning
+
+An agent node (or a parallel-branch override) sets `last_response_truncate` to a negative value. The field is a character cap on the prior node's response before it is auto-injected into this agent's prompt (a mitigation for the `${ctx.last_response}` flow); a negative cap is meaningless. On an agent, `0` (or unset) means no truncation; on a parallel-branch override, `0` (or unset) inherits the target agent's cap. Detection only — dippin carries and lints the field; a runtime enforces the truncation.
+
+```text
+warning[DIP148]: agent "Writer" last_response_truncate is -1; cannot be negative
+```
+
+### DIP149 — Ambiguous routing
+
+**Severity:** Warning
+
+A node has two or more **unconditional** (no `when`) outgoing forward edges. Both are equally eligible, so which one fires is decided only by the routing cascade's lexical tiebreak — the alphabetical order of the target node ID. That is silent action-at-a-distance: renaming a target node can change which edge fires with no other change. Restart/`loop` back-edges are excluded, and `parallel` fan-out and `human` choice gates are exempt. Keep one unconditional edge as the default fallback and guard the others with a `when` condition.
+
+```text
+warning[DIP149]: node "Route" has multiple unconditional outgoing edges; which one fires is decided only by the lexical tiebreak
+```
+
+> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP149) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.


### PR DESCRIPTION
Content-only sync of the hand-maintained surfaces that still described the pre-v0.41.0 language. No `.go` behavior change, no new DIP code, no release. The website redeploys from `main` on merge; the editor extensions publish on their own cadence.

## What changed (8 items)

**A. Website content (`site/content/`)**
1. `validation.md` — `57`→`59` / `47`→`49` diagnostic counts; `DIP101-DIP147`→`DIP101-DIP149` ranges; added `DIP148` + `DIP149` entries in the same format as the adjacent DIP144–147 entries. The page's intentional curated subset (the ~22 historically-omitted older codes) is left as-is.
2. `language.md` — edge signature line now shows `[on <token> | when <condition>] … [loop]`; added **Outcome Shorthand (`on`)** and **Loop Edges** subsections, a `dip N` format-version note in File Structure, and a single-quoted-string note in Conditions.
3. `cli.md` — `--migrate` mention on the `fmt` card.

**B. Editor syntax highlighting**
4. `tree-sitter-dippin/queries/highlights.scm` — added `on`, `loop`, the `dip` version-declaration keyword, and the previously-missing `override` edge attribute. Node names verified against `src/node-types.json`.
5. `zed-dippin/languages/dippin/highlights.scm` — resynced to be byte-identical to the tree-sitter copy (which also pulls in the previously-missing `manager_loop` node-kind/highlight that the hand-kept copy had drifted from). `extension.toml`: commit pin bumped to the v0.41.0 release commit `10cc50f`; extension `version` `0.0.1`→`0.0.2`.
6. `vscode/syntaxes/dippin.tmLanguage.json` — `on`/`loop` edge keywords, a top-of-file `^dip \d+` version pattern, and `override` added to the attribute alternation. `package.json` `version` `0.2.0`→`0.3.0`.

**C. Canonical docs**
7. `docs/cli.md` — `--migrate` flag in the `fmt` section.
8. `docs/GRAMMAR.ebnf` — single-quoted `STRING` alternative with a `single_string_char` production (doubled `''` is the only escape; backslashes literal).

These correspond to the v0.41.0 PRs: #140 (`on`), #143 (`loop`), #144 (DIP149), #148 (`dip N` / `fmt --migrate`), #146 (single-quotes), #139 (edge-attr robustness).

## Scope note (GRAMMAR.ebnf)

`docs/GRAMMAR.ebnf` still omits a formal production for the unknown-attr diagnostic and colon-gated `when`-termination (#139). These are parser **robustness** behaviors, not new accepted grammar surface — EBNF describes accepted syntax rather than error recovery — so they are deliberately out of scope here.

## Verification

- `scripts/pre-commit` passes (build, vet, golangci-lint, gofmt, race tests, releasecheck/spec-freshness, complexity, validate-examples). `scripts/gen-spec.sh` produces zero diff.
- tmLanguage JSON validated with `python3 -m json.tool`.
- tree-sitter queries: every referenced node (`version_decl`, `edge_attr`, `dip`/`on`/`loop`/`override`) is confirmed present in `src/node-types.json`. `npx tree-sitter test` could **not** run in this environment (tree-sitter CLI absent — the known-local red herring); CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784217350&installation_id=131176874&pr_number=150&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F150&signature=0b9303f7619d97055f7f1cc48cb4a72b8751ef3c22d7920234bcf3a88227b3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `dip <number>` format version header (defaults to v1) and `dippin fmt --migrate` to re-emit files in their current format version.
  * Expanded string literals to support single-quoted forms (including doubled `''` for embedded quotes).
  * Enhanced edge syntax with `on <token>` and `loop` (with `restart: true` accepted as a synonym).
* **Documentation**
  * Updated CLI, language reference, and formatting/migration behavior.
* **Validation**
  * Extended semantic warning catalog with **DIP148** and **DIP149** (and broadened semantic lint rule coverage).
* **Chores**
  * Refreshed editor syntax highlighting for the updated language features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->