### PR TITLE
feat(validator): DIP151 soft-deprecation lint for unused weight: (#131)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Editor / agent integrations:
 ```sh
 dippin parse pipeline.dip          # JSON IR
 dippin validate pipeline.dip       # structural errors (DIP001-DIP010)
-dippin lint pipeline.dip           # validation + semantic warnings (DIP101-DIP150)
+dippin lint pipeline.dip           # validation + semantic warnings (DIP101-DIP151)
 dippin format pipeline.dip         # canonical formatting
 dippin doctor pipeline.dip         # A-F health report
 dippin cost pipeline.dip           # per-run cost estimate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistr
 
 ## Lint Rules
 
-60 diagnostic codes: DIP001-DIP010 (structural errors), DIP101-DIP150 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
+61 diagnostic codes: DIP001-DIP010 (structural errors), DIP101-DIP151 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ graph LR
 | Shell scripts | `tool_command="#!/bin/sh\nset -eu\nif..."` | Real multiline, real syntax |
 | Model config | Untyped `llm_model="..."` attribute | Typed `model:` field with validation |
 | Branching | `condition="context.x!=y && context.a==b"` | `when ctx.x != "y" and ctx.a == "b"` |
-| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP150) |
+| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP151) |
 | Node types | Shape overloading (`box`=agent, `hexagon`=human) | Explicit `agent`, `tool`, `human` keywords |
 | Composition | No import/include system | `subgraph` with ref (v2) |
 
@@ -131,7 +131,7 @@ Every analysis command (`validate`, `lint`, `doctor`, `parse`, `cost`, `coverage
 |---------|-------------|
 | `dippin parse <file>` | Parse and output IR as JSON |
 | `dippin validate <file>` | Structural validation (DIP001–DIP010) |
-| `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP150) |
+| `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP151) |
 | `dippin check [--format json\|text] <file>` | Parse+validate+lint in one shot (JSON default, for LLM tooling) |
 | `dippin fmt [--check] [--write] <file>` | Format to canonical style |
 | `dippin new [--name N] [--write F] <template>` | Generate a starter .dip from a template |
@@ -390,7 +390,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 | DIP008 | Duplicate node ID |
 | DIP009 | Duplicate edge |
 
-### Warnings (DIP101–DIP150 — selected; see [docs/validation.md](docs/validation.md) for the full catalog)
+### Warnings (DIP101–DIP151 — selected; see [docs/validation.md](docs/validation.md) for the full catalog)
 
 | Code | What it catches |
 |------|----------------|

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -192,10 +192,10 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-60 diagnostic codes across two categories:
+61 diagnostic codes across two categories:
 
 - **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
-- **DIP101–DIP150** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges), human-gate choice key (label routes without explicit choice)
+- **DIP101–DIP151** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges), human-gate choice key (label routes without explicit choice), edge weight (unused by routing)
 
 ---
 
@@ -565,7 +565,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP150) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP151) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |
@@ -696,6 +696,7 @@ The primary loop for authoring .dip files:
 | DIP147 | A `tool_access: none` agent `writes:` a context key that a downstream tool-bearing agent `reads:` (chain-attack / info-flow) | Confirm the restricted agent's input is trusted; if not, give the consumer `tool_access: none` too or insert a sanitizing step. Detection only — the runtime enforces |
 | DIP149 | A node has 2+ unconditional outgoing edges — which one fires is decided only by the lexical (alphabetical) tiebreak on target node ID | Keep at most one unconditional edge as the default fallback; guard the others with `when`. Restart/`loop` back-edges are exempt |
 | DIP150 | A label-routing `human` gate (mode `choice`, `yes_no`, or unset default) routes an outgoing edge by `label:` with no explicit `choice:` — the label doubles as the routing key, so nothing signals it is load-bearing (Hint). `freeform`/`interview` gates are exempt | Add `choice: "<key>"` to mark the routing key, leaving `label:` for display. `choice:` wins when present; `label:` still routes when it is absent |
+| DIP151 | An edge carries a `weight:` attribute — speculative tier-4 routing priority that the cascade never consults and no real workflow uses. It still parses (carry-only), but the keyword and cascade tier are slated for removal in `dip 2` (Warning) | Remove `weight:`; express priority with conditions — guard edges with `when` / `on`, or rely on a single unconditional fallback |
 
 ## Best Practices
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ dippin-lang/
 │
 ├── validator/          # Graph validation + semantic linting
 │   ├── codes.go        # Error code constants (DIP001–DIP010)
-│   ├── lint_codes.go   # Warning code constants (DIP101–DIP150)
+│   ├── lint_codes.go   # Warning code constants (DIP101–DIP151)
 │   ├── diagnostic.go   # Diagnostic type, Result, Severity
 │   ├── validate.go     # 10 structural checks
 │   ├── lint.go         # Lint orchestration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,7 +124,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 
 ### lint
 
-Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP150).
+Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP151).
 
 ```bash
 dippin lint [--extra-models <spec>] <file>
@@ -132,7 +132,7 @@ dippin lint [--extra-models <spec>] <file>
 
 **Input**: `.dip` or `.dot` file
 
-**Checks**: All 60 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP150) are reported but don't affect the exit code.
+**Checks**: All 61 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP151) are reported but don't affect the exit code.
 
 **Output**: All diagnostics (errors and warnings) to stderr.
 

--- a/docs/edges.md
+++ b/docs/edges.md
@@ -50,7 +50,7 @@ Each edge is a single line:
 | `when` | Condition | No | Boolean guard expression. Edge is only traversed if true at runtime. |
 | `label` | String | No | Human-readable text. Displayed on the edge in DOT exports. Also used for human gate choice matching when no `choice:` is set (see [Choice keys vs display labels](#choice-keys-vs-display-labels)). |
 | `choice` | String | No | Carried, not interpreted by dippin. Explicit human-gate routing key the paired runtime matches the user's selection against; lets `label:` stay display-only. When set it is the routing key; when absent the runtime falls back to `label:`. |
-| `weight` | Integer | No | Priority hint. Higher values win when multiple edges are candidates. |
+| `weight` | Integer | No | **Soft-deprecated.** Parsed but **unused by routing**; slated for removal in `dip 2`. Raises [DIP151](validation.md#dip151-edge-weight-is-unused-by-routing). Historically a priority hint (higher values win when multiple edges are candidates), but the cascade never consults it — guard edges with `when` / `on` instead. |
 | `loop` | Flag | No | Bare keyword marking this as a back-edge that triggers a loop restart. The legacy `restart: true` is an accepted synonym that `dippin fmt` rewrites to `loop`. |
 | `override` | Boolean | No | Carried, not interpreted by dippin. Marks an edge as a human-authored validation override for a paired runtime to act on (e.g. tracker's `validation_overridden` flow); dippin does not assign it any execution semantics. |
 
@@ -136,6 +136,8 @@ explicit key.
 
 ### Weighted Edges
 
+> **Soft-deprecated (raises [DIP151](validation.md#dip151-edge-weight-is-unused-by-routing)).** `weight:` still parses (carry-only — no breakage), but routing never consults it and no real workflow uses it. Both the keyword and the cascade tier are slated for removal in `dip 2`. Express priority with conditions instead — guard edges with `when` / `on`, or rely on a single unconditional fallback. The description below is retained for historical context.
+
 Weight provides a priority hint when multiple edges compete:
 
 ```dippin
@@ -180,7 +182,7 @@ When a node completes, the engine selects the next edge using this cascade (firs
 | 1 | **Condition match** | First edge whose `when` condition evaluates to true |
 | 2 | **Handler preference** | Edge whose label matches the node's `PreferredLabel` from its outcome |
 | 3 | **Handler suggestion** | Edge leading to a node in the handler's `SuggestedNextNodes` |
-| 4 | **Weight** | Highest `weight` value among remaining edges |
+| 4 | **Weight** | _Soft-deprecated ([DIP151](validation.md#dip151-edge-weight-is-unused-by-routing)) — parsed but unused by routing; slated for removal in `dip 2`._ Historically: highest `weight` value among remaining edges |
 | 5 | **Lexical** | Alphabetically first by target node ID |
 
 This means conditions always take precedence over labels, and labels over weights. The lexical fallback ensures deterministic behavior.
@@ -361,6 +363,8 @@ graph LR
 ```
 
 ### Weighted fallback
+
+> **Soft-deprecated ([DIP151](validation.md#dip151-edge-weight-is-unused-by-routing)).** `weight:` is parsed but unused by routing and slated for removal in `dip 2`. Prefer conditions / `on` or a single unconditional fallback. Shown here for historical context.
 
 ```mermaid
 graph LR

--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -18,7 +18,7 @@ This starts the server on stdio (stdin/stdout), speaking JSON-RPC 2.0 per the LS
 
 | Feature | Description |
 |---------|-------------|
-| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP150 semantic) |
+| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP151 semantic) |
 | **Hover** | Tooltip showing node kind, model, provider, prompt preview, and field summary |
 | **Go-to-definition** | Jump from a node reference in an edge to the node's declaration |
 | **Autocomplete** | Node IDs in edges, field names within node blocks, keywords |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -111,7 +111,7 @@ if result.HasErrors() {
     }
 }
 
-// Semantic lint (DIP101–DIP150; DIP146 is CLI/cross-file only) — warnings
+// Semantic lint (DIP101–DIP151; DIP146 is CLI/cross-file only) — warnings
 lintResult := validator.Lint(workflow)
 for _, d := range lintResult.Diagnostics {
     fmt.Println(d.String())

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -190,7 +190,7 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-60 diagnostic codes across two categories:
+61 diagnostic codes across two categories:
 
 - **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
-- **DIP101–DIP150** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges), human-gate choice key (label routes without explicit choice)
+- **DIP101–DIP151** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges), human-gate choice key (label routes without explicit choice), edge weight (unused by routing)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,9 +1,9 @@
 # Validation and Linting Reference
 
-Dippin registers 60 diagnostic codes split into two categories; this page gives a dedicated section to every code except `DIP138`, which is reserved and has no firing logic (59 documented sections):
+Dippin registers 61 diagnostic codes split into two categories; this page gives a dedicated section to every code except `DIP138`, which is reserved and has no firing logic (60 documented sections):
 
 - **Structural validation** (DIP001–DIP010): Errors that **must** be fixed. A workflow with any of these cannot execute.
-- **Semantic linting** (DIP101–DIP150): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
+- **Semantic linting** (DIP101–DIP151): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
 
 Run `dippin validate <file>` for structural checks only, or `dippin lint <file>` for both.
 
@@ -12,7 +12,7 @@ graph LR
     SRC[".dip file"] --> PARSE["Parser"]
     PARSE --> IR["IR"]
     IR --> VAL["Structural Validation<br>DIP001–DIP010<br>(errors)"]
-    IR --> LINT["Semantic Linting<br>DIP101–DIP150<br>(warnings)"]
+    IR --> LINT["Semantic Linting<br>DIP101–DIP151<br>(warnings)"]
     VAL --> DIAG["Diagnostics"]
     LINT --> DIAG
 ```
@@ -248,7 +248,7 @@ lints (DIP103/DIP120/DIP121/DIP122), so one bad condition no longer masks the re
 
 ---
 
-## Semantic Lint Warnings (DIP101–DIP150)
+## Semantic Lint Warnings (DIP101–DIP151)
 
 ### DIP101: Node Only Reachable via Conditional Edges
 
@@ -1338,6 +1338,30 @@ existing human-choice workflows route unchanged. See
 
 ---
 
+### DIP151: Edge weight is unused by routing
+
+**Severity**: Warning
+
+An edge carries a `weight:` attribute. `weight:` was tier 4 of the 5-level
+routing cascade — a speculative priority hint meant to break ties when conditions
+and labels don't resolve a choice. In practice the cascade never consults it and
+no real workflow uses it. The keyword still **parses** (carry-only, no breakage
+in Phase 0), but both the keyword and the cascade tier are slated for removal
+under `dip 2`. This warning is the soft-deprecation signal.
+
+```text
+warning[DIP151]: edge "Route" -> "A" sets weight: 5, which routing does not use; guard edges with when / on or rely on a single unconditional fallback instead
+```
+
+**Trigger:** Any edge with a non-zero `weight:` value (`weight:` defaults to 0
+when unset). One diagnostic per offending edge.
+
+**Fix:** Remove `weight:`. Express edge priority with conditions instead — guard
+edges with `when` / `on`, or rely on a single unconditional fallback to make
+routing explicit and deterministic.
+
+---
+
 ## Running Validation
 
 ### Structural validation only
@@ -1354,7 +1378,7 @@ Runs DIP001–DIP010. Exit code 0 if all pass, 1 if any errors.
 dippin lint pipeline.dip
 ```
 
-Runs all DIP001–DIP010 errors and DIP101–DIP150 warnings. Exit code 1 only for errors; warnings alone exit 0.
+Runs all DIP001–DIP010 errors and DIP101–DIP151 warnings. Exit code 1 only for errors; warnings alone exit 0.
 
 ### JSON output for CI
 

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -56,7 +56,7 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 <div class="cmd-card">
   <h3>lint</h3>
   <div class="cmd-usage">dippin lint [--extra-models &lt;spec&gt;] &lt;file&gt;</div>
-  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP150). All 60 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
+  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP151). All 61 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
   <dl>
     <dt><code>--extra-models "provider:model1,model2;provider2:model3"</code></dt>
     <dd>Extend the DIP108 model catalog at runtime for private or newly-released models.</dd>

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -1,8 +1,8 @@
 ---
 title: "Validation & Linting"
-description: "60 diagnostic codes for AI pipeline workflows. 10 structural errors and 50 semantic warnings catch bugs before runtime."
+description: "61 diagnostic codes for AI pipeline workflows. 10 structural errors and 51 semantic warnings catch bugs before runtime."
 section_label: "Diagnostics"
-subtitle: "60 diagnostic codes — 10 structural errors and 50 semantic warnings — to catch problems before runtime."
+subtitle: "61 diagnostic codes — 10 structural errors and 51 semantic warnings — to catch problems before runtime."
 ---
 
 ## Overview
@@ -11,7 +11,7 @@ Dippin provides two levels of analysis:
 
 **Structural validation** (DIP001-DIP010): Errors that must be fixed. A workflow with any of these cannot execute. Run with `dippin validate`.
 
-**Semantic linting** (DIP101-DIP150): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
+**Semantic linting** (DIP101-DIP151): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
 
 ### Diagnostic Format
 
@@ -107,7 +107,7 @@ These must be fixed for a workflow to be valid. Each causes exit code 1.
   = help: valid operators: = == != contains startswith endswith in</pre>
 </div>
 
-## Semantic Warnings (DIP101-DIP150)
+## Semantic Warnings (DIP101-DIP151)
 
 These flag likely bugs or questionable patterns. Warnings alone exit 0.
 
@@ -338,4 +338,14 @@ An outgoing edge from a **label-routing** `human` node (mode `choice`, `yes_no`,
 hint[DIP150]: human gate "Approve" routes by label "yes"; use choice: "yes" to mark the routing key (label: stays for display)
 ```
 
-> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP150) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.
+### DIP151 — Edge weight is unused by routing
+
+**Severity:** Warning
+
+An edge carries a `weight:` attribute. `weight:` was tier 4 of the routing cascade — a speculative priority hint — but the cascade never consults it and no real workflow uses it. It still **parses** (carry-only, no breakage in Phase 0), but both the keyword and the cascade tier are slated for removal under `dip 2`. Remove `weight:` and express priority with conditions instead — guard edges with `when` / `on`, or rely on a single unconditional fallback.
+
+```text
+warning[DIP151]: edge "Route" -> "A" sets weight: 5, which routing does not use; guard edges with when / on or rely on a single unconditional fallback instead
+```
+
+> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP151) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -383,7 +383,7 @@ Use `dippin help` (not `--help`) to see all commands.
 |---------|---------|
 | `dippin parse <file>` | Output IR as JSON |
 | `dippin validate <file>` | Structural checks only (DIP001-DIP010) |
-| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP150) |
+| `dippin lint <file>` | Full validation + semantic warnings (DIP001–DIP151) |
 | `dippin check <file>` | All-in-one. JSON output by default — **use this for automated workflows** |
 | `dippin fmt <file>` | Print canonical format to stdout |
 | `dippin fmt --check <file>` | Exit 1 if not formatted |
@@ -514,6 +514,7 @@ The primary loop for authoring .dip files:
 | DIP147 | A `tool_access: none` agent `writes:` a context key that a downstream tool-bearing agent `reads:` (chain-attack / info-flow) | Confirm the restricted agent's input is trusted; if not, give the consumer `tool_access: none` too or insert a sanitizing step. Detection only — the runtime enforces |
 | DIP149 | A node has 2+ unconditional outgoing edges — which one fires is decided only by the lexical (alphabetical) tiebreak on target node ID | Keep at most one unconditional edge as the default fallback; guard the others with `when`. Restart/`loop` back-edges are exempt |
 | DIP150 | A label-routing `human` gate (mode `choice`, `yes_no`, or unset default) routes an outgoing edge by `label:` with no explicit `choice:` — the label doubles as the routing key, so nothing signals it is load-bearing (Hint). `freeform`/`interview` gates are exempt | Add `choice: "<key>"` to mark the routing key, leaving `label:` for display. `choice:` wins when present; `label:` still routes when it is absent |
+| DIP151 | An edge carries a `weight:` attribute — speculative tier-4 routing priority that the cascade never consults and no real workflow uses. It still parses (carry-only), but the keyword and cascade tier are slated for removal in `dip 2` (Warning) | Remove `weight:`; express priority with conditions — guard edges with `when` / `on`, or rely on a single unconditional fallback |
 
 ## Best Practices
 

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -166,6 +166,13 @@ func reachabilityExplanations() map[string]Explanation {
 			Fix:     "Add choice: \"<key>\" to mark the routing key explicitly, leaving label: for display. choice: wins when present; label: still routes when choice: is absent (Phase 0 fallback).",
 			Example: "human Approve\n  mode: choice\nApprove -> Ship label: \"yes\"  // DIP150: add choice: \"yes\" to mark the routing key",
 		},
+		DIP151: {
+			Code:    DIP151,
+			Summary: "edge weight: is unused by routing (soft-deprecated)",
+			Trigger: "An edge carries a `weight:` attribute. weight: was tier 4 of the routing cascade — a speculative priority hint — but the cascade never consults it, and no real workflow uses it. It still parses (carry-only, no breakage), but the keyword and the cascade tier are slated for removal under `dip 2`.",
+			Fix:     "Remove weight:. Express edge priority with conditions instead — guard edges with `when` / `on`, or rely on a single unconditional fallback to make routing explicit.",
+			Example: "agent Route\n  prompt: \"decide\"\nRoute -> A weight: 5  // DIP151: weight: is unused by routing; guard with when or drop it\nRoute -> B",
+		},
 	}
 }
 

--- a/validator/lint.go
+++ b/validator/lint.go
@@ -5,7 +5,7 @@ import (
 	"github.com/2389-research/dippin-lang/simulate"
 )
 
-// Lint runs all semantic quality checks (DIP101–DIP150, except DIP146 — which
+// Lint runs all semantic quality checks (DIP101–DIP151, except DIP146 — which
 // the CLI's cross-file pass emits, not this function) on the workflow
 // and returns all diagnostics found. These are warnings, not errors —
 // the workflow can still execute, but the findings indicate likely bugs
@@ -95,6 +95,7 @@ func LintWithOptions(w *ir.Workflow, opts Options) Result {
 	diags = append(diags, lintChainAttack(w)...)
 	diags = append(diags, lintLastResponseTruncate(w)...)
 	diags = append(diags, lintAmbiguousRouting(w)...)
+	diags = append(diags, lintUnusedWeight(w)...)
 
 	return Result{Diagnostics: diags}
 }

--- a/validator/lint_codes.go
+++ b/validator/lint_codes.go
@@ -1,6 +1,6 @@
 package validator
 
-// Diagnostic codes for semantic quality warnings (DIP101–DIP150).
+// Diagnostic codes for semantic quality warnings (DIP101–DIP151).
 const (
 	DIP101 = "DIP101" // unreachable nodes after conditional branches
 	DIP102 = "DIP102" // routing node without default/unconditional edge
@@ -55,58 +55,66 @@ const (
 	DIP148 = "DIP148" // last_response_truncate is negative
 	DIP149 = "DIP149" // ambiguous routing: 2+ unconditional outgoing edges resolved only by the lexical tiebreak
 	DIP150 = "DIP150" // human gate routes by label: which doubles as the routing key — use choice: to mark it explicitly
+	DIP151 = "DIP151" // edge sets weight: which routing does not use (soft-deprecated, slated for removal in dip 2)
 )
 
 func init() {
 	// Extend CodeDescription with linter codes.
-	CodeDescription[DIP101] = "unreachable node after conditional branches"
-	CodeDescription[DIP102] = "routing node has no default/unconditional edge"
-	CodeDescription[DIP103] = "overlapping or contradictory conditions"
-	CodeDescription[DIP104] = "unbounded retry loop (no max_retries or fallback)"
-	CodeDescription[DIP105] = "no success path from start to exit"
-	CodeDescription[DIP106] = "undefined variable reference in prompt"
-	CodeDescription[DIP107] = "unused context key (written but never read)"
-	CodeDescription[DIP108] = "unknown model/provider combination"
-	CodeDescription[DIP109] = "namespace collision in imports"
-	CodeDescription[DIP110] = "empty prompt on agent node"
-	CodeDescription[DIP111] = "tool command has no timeout"
-	CodeDescription[DIP112] = "reads key not produced by any upstream writes"
-	CodeDescription[DIP113] = "invalid retry policy name"
-	CodeDescription[DIP114] = "invalid fidelity level"
-	CodeDescription[DIP115] = "goal_gate node without retry or fallback target"
-	CodeDescription[DIP116] = "invalid compaction threshold or on_resume value"
-	CodeDescription[DIP117] = "stylesheet class references undefined class"
-	CodeDescription[DIP118] = "stylesheet ID references unknown node"
-	CodeDescription[DIP119] = "invalid reasoning_effort value"
-	CodeDescription[DIP120] = "condition variable missing namespace prefix"
-	CodeDescription[DIP121] = "condition references variable not in source node writes"
-	CodeDescription[DIP122] = "condition tests value not in source tool outputs"
-	CodeDescription[DIP123] = "tool command has shell syntax errors"
-	CodeDescription[DIP124] = "tool command references runtime-only ${ctx.*} variable"
-	CodeDescription[DIP125] = "tool command binary not found on PATH"
-	CodeDescription[DIP126] = "subgraph ref file does not exist"
-	CodeDescription[DIP127] = "invalid human node mode"
-	CodeDescription[DIP128] = "interview mode with meaningless default value"
-	CodeDescription[DIP129] = "interview mode with conflicting choice-style edges"
-	CodeDescription[DIP130] = "invalid response_format value or on non-agent node"
-	CodeDescription[DIP131] = "response_schema and response_format mismatch"
-	CodeDescription[DIP132] = "response_schema is not valid JSON"
-	CodeDescription[DIP133] = "agent params key shadows a first-class field"
-	CodeDescription[DIP134] = "max_retries set in defaults with restart edges but no max_restarts — did you mean max_restarts?"
-	CodeDescription[DIP135] = "manager_loop subgraph_ref missing or file does not exist"
-	CodeDescription[DIP136] = "manager_loop control field has invalid value (poll_interval or max_cycles)"
-	CodeDescription[DIP137] = "unbounded manager_loop: no stop_condition and no max_cycles"
-	CodeDescription[DIP138] = "tool node routes on stdout but declares no marker_grep / outputs"
-	CodeDescription[DIP139] = "invalid tool_access value on agent node or parallel branch"
-	CodeDescription[DIP140] = "params re-enables tools that tool_access strips"
-	CodeDescription[DIP141] = "writable_paths nullified by tool_access: none (dead config)"
-	CodeDescription[DIP142] = "unsafe writable_paths entry (absolute / ~ / parent-escape / brace)"
-	CodeDescription[DIP143] = "referenced subgraph does not inherit this workflow's tool_access restrictions"
-	CodeDescription[DIP144] = "agent node has no failure route"
-	CodeDescription[DIP145] = "graph budget default is negative"
-	CodeDescription[DIP146] = "child subgraph re-grants tools the parent restricted (cross-file)"
-	CodeDescription[DIP147] = "restricted agent output flows into a tool-bearing agent (chain-attack)"
-	CodeDescription[DIP148] = "last_response_truncate is negative"
-	CodeDescription[DIP149] = "ambiguous routing: multiple unconditional outgoing edges"
-	CodeDescription[DIP150] = "human gate routes by label; use choice: to mark the routing key"
+	for code, desc := range linterCodeDescriptions {
+		CodeDescription[code] = desc
+	}
+}
+
+var linterCodeDescriptions = map[string]string{
+	DIP101: "unreachable node after conditional branches",
+	DIP102: "routing node has no default/unconditional edge",
+	DIP103: "overlapping or contradictory conditions",
+	DIP104: "unbounded retry loop (no max_retries or fallback)",
+	DIP105: "no success path from start to exit",
+	DIP106: "undefined variable reference in prompt",
+	DIP107: "unused context key (written but never read)",
+	DIP108: "unknown model/provider combination",
+	DIP109: "namespace collision in imports",
+	DIP110: "empty prompt on agent node",
+	DIP111: "tool command has no timeout",
+	DIP112: "reads key not produced by any upstream writes",
+	DIP113: "invalid retry policy name",
+	DIP114: "invalid fidelity level",
+	DIP115: "goal_gate node without retry or fallback target",
+	DIP116: "invalid compaction threshold or on_resume value",
+	DIP117: "stylesheet class references undefined class",
+	DIP118: "stylesheet ID references unknown node",
+	DIP119: "invalid reasoning_effort value",
+	DIP120: "condition variable missing namespace prefix",
+	DIP121: "condition references variable not in source node writes",
+	DIP122: "condition tests value not in source tool outputs",
+	DIP123: "tool command has shell syntax errors",
+	DIP124: "tool command references runtime-only ${ctx.*} variable",
+	DIP125: "tool command binary not found on PATH",
+	DIP126: "subgraph ref file does not exist",
+	DIP127: "invalid human node mode",
+	DIP128: "interview mode with meaningless default value",
+	DIP129: "interview mode with conflicting choice-style edges",
+	DIP130: "invalid response_format value or on non-agent node",
+	DIP131: "response_schema and response_format mismatch",
+	DIP132: "response_schema is not valid JSON",
+	DIP133: "agent params key shadows a first-class field",
+	DIP134: "max_retries set in defaults with restart edges but no max_restarts — did you mean max_restarts?",
+	DIP135: "manager_loop subgraph_ref missing or file does not exist",
+	DIP136: "manager_loop control field has invalid value (poll_interval or max_cycles)",
+	DIP137: "unbounded manager_loop: no stop_condition and no max_cycles",
+	DIP138: "tool node routes on stdout but declares no marker_grep / outputs",
+	DIP139: "invalid tool_access value on agent node or parallel branch",
+	DIP140: "params re-enables tools that tool_access strips",
+	DIP141: "writable_paths nullified by tool_access: none (dead config)",
+	DIP142: "unsafe writable_paths entry (absolute / ~ / parent-escape / brace)",
+	DIP143: "referenced subgraph does not inherit this workflow's tool_access restrictions",
+	DIP144: "agent node has no failure route",
+	DIP145: "graph budget default is negative",
+	DIP146: "child subgraph re-grants tools the parent restricted (cross-file)",
+	DIP147: "restricted agent output flows into a tool-bearing agent (chain-attack)",
+	DIP148: "last_response_truncate is negative",
+	DIP149: "ambiguous routing: multiple unconditional outgoing edges",
+	DIP150: "human gate routes by label; use choice: to mark the routing key",
+	DIP151: "edge weight: is unused by routing (soft-deprecated)",
 }

--- a/validator/lint_routing.go
+++ b/validator/lint_routing.go
@@ -69,6 +69,29 @@ func checkAmbiguousRouting(n *ir.Node, edges []*ir.Edge) (Diagnostic, bool) {
 	}, true
 }
 
+// lintUnusedWeight checks DIP151: an edge carrying a `weight:` attribute. The
+// routing cascade does not consult weights, so the keyword is dead machinery —
+// speculative tier-4 priority that no real workflow uses. weight: still parses
+// (carry-only, no breakage in Phase 0), but the keyword and the cascade tier are
+// slated for removal under `dip 2`. The lint steers authors toward conditions,
+// `on`, or a single unconditional fallback before that removal lands.
+func lintUnusedWeight(w *ir.Workflow) []Diagnostic {
+	var diags []Diagnostic
+	for _, e := range w.Edges {
+		if e.Weight == 0 {
+			continue
+		}
+		diags = append(diags, Diagnostic{
+			Code:     DIP151,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("edge %q -> %q sets weight: %d, which routing does not use; guard edges with when / on or rely on a single unconditional fallback instead", e.From, e.To, e.Weight),
+			Location: e.Source,
+			Help:     "weight: is parsed but unused by routing and is slated for removal in dip 2; remove it or express priority with conditions",
+		})
+	}
+	return diags
+}
+
 // countUnconditionalForwardEdges counts edges with no condition that are not
 // restart back-edges.
 func countUnconditionalForwardEdges(edges []*ir.Edge) int {

--- a/validator/lint_weight_test.go
+++ b/validator/lint_weight_test.go
@@ -16,8 +16,9 @@ func TestLint_DIP151_WeightFires(t *testing.T) {
   edges
     A -> B weight: 5
 `
-	if !hasCode(lintSrc(t, src), DIP151) {
-		t.Errorf("expected DIP151, got: %v", codes(lintSrc(t, src)))
+	diags := lintSrc(t, src)
+	if !hasCode(diags, DIP151) {
+		t.Errorf("expected DIP151, got: %v", codes(diags))
 	}
 }
 
@@ -35,8 +36,9 @@ func TestLint_DIP151_NoWeightSilent(t *testing.T) {
   edges
     A -> B
 `
-	if hasCode(lintSrc(t, src), DIP151) {
-		t.Errorf("did not expect DIP151, got: %v", codes(lintSrc(t, src)))
+	diags := lintSrc(t, src)
+	if hasCode(diags, DIP151) {
+		t.Errorf("did not expect DIP151, got: %v", codes(diags))
 	}
 }
 
@@ -59,13 +61,14 @@ func TestLint_DIP151_TwoWeightedEdgesTwoDiagnostics(t *testing.T) {
     A -> C weight: 5
     B -> C
 `
+	diags := lintSrc(t, src)
 	n := 0
-	for _, d := range lintSrc(t, src) {
+	for _, d := range diags {
 		if d.Code == DIP151 {
 			n++
 		}
 	}
 	if n != 2 {
-		t.Errorf("expected 2 DIP151 diagnostics, got %d: %v", n, codes(lintSrc(t, src)))
+		t.Errorf("expected 2 DIP151 diagnostics, got %d: %v", n, codes(diags))
 	}
 }

--- a/validator/lint_weight_test.go
+++ b/validator/lint_weight_test.go
@@ -1,0 +1,71 @@
+package validator
+
+import "testing"
+
+func TestLint_DIP151_WeightFires(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: B
+
+  agent A
+    prompt: "decide"
+
+  agent B
+    prompt: "done"
+
+  edges
+    A -> B weight: 5
+`
+	if !hasCode(lintSrc(t, src), DIP151) {
+		t.Errorf("expected DIP151, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP151_NoWeightSilent(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: B
+
+  agent A
+    prompt: "decide"
+
+  agent B
+    prompt: "done"
+
+  edges
+    A -> B
+`
+	if hasCode(lintSrc(t, src), DIP151) {
+		t.Errorf("did not expect DIP151, got: %v", codes(lintSrc(t, src)))
+	}
+}
+
+func TestLint_DIP151_TwoWeightedEdgesTwoDiagnostics(t *testing.T) {
+	src := `workflow X
+  start: A
+  exit: C
+
+  agent A
+    prompt: "decide"
+
+  agent B
+    prompt: "b"
+
+  agent C
+    prompt: "c"
+
+  edges
+    A -> B weight: 10
+    A -> C weight: 5
+    B -> C
+`
+	n := 0
+	for _, d := range lintSrc(t, src) {
+		if d.Code == DIP151 {
+			n++
+		}
+	}
+	if n != 2 {
+		t.Errorf("expected 2 DIP151 diagnostics, got %d: %v", n, codes(lintSrc(t, src)))
+	}
+}


### PR DESCRIPTION
## Summary

Completes **Phase 0** of epic #127 by adding **DIP151** (Warning), the soft-deprecation signal for the `weight:` edge attribute. `weight:` was tier 4 of the 5-level routing cascade — a speculative priority hint — but the cascade never consults it and **no real workflow uses it** (`grep -rl "weight:" examples/` finds only docs). The lint steers authors toward conditions / `on` / a single unconditional fallback before the keyword is removed.

**Carry-only / no breakage:** `weight:` still parses exactly as before; dippin only now *warns*. Removing the keyword and the cascade tier is **deferred to `dip 2` (#134)**, out of scope here.

## Lint

- **Severity:** Warning (per #131's "Lint warns (not errors)" acceptance criterion).
- **Trigger:** any edge with `Weight != 0`. One diagnostic per offending edge, located at `e.Source`.
- Surfaces in lint / check / watch / doctor (it's in `validator.Lint`, which all four call).

## Edit sites

- `validator/lint_routing.go` — `lintUnusedWeight` (mirrors DIP149's style)
- `validator/lint.go` — register the lint; bump `Lint` doc-comment range
- `validator/lint_codes.go` — `DIP151` const + description; range comment; `init()` converted to a map merge to stay under `funlen` (51 entries now)
- `validator/explanations.go` — `DIP151` explanation (all four fields → parity tests green)
- `validator/lint_weight_test.go` — parser-driven tests (fires / silent / two weighted edges)
- `docs/{validation,edges,llm-reference}.md`, `site/content/validation.md`, `site/static/skill.md` — DIP151 sections/rows + `weight:` deprecation notes
- count/range sweep: **61 codes / 51 semantic warnings / DIP101–DIP151 / 60 documented sections**
- `cmd/dippin/generated-spec.md` — regenerated via `scripts/gen-spec.sh`

## Verification

`bash scripts/pre-commit` ends with `all checks passed` (build, vet, golangci-lint, ≤5 cyclo / ≤7 cognitive, gofmt, race tests, releasecheck, validate-examples, gen-spec regen).

Closes #131. Part of epic #127. Keyword + cascade-tier removal deferred to `dip 2` (#134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784233894&installation_id=131176874&pr_number=152&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F152&signature=d0af459f95e02a9de6fa8eb2136a283f8492f725dadbe2e36cda38fd430eec1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->