### PR TITLE
cleanup: dedupe simulate event-construction and lowercase+substring-match loops

### DIFF
--- a/optimize/prompt.go
+++ b/optimize/prompt.go
@@ -43,6 +43,17 @@ var complexityIndicators = []complexityIndicator{
 	{keywordCounter([]string{"code", "implement", "refactor", "debug", "architect"}, 4)},
 }
 
+// containsAny reports whether the lowercased s contains any of subs as a substring.
+func containsAny(s string, subs []string) bool {
+	lower := strings.ToLower(s)
+	for _, sub := range subs {
+		if strings.Contains(lower, sub) {
+			return true
+		}
+	}
+	return false
+}
+
 // keywordCounter returns a scoring function that adds points per keyword match.
 func keywordCounter(keywords []string, points int) func(string) int {
 	return func(prompt string) int {
@@ -59,35 +70,17 @@ func keywordCounter(keywords []string, points int) func(string) int {
 
 // isExpensiveModel returns true for high-tier models.
 func isExpensiveModel(model string) bool {
-	lower := strings.ToLower(model)
-	for _, pattern := range expensiveModels {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-	return false
+	return containsAny(model, expensiveModels)
 }
 
 // isCheapModel returns true for budget-tier models.
 func isCheapModel(model string) bool {
-	lower := strings.ToLower(model)
-	for _, pattern := range cheapModels {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-	return false
+	return containsAny(model, cheapModels)
 }
 
 // isBookkeepingPrompt detects prompts that are simple bookkeeping tasks.
 func isBookkeepingPrompt(prompt string) bool {
-	lower := strings.ToLower(prompt)
-	for _, kw := range bookkeepingKeywords {
-		if strings.Contains(lower, kw) {
-			return true
-		}
-	}
-	return false
+	return containsAny(prompt, bookkeepingKeywords)
 }
 
 // suggestCheaperModel returns a budget model for the given provider.

--- a/simulate/events.go
+++ b/simulate/events.go
@@ -38,44 +38,73 @@ func populateEnterFields(evt *event.NodeEnter, node *ir.Node, w *ir.Workflow) {
 	}
 }
 
-func (s *simulator) emitEdgeTraverse(e *ir.Edge) {
-	evt := event.EdgeTraverse{
-		Event:     event.TypeEdgeTraverse,
-		From:      e.From,
-		To:        e.To,
-		Label:     e.Label,
-		Restart:   e.Restart,
+// buildPipelineStartEvent constructs a PipelineStart event.
+func buildPipelineStartEvent(runID, workflowName string) event.PipelineStart {
+	return event.PipelineStart{
+		Event:     event.TypePipelineStart,
+		RunID:     runID,
+		Workflow:  workflowName,
 		Timestamp: event.Now(),
 	}
-	if e.Condition != nil {
-		evt.Condition = e.Condition.Raw
-	}
-	s.emit(evt)
 }
 
-// emitFanOutIn handles parallel and fan-in nodes, returning true if the node was handled.
-func (s *simulator) emitFanOutIn(node *ir.Node, enterEvt event.NodeEnter) bool {
+// buildPipelineEndEvent constructs a PipelineEnd event.
+func buildPipelineEndEvent(status string, nodesVisited int) event.PipelineEnd {
+	return event.PipelineEnd{
+		Event:        event.TypePipelineEnd,
+		Status:       status,
+		NodesVisited: nodesVisited,
+		Timestamp:    event.Now(),
+	}
+}
+
+// newNodeExitSuccess constructs a successful NodeExit event for a node.
+func newNodeExitSuccess(nodeID string) event.NodeExit {
+	return event.NodeExit{
+		Event:      event.TypeNodeExit,
+		Node:       nodeID,
+		Status:     "success",
+		DurationMs: 0,
+		Timestamp:  event.Now(),
+	}
+}
+
+// buildNodeEventSequence returns the ordered events for visiting a node:
+// the node_enter event, any kind-specific parallel/fan-in event, and the
+// trailing successful node_exit. Used by both the single-path simulator and
+// the all-paths enumerator so they emit identical sequences.
+func buildNodeEventSequence(node *ir.Node, enterEvt event.NodeEnter) []event.Event {
+	events := []event.Event{enterEvt}
 	switch cfg := node.Config.(type) {
 	case ir.ParallelConfig:
-		s.emit(enterEvt)
-		s.emit(event.ParallelStart{
+		events = append(events, event.ParallelStart{
 			Event: event.TypeParallelStart, Node: node.ID,
 			Targets: cfg.Targets, Timestamp: event.Now(),
 		})
 	case ir.FanInConfig:
-		s.emit(enterEvt)
-		s.emit(event.ParallelEnd{
+		events = append(events, event.ParallelEnd{
 			Event: event.TypeParallelEnd, Node: node.ID,
 			Sources: cfg.Sources, Timestamp: event.Now(),
 		})
+	}
+	return append(events, newNodeExitSuccess(node.ID))
+}
+
+func (s *simulator) emitEdgeTraverse(e *ir.Edge) {
+	s.emit(buildEdgeTraverseEvent(e))
+}
+
+// emitFanOutIn handles parallel and fan-in nodes, returning true if the node was handled.
+func (s *simulator) emitFanOutIn(node *ir.Node, enterEvt event.NodeEnter) bool {
+	switch node.Config.(type) {
+	case ir.ParallelConfig, ir.FanInConfig:
+		for _, evt := range buildNodeEventSequence(node, enterEvt) {
+			s.emit(evt)
+		}
+		return true
 	default:
 		return false
 	}
-	s.emit(event.NodeExit{
-		Event: event.TypeNodeExit, Node: node.ID,
-		Status: "success", DurationMs: 0, Timestamp: event.Now(),
-	})
-	return true
 }
 
 func resolveModel(nodeModel, defaultModel string) string {

--- a/simulate/path_enumerator.go
+++ b/simulate/path_enumerator.go
@@ -137,12 +137,7 @@ func (pe *pathEnumerator) cloneState(state *pathState) (map[string]string, map[s
 
 	// At the root of the traversal (no events yet), add PipelineStart.
 	if len(events) == 0 {
-		events = append(events, event.PipelineStart{
-			Event:     event.TypePipelineStart,
-			RunID:     "sim-path-pending",
-			Workflow:  pe.workflow.Name,
-			Timestamp: event.Now(),
-		})
+		events = append(events, buildPipelineStartEvent("sim-path-pending", pe.workflow.Name))
 	}
 
 	return ctx, visited, events, path
@@ -151,39 +146,12 @@ func (pe *pathEnumerator) cloneState(state *pathState) (map[string]string, map[s
 // appendNodeEvents adds the node_enter (with kind-specific events) and node_exit events.
 func (pe *pathEnumerator) appendNodeEvents(node *ir.Node, events []event.Event) []event.Event {
 	enterEvt := buildNodeEnterEvent(node, pe.workflow)
-
-	switch cfg := node.Config.(type) {
-	case ir.ParallelConfig:
-		events = append(events, enterEvt)
-		events = append(events, event.ParallelStart{
-			Event: event.TypeParallelStart, Node: node.ID,
-			Targets: cfg.Targets, Timestamp: event.Now(),
-		})
-	case ir.FanInConfig:
-		events = append(events, enterEvt)
-		events = append(events, event.ParallelEnd{
-			Event: event.TypeParallelEnd, Node: node.ID,
-			Sources: cfg.Sources, Timestamp: event.Now(),
-		})
-	default:
-		events = append(events, enterEvt)
-	}
-
-	events = append(events, event.NodeExit{
-		Event: event.TypeNodeExit, Node: node.ID,
-		Status: "success", DurationMs: 0, Timestamp: event.Now(),
-	})
-	return events
+	return append(events, buildNodeEventSequence(node, enterEvt)...)
 }
 
 // recordPath records a completed or dead-end path as a result.
 func (pe *pathEnumerator) recordPath(events []event.Event, visited map[string]int, path []string, status string) {
-	events = append(events, event.PipelineEnd{
-		Event:        event.TypePipelineEnd,
-		Status:       status,
-		NodesVisited: len(visited),
-		Timestamp:    event.Now(),
-	})
+	events = append(events, buildPipelineEndEvent(status, len(visited)))
 	pe.pathCount++
 	events = assignRunID(events, fmt.Sprintf("sim-path-%03d", pe.pathCount))
 	pe.results = append(pe.results, &Result{

--- a/simulate/simulate.go
+++ b/simulate/simulate.go
@@ -148,12 +148,7 @@ const maxSteps = 500 // safety valve against infinite loops
 func (s *simulator) run() (*Result, error) {
 	runID := generateRunID()
 
-	s.emit(event.PipelineStart{
-		Event:     event.TypePipelineStart,
-		RunID:     runID,
-		Workflow:  s.workflow.Name,
-		Timestamp: event.Now(),
-	})
+	s.emit(buildPipelineStartEvent(runID, s.workflow.Name))
 
 	current := s.workflow.Start
 	for s.steps < maxSteps {
@@ -208,12 +203,7 @@ func (s *simulator) advanceToNext(node *ir.Node) (string, *Result, error) {
 
 // finishRun emits a PipelineEnd event and returns the final Result.
 func (s *simulator) finishRun(status string) *Result {
-	s.emit(event.PipelineEnd{
-		Event:        event.TypePipelineEnd,
-		Status:       status,
-		NodesVisited: len(s.visited),
-		Timestamp:    event.Now(),
-	})
+	s.emit(buildPipelineEndEvent(status, len(s.visited)))
 	return &Result{
 		Events:       s.events,
 		NodesVisited: len(s.visited),
@@ -243,13 +233,7 @@ func (s *simulator) visitNode(node *ir.Node) error {
 		return err
 	}
 
-	s.emit(event.NodeExit{
-		Event:      event.TypeNodeExit,
-		Node:       node.ID,
-		Status:     "success",
-		DurationMs: 0,
-		Timestamp:  event.Now(),
-	})
+	s.emit(newNodeExitSuccess(node.ID))
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Pure internal refactor removing two duplication patterns called out in #162.

**1. Shared simulate event factories.** Added `buildPipelineStartEvent`, `buildPipelineEndEvent`, `newNodeExitSuccess`, and `buildNodeEventSequence` to `simulate/events.go`. Both the single-path simulator and the all-paths enumerator now route through them, so the two paths can no longer drift in the event schemas they emit (a field added to one `PipelineEnd` literal but not its twin would previously diverge with no compiler error).

**2. `optimize/prompt.go` substring scan.** Extracted `containsAny(s, subs)`; collapsed `isExpensiveModel`/`isCheapModel`/`isBookkeepingPrompt` to one-line wrappers.

No behavior change — guarded by the existing simulate event-sequence assertions (`just test-pkg simulate` green; full pre-commit suite green).

## Inventory checklist

Fixed:
- [x] `events.go:41` `emitEdgeTraverse` → now `s.emit(buildEdgeTraverseEvent(e))`
- [x] `events.go:57` `emitFanOutIn` → routes through shared `buildNodeEventSequence`
- [x] `path_enumerator.go:140` `cloneState` → `buildPipelineStartEvent`
- [x] `path_enumerator.go:152` `appendNodeEvents` → shared `buildNodeEventSequence`
- [x] `path_enumerator.go:181` `recordPath` → `buildPipelineEndEvent`
- [x] `path_enumerator.go:220` `buildEdgeTraverseEvent` → kept as single source of truth; `emitEdgeTraverse` routed through it
- [x] `simulate.go:151` `run` → `buildPipelineStartEvent`
- [x] `simulate.go:211` `finishRun` → `buildPipelineEndEvent`
- [x] `simulate.go:246` `visitNode` → `newNodeExitSuccess`
- [x] `prompt.go:61/72/83` three predicates → one-line `containsAny` wrappers

Skipped (with reasons):
- [ ] `prompt.go:47` `keywordCounter` — intentionally left as-is. It *sums* `points` across every matching keyword; the bool `containsAny` returns on first hit, so it cannot back the accumulator without changing semantics. No clean shared primitive without over-abstracting.
- [ ] `simulate.go:306` `matchEdgeLabel` + `cost.go:213` `outputTokensForModel` — the issue's own cross-package note **recommends skipping** this. A shared helper would need a new neutral package the ~4-line loop doesn't justify; additionally `matchEdgeLabel` emits an event as a side effect and `outputTokensForModel` returns a typed tier, so neither maps to the bool `containsAny`. Intentional duplication left documented.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784740677&installation_id=131176874&pr_number=165&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F165&signature=3a55e414ce677a8fa030347fd62b43cdd8b3a1f832738e8604212c898603da6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization and removed duplication in prompt classification logic.
  * Streamlined event construction and sequencing throughout the simulation pipeline for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->