### PR TITLE
cleanup: remove defensive branches guarding caller-unreachable states

### DIFF
--- a/cost/cost.go
+++ b/cost/cost.go
@@ -139,7 +139,7 @@ func estimateNodeCost(n *ir.Node, w *ir.Workflow, pricing PricingTable, r *Repor
 		return nc // non-agent nodes have zero cost
 	}
 
-	nc.Model, nc.Provider = getModelProvider(n, w)
+	nc.Model, nc.Provider = getModelProvider(ac, w)
 	nc.Tokens = estimateTokens(ac, nc.Model)
 	nc.Turns = estimateTurns(ac)
 
@@ -155,12 +155,8 @@ func estimateNodeCost(n *ir.Node, w *ir.Workflow, pricing PricingTable, r *Repor
 	return nc
 }
 
-// getModelProvider resolves the model and provider for a node.
-func getModelProvider(n *ir.Node, w *ir.Workflow) (string, string) {
-	ac, ok := n.Config.(ir.AgentConfig)
-	if !ok {
-		return w.Defaults.Model, w.Defaults.Provider
-	}
+// getModelProvider resolves the model and provider for an agent node.
+func getModelProvider(ac ir.AgentConfig, w *ir.Workflow) (string, string) {
 	model := ac.Model
 	if model == "" {
 		model = w.Defaults.Model

--- a/cost/cost_test.go
+++ b/cost/cost_test.go
@@ -428,28 +428,6 @@ func TestSortTopCostsTruncation(t *testing.T) {
 	}
 }
 
-func TestGetModelProviderFallbackToDefaults(t *testing.T) {
-	// Direct test of getModelProvider when node has non-agent config.
-	w := &ir.Workflow{
-		Defaults: ir.WorkflowDefaults{
-			Model:    "default-model",
-			Provider: "default-provider",
-		},
-	}
-	n := &ir.Node{
-		ID:     "h1",
-		Kind:   ir.NodeHuman,
-		Config: ir.HumanConfig{Mode: "freeform"},
-	}
-	model, provider := getModelProvider(n, w)
-	if model != "default-model" {
-		t.Errorf("model = %q, want default-model", model)
-	}
-	if provider != "default-provider" {
-		t.Errorf("provider = %q, want default-provider", provider)
-	}
-}
-
 func TestEstimateTurnsZeroMaxTurns(t *testing.T) {
 	// When MaxTurns is 0, defaults to 10, then expected = 10/3 = 3.
 	ac := ir.AgentConfig{Prompt: "test", MaxTurns: 0}

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -64,19 +64,16 @@ func Analyze(w *ir.Workflow) *Report {
 // analyzeNodes evaluates edge coverage for each tool node.
 func analyzeNodes(w *ir.Workflow, r *Report) {
 	for _, n := range w.Nodes {
-		if _, ok := n.Config.(ir.ToolConfig); !ok {
+		cfg, ok := n.Config.(ir.ToolConfig)
+		if !ok {
 			continue
 		}
-		r.Nodes[n.ID] = analyzeToolNode(w, n)
+		r.Nodes[n.ID] = analyzeToolNode(w, n, cfg)
 	}
 }
 
 // analyzeToolNode computes coverage for a single tool node.
-func analyzeToolNode(w *ir.Workflow, n *ir.Node) NodeCoverage {
-	cfg, ok := n.Config.(ir.ToolConfig)
-	if !ok {
-		return NodeCoverage{NodeID: n.ID}
-	}
+func analyzeToolNode(w *ir.Workflow, n *ir.Node, cfg ir.ToolConfig) NodeCoverage {
 	edges := w.EdgesFrom(n.ID)
 	conditions, hasFallback := collectEdgeConditions(edges)
 	terms := collectEdgeConditionTerms(edges)

--- a/dipx/resolve.go
+++ b/dipx/resolve.go
@@ -243,9 +243,10 @@ func dfsVisitEdge(graph map[string][]string, color map[string]int, stack *[]stri
 }
 
 // formatCycle renders the active DFS stack as "n1 -> n2 -> ... -> nk -> n1"
-// where n1 is the cycle entry node (where the back-edge points). The target
-// is expected to appear in the stack; if not (which would indicate an
-// invariant violation), the function falls back to the closing edge.
+// where n1 is the cycle entry node (where the back-edge points). The caller
+// (dfsVisitEdge) only invokes this when target is colorGray, which the tri-color
+// DFS sets exactly while target is on the active stack — so target is always
+// found. A miss would be an invariant violation, hence the panic.
 func formatCycle(stack []string, target string) string {
 	idx := -1
 	for i, n := range stack {
@@ -255,10 +256,7 @@ func formatCycle(stack []string, target string) string {
 		}
 	}
 	if idx < 0 {
-		if len(stack) > 0 {
-			return stack[len(stack)-1] + " -> " + target
-		}
-		return target
+		panic(fmt.Sprintf("formatCycle: target %q not on active DFS stack %v", target, stack))
 	}
 	cycle := append([]string{}, stack[idx:]...)
 	cycle = append(cycle, target)

--- a/graph/render.go
+++ b/graph/render.go
@@ -109,13 +109,13 @@ func boxHeight(boxes [][]string) int {
 	return max
 }
 
-// mergeBoxLine merges one line across all boxes.
+// mergeBoxLine merges one line across all boxes. Every box comes from
+// renderNodeBox, which always returns exactly 3 lines, so lineIdx is always in
+// range and every box contributes a part.
 func mergeBoxLine(boxes [][]string, lineIdx int) string {
 	parts := make([]string, 0, len(boxes))
 	for _, b := range boxes {
-		if lineIdx < len(b) {
-			parts = append(parts, b[lineIdx])
-		}
+		parts = append(parts, b[lineIdx])
 	}
 	return strings.Join(parts, " ")
 }

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -16,7 +16,7 @@ func (s *Server) handleCompletion(ctx context.Context, reply jsonrpc2.Replier, r
 	}
 
 	doc := s.store.get(string(params.TextDocument.URI))
-	if doc == nil || doc.Parsed == nil {
+	if doc == nil {
 		return reply(ctx, nil, nil)
 	}
 

--- a/lsp/definition.go
+++ b/lsp/definition.go
@@ -25,7 +25,7 @@ func (s *Server) handleDefinition(ctx context.Context, reply jsonrpc2.Replier, r
 // resolveDefinition finds the definition location for the word at the cursor.
 func (s *Server) resolveDefinition(params protocol.DefinitionParams) *protocol.Location {
 	doc := s.store.get(string(params.TextDocument.URI))
-	if doc == nil || doc.Parsed == nil {
+	if doc == nil {
 		return nil
 	}
 	word := wordAtPosition(doc.Content, params.Position)

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -24,25 +24,10 @@ func (s *Server) publishDiagnostics(ctx context.Context, doc *document) {
 	_ = conn.Notify(ctx, "textDocument/publishDiagnostics", params)
 }
 
-// collectDiagnostics gathers all diagnostics for a document.
+// collectDiagnostics gathers all diagnostics for a document. parser.Parse()
+// always returns a non-nil *ir.Workflow, so doc.Parsed is never nil here.
 func collectDiagnostics(doc *document) []protocol.Diagnostic {
-	if doc.Parsed == nil {
-		return parseErrorDiagnostic(doc)
-	}
 	return lintDiagnostics(doc)
-}
-
-// parseErrorDiagnostic returns a single diagnostic for a parse error.
-func parseErrorDiagnostic(doc *document) []protocol.Diagnostic {
-	if doc.Err == nil {
-		return nil
-	}
-	return []protocol.Diagnostic{{
-		Range:    zeroRange(),
-		Severity: protocol.DiagnosticSeverityError,
-		Source:   "dippin",
-		Message:  doc.Err.Error(),
-	}}
 }
 
 // lintDiagnostics runs validator and lint, converting results to LSP diagnostics.

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -20,7 +20,7 @@ func (s *Server) handleHover(ctx context.Context, reply jsonrpc2.Replier, req js
 	}
 
 	doc := s.store.get(string(params.TextDocument.URI))
-	if doc == nil || doc.Parsed == nil {
+	if doc == nil {
 		return reply(ctx, nil, nil)
 	}
 

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -104,14 +104,6 @@ func TestCollectDiagnostics_ValidDocument(t *testing.T) {
 	}
 }
 
-func TestCollectDiagnostics_NilParsed(t *testing.T) {
-	doc := &document{URI: "file:///bad.dip", Err: nil, Parsed: nil}
-	diags := collectDiagnostics(doc)
-	if len(diags) != 0 {
-		t.Errorf("expected no diagnostics for nil parsed without error, got %d", len(diags))
-	}
-}
-
 func TestMapSeverity(t *testing.T) {
 	tests := []struct {
 		input validator.Severity

--- a/lsp/symbols.go
+++ b/lsp/symbols.go
@@ -18,7 +18,7 @@ func (s *Server) handleDocumentSymbol(ctx context.Context, reply jsonrpc2.Replie
 	}
 
 	doc := s.store.get(string(params.TextDocument.URI))
-	if doc == nil || doc.Parsed == nil {
+	if doc == nil {
 		return reply(ctx, nil, nil)
 	}
 

--- a/optimize/optimize.go
+++ b/optimize/optimize.go
@@ -38,8 +38,8 @@ func Analyze(w *ir.Workflow, pricing cost.PricingTable) *Report {
 		if !ok {
 			continue
 		}
-		model, provider := resolveModelProvider(n, w)
-		ctx := ruleContext{node: n, config: ac, model: model, provider: provider, workflow: w, pricing: pricing}
+		model, provider := resolveModelProvider(ac, w)
+		ctx := ruleContext{node: n, config: ac, model: model, provider: provider, workflow: w, pricing: pricing, costReport: costReport}
 		r.Suggestions = append(r.Suggestions, applyRules(ctx)...)
 	}
 
@@ -50,20 +50,17 @@ func Analyze(w *ir.Workflow, pricing cost.PricingTable) *Report {
 
 // ruleContext bundles the data each rule needs.
 type ruleContext struct {
-	node     *ir.Node
-	config   ir.AgentConfig
-	model    string
-	provider string
-	workflow *ir.Workflow
-	pricing  cost.PricingTable
+	node       *ir.Node
+	config     ir.AgentConfig
+	model      string
+	provider   string
+	workflow   *ir.Workflow
+	pricing    cost.PricingTable
+	costReport *cost.Report
 }
 
-// resolveModelProvider gets the effective model and provider for a node.
-func resolveModelProvider(n *ir.Node, w *ir.Workflow) (string, string) {
-	ac, ok := n.Config.(ir.AgentConfig)
-	if !ok {
-		return w.Defaults.Model, w.Defaults.Provider
-	}
+// resolveModelProvider gets the effective model and provider for an agent node.
+func resolveModelProvider(ac ir.AgentConfig, w *ir.Workflow) (string, string) {
 	model := ac.Model
 	if model == "" {
 		model = w.Defaults.Model

--- a/optimize/rules.go
+++ b/optimize/rules.go
@@ -124,13 +124,11 @@ func savingsRatio(current, suggested cost.ModelPrice) float64 {
 	return ratio
 }
 
-// estimateNodeCost gets the cost range for a node from a fresh cost analysis.
+// estimateNodeCost gets the cost range for a node from the precomputed report.
+// cost.Analyze writes a NodeCost for every node in the workflow, and ctx.node
+// is iterated from that same workflow, so the lookup always succeeds.
 func estimateNodeCost(ctx ruleContext) cost.CostRange {
-	report := cost.Analyze(ctx.workflow, ctx.pricing)
-	if nc, ok := report.Nodes[ctx.node.ID]; ok {
-		return nc.Cost
-	}
-	return cost.CostRange{}
+	return ctx.costReport.Nodes[ctx.node.ID].Cost
 }
 
 // lookupPrice finds pricing for a provider/model pair.

--- a/parser/resolve.go
+++ b/parser/resolve.go
@@ -70,10 +70,11 @@ func resolveAgentDirective(n *ir.Node, cfg ir.AgentConfig, baseDir string) error
 }
 
 // loadDirectiveInto reads path (relative to baseDir) into *dst, no-op if path
-// is empty. The *dst != "" guard preserves an inline value if one is already
-// set, defensive against the parser's mutual-exclusion check getting bypassed.
+// is empty. When path is non-empty, *dst is always empty: the parser rejects a
+// node declaring both an inline value and its *_file directive, and the CLI
+// bails on that parse error before reaching the resolver.
 func loadDirectiveInto(dst *string, path, baseDir, nodeID, directive string) error {
-	if path == "" || *dst != "" {
+	if path == "" {
 		return nil
 	}
 	contents, err := loadDirectiveFile(baseDir, path)

--- a/simulate/path_enumerator.go
+++ b/simulate/path_enumerator.go
@@ -53,11 +53,7 @@ type pathState struct {
 }
 
 func (pe *pathEnumerator) enumerate() ([]*Result, error) {
-	// Ensure conditions are parsed.
-	if err := EnsureConditionsParsed(pe.workflow); err != nil {
-		return nil, err
-	}
-
+	// Conditions are already parsed by RunAllPaths, the sole caller.
 	initial := &pathState{
 		nodeID:  pe.workflow.Start,
 		ctx:     make(map[string]string),


### PR DESCRIPTION
## Summary

Removes 14 of the 15 dead defensive branches inventoried in #163. Each guarded a state that the sole caller — or prior validation — makes unreachable. Before removing any guard, every caller was traced to prove the guarded state genuinely cannot occur. The one item the issue itself recommended retaining (the symlink check) was kept.

Changes break into four clusters:

- **Assertion-threading** (`coverage.go`, `cost.go`, `optimize/optimize.go`, `optimize/rules.go`): pass the already-asserted config down instead of re-asserting it behind an unreachable `!ok` fallback. `optimize` additionally threads the precomputed `cost.Report` through `ruleContext` so `rules.go` stops recomputing `cost.Analyze` on every node. Deletes `TestGetModelProviderFallbackToDefaults`, which only covered the removed branch.
- **LSP `Parse()` contract** (`diagnostics.go`, `hover.go`, `definition.go`, `completion.go`, `symbols.go`): drop the `doc.Parsed == nil` guards. `parser.Parse()` always returns a non-nil `*ir.Workflow` (initialized in `NewParser`, returned on both paths), so `doc.Parsed` is never nil. Removes `parseErrorDiagnostic` and the dead-branch test `TestCollectDiagnostics_NilParsed`.
- **Redundant work**: `simulate/path_enumerator.go` drops the second `EnsureConditionsParsed` that `RunAllPaths` (the only caller) already ran.
- **One-offs**: `dipx/resolve.go` replaces `formatCycle`'s silent degraded fallback with a `panic` documenting the tri-color DFS invariant; `graph/render.go` indexes box lines directly since all boxes are uniform 3-line `renderNodeBox` output; `parser/resolve.go` drops the `*dst != ""` half of `loadDirectiveInto`'s guard (the parser rejects inline+`*_file` conflicts and both CLI callers bail on the parse error before the resolver runs).

## Inventory checklist

Fixed (14):
- [x] `coverage.go:77` — thread `cfg`
- [x] `cost.go:160` — thread `ac`, delete dead test
- [x] `optimize.go:62` — thread `ac`
- [x] `optimize/rules.go:133` — thread precomputed `cost.Report`, drop miss branch + duplicate `cost.Analyze`
- [x] `parser/resolve.go:76` — drop `*dst != ""` clause
- [x] `dipx/resolve.go:257` — convert dead fallback to invariant `panic`
- [x] `lsp/diagnostics.go:29` — drop dead branch
- [x] `lsp/diagnostics.go:37` — remove `parseErrorDiagnostic`
- [x] `lsp/hover.go:23` — drop `doc.Parsed == nil`
- [x] `lsp/definition.go:28` — drop `doc.Parsed == nil`
- [x] `lsp/completion.go:19` — drop `doc.Parsed == nil`
- [x] `lsp/symbols.go:21` — drop `doc.Parsed == nil`
- [x] `simulate/path_enumerator.go:57` — drop redundant `EnsureConditionsParsed`
- [x] `graph/render.go:116` — index box lines directly

Skipped (1):
- [ ] `parser/resolve.go:249` (symlink check) — **kept**, per the issue's own recommendation: intentional, self-documented defense-in-depth on a security-sensitive file-read path.

## Verification

`just build`, `just vet`, `just test-race`, `just complexity`, `just validate-examples` all green; full pre-commit hook (golangci-lint, race tests, release checks, complexity, examples) passed. The two deleted tests were confirmed to exercise only the removed branches.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784740968&installation_id=131176874&pr_number=166&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F166&signature=93f71e8648657f3829fcbd87a7056bf7cd7d6686f7988b80e9afe6ae4fc80af5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->