### PR TITLE
cleanup: remove de-facto-constant config knobs, single-use parameters, and hand-rolled stdlib reimplementations

### DIFF
--- a/cmd/dippin/cmd_diff.go
+++ b/cmd/dippin/cmd_diff.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/2389-research/dippin-lang/cost"
 	"github.com/2389-research/dippin-lang/diff"
 )
 
@@ -33,7 +32,7 @@ func (c *CLI) CmdDiff(args []string) ExitCode {
 		return ExitError
 	}
 
-	report := diff.Compare(oldW, newW, cost.DefaultPricing())
+	report := diff.Compare(oldW, newW)
 	return c.renderDiffReport(report)
 }
 

--- a/cmd/dippin/cmd_doctor.go
+++ b/cmd/dippin/cmd_doctor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/2389-research/dippin-lang/cost"
 	"github.com/2389-research/dippin-lang/doctor"
 )
 
@@ -28,7 +27,7 @@ func (c *CLI) CmdDoctor(args []string) ExitCode {
 	// effect is minor (a DIP143 vs DIP146 hint is counted the same; only a
 	// fully-restricted child differs by one hint). `dippin lint`/`check`/`watch`
 	// carry the precise DIP146 behavior. (#89)
-	report := doctor.DiagnoseWithOptions(w, cost.DefaultPricing(), lintOptions(extraModels))
+	report := doctor.DiagnoseWithOptions(w, lintOptions(extraModels))
 	return c.renderDoctorReport(report)
 }
 

--- a/cmd/dippin/cmd_explain.go
+++ b/cmd/dippin/cmd_explain.go
@@ -45,7 +45,7 @@ func (c *CLI) renderExplanation(exp validator.Explanation) ExitCode {
 
 func renderExplanationText(w io.Writer, exp validator.Explanation) {
 	header := fmt.Sprintf("═══ %s ", exp.Code)
-	header += strings.Repeat("═", maxInt(0, 58-len(header)))
+	header += strings.Repeat("═", max(0, 58-len(header)))
 	fmt.Fprintln(w, header)
 	fmt.Fprintf(w, "  %s\n", exp.Summary)
 	fmt.Fprintln(w)
@@ -65,11 +65,4 @@ func printValidCodes(w io.Writer) {
 	}
 	sort.Strings(codes)
 	fmt.Fprintf(w, "valid codes: %s\n", strings.Join(codes, ", "))
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/cmd/dippin/cmd_simulate.go
+++ b/cmd/dippin/cmd_simulate.go
@@ -38,7 +38,7 @@ func (c *CLI) CmdSimulate(args []string) ExitCode {
 	}
 
 	path := fs.Arg(0)
-	w, opts, code := c.prepareSimulation(path, scenarios.values, *interactive, *allPaths)
+	w, opts, code := c.prepareSimulation(path, scenarios.values, *interactive)
 	if code != ExitCode(-1) {
 		return code
 	}
@@ -50,7 +50,7 @@ func (c *CLI) CmdSimulate(args []string) ExitCode {
 }
 
 // prepareSimulation loads and validates the workflow, then builds simulation options.
-func (c *CLI) prepareSimulation(path string, scenario map[string]string, interactive, allPaths bool) (*ir.Workflow, simulate.Options, ExitCode) {
+func (c *CLI) prepareSimulation(path string, scenario map[string]string, interactive bool) (*ir.Workflow, simulate.Options, ExitCode) {
 	w, err := loadWorkflow(path)
 	if err != nil {
 		c.renderError(err, path)
@@ -66,7 +66,6 @@ func (c *CLI) prepareSimulation(path string, scenario map[string]string, interac
 	opts := simulate.Options{
 		Scenario:    scenario,
 		Interactive: interactive,
-		AllPaths:    allPaths,
 	}
 	if interactive {
 		opts.Stdin = os.Stdin
@@ -90,7 +89,7 @@ func (c *CLI) emitPathResult(i int, res *simulate.Result) error {
 
 // simulateAllPaths runs simulation in all-paths mode and renders results.
 func (c *CLI) simulateAllPaths(w *ir.Workflow, opts simulate.Options) ExitCode {
-	results, err := simulate.RunAllPaths(w, opts)
+	results, err := simulate.RunAllPaths(w, opts.Scenario)
 	if err != nil {
 		fmt.Fprintf(c.Stderr, "simulation error: %v\n", err)
 		return ExitError

--- a/cost/cost.go
+++ b/cost/cost.go
@@ -78,7 +78,7 @@ func Analyze(w *ir.Workflow, pricing PricingTable) *Report {
 
 	r.Total = aggregateTotal(r.Nodes)
 	r.ByProvider = aggregateByProvider(r.Nodes)
-	r.TopCosts = sortTopCosts(r.Nodes, 5)
+	r.TopCosts = sortTopCosts(r.Nodes)
 	return r
 }
 
@@ -86,7 +86,7 @@ func Analyze(w *ir.Workflow, pricing PricingTable) *Report {
 func aggregateTotal(nodes map[string]NodeCost) CostRange {
 	var total CostRange
 	for _, nc := range nodes {
-		total = addCostRange(total, nc.Cost)
+		total = AddCostRange(total, nc.Cost)
 	}
 	return total
 }
@@ -98,13 +98,13 @@ func aggregateByProvider(nodes map[string]NodeCost) map[string]CostRange {
 		if nc.Provider == "" {
 			continue
 		}
-		byProv[nc.Provider] = addCostRange(byProv[nc.Provider], nc.Cost)
+		byProv[nc.Provider] = AddCostRange(byProv[nc.Provider], nc.Cost)
 	}
 	return byProv
 }
 
-// addCostRange adds two CostRange values.
-func addCostRange(a, b CostRange) CostRange {
+// AddCostRange adds two CostRange values.
+func AddCostRange(a, b CostRange) CostRange {
 	return CostRange{
 		Min:      a.Min + b.Min,
 		Expected: a.Expected + b.Expected,
@@ -112,8 +112,11 @@ func addCostRange(a, b CostRange) CostRange {
 	}
 }
 
-// sortTopCosts returns the top N nodes sorted by max cost descending.
-func sortTopCosts(nodes map[string]NodeCost, limit int) []NodeCost {
+// topCostLimit caps how many of the most expensive nodes Analyze reports.
+const topCostLimit = 5
+
+// sortTopCosts returns the topCostLimit nodes sorted by max cost descending.
+func sortTopCosts(nodes map[string]NodeCost) []NodeCost {
 	all := make([]NodeCost, 0, len(nodes))
 	for _, nc := range nodes {
 		all = append(all, nc)
@@ -121,8 +124,8 @@ func sortTopCosts(nodes map[string]NodeCost, limit int) []NodeCost {
 	sort.Slice(all, func(i, j int) bool {
 		return all[i].Cost.Max > all[j].Cost.Max
 	})
-	if len(all) > limit {
-		all = all[:limit]
+	if len(all) > topCostLimit {
+		all = all[:topCostLimit]
 	}
 	return all
 }

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -7,6 +7,7 @@ package diff
 
 import (
 	"sort"
+	"strconv"
 
 	"github.com/2389-research/dippin-lang/cost"
 	"github.com/2389-research/dippin-lang/ir"
@@ -50,11 +51,11 @@ type CostDelta struct {
 }
 
 // Compare produces a semantic diff between old and new workflows.
-func Compare(old, new *ir.Workflow, pricing cost.PricingTable) *Report {
+func Compare(old, new *ir.Workflow) *Report {
 	r := &Report{}
 	compareNodes(old, new, r)
 	compareEdges(old, new, r)
-	r.CostDelta = compareCosts(old, new, pricing)
+	r.CostDelta = compareCosts(old, new)
 	return r
 }
 
@@ -155,8 +156,8 @@ func agentFieldTable(old, new ir.AgentConfig) []agentField {
 	return []agentField{
 		{"model", old.Model, new.Model},
 		{"provider", old.Provider, new.Provider},
-		{"prompt", truncate(old.Prompt, 50), truncate(new.Prompt, 50)},
-		{"max_turns", itoa(old.MaxTurns), itoa(new.MaxTurns)},
+		{"prompt", truncate(old.Prompt), truncate(new.Prompt)},
+		{"max_turns", strconv.Itoa(old.MaxTurns), strconv.Itoa(new.MaxTurns)},
 		{"reasoning_effort", old.ReasoningEffort, new.ReasoningEffort},
 		{"fidelity", old.Fidelity, new.Fidelity},
 	}
@@ -207,7 +208,8 @@ func findAddedEdges(a, b map[string]EdgeSummary) []EdgeSummary {
 }
 
 // compareCosts computes cost delta between workflows.
-func compareCosts(old, new *ir.Workflow, pricing cost.PricingTable) CostDelta {
+func compareCosts(old, new *ir.Workflow) CostDelta {
+	pricing := cost.DefaultPricing()
 	oldCost := cost.Analyze(old, pricing).Total
 	newCost := cost.Analyze(new, pricing).Total
 	return CostDelta{
@@ -221,28 +223,13 @@ func compareCosts(old, new *ir.Workflow, pricing cost.PricingTable) CostDelta {
 	}
 }
 
-// truncate shortens a string to maxLen, adding "..." if truncated.
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
+// promptDiffMaxLen bounds the prompt preview shown in field-change tables.
+const promptDiffMaxLen = 50
+
+// truncate shortens a string to promptDiffMaxLen, adding "..." if truncated.
+func truncate(s string) string {
+	if len(s) <= promptDiffMaxLen {
 		return s
 	}
-	return s[:maxLen] + "..."
-}
-
-// itoa converts an int to a string without importing strconv.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	return intToStr(n)
-}
-
-func intToStr(n int) string {
-	if n < 0 {
-		return "-" + intToStr(-n)
-	}
-	if n < 10 {
-		return string(rune('0' + n))
-	}
-	return intToStr(n/10) + string(rune('0'+n%10))
+	return s[:promptDiffMaxLen] + "..."
 }

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/2389-research/dippin-lang/cost"
 	"github.com/2389-research/dippin-lang/diff"
 	"github.com/2389-research/dippin-lang/ir"
 	"github.com/2389-research/dippin-lang/parser"
@@ -28,7 +27,7 @@ func TestCompare_V1toV2(t *testing.T) {
 	v1 := loadFixture(t, "testdata/v1.dip")
 	v2 := loadFixture(t, "testdata/v2.dip")
 
-	report := diff.Compare(v1, v2, cost.DefaultPricing())
+	report := diff.Compare(v1, v2)
 
 	// Review was added in v2.
 	if len(report.NodesAdded) != 1 || report.NodesAdded[0] != "Review" {
@@ -59,7 +58,7 @@ func TestCompare_EdgesChanged(t *testing.T) {
 	v1 := loadFixture(t, "testdata/v1.dip")
 	v2 := loadFixture(t, "testdata/v2.dip")
 
-	report := diff.Compare(v1, v2, cost.DefaultPricing())
+	report := diff.Compare(v1, v2)
 
 	// Process -> Done was removed, Process -> Review and Review -> Done added.
 	if len(report.EdgesAdded) < 1 {
@@ -74,7 +73,7 @@ func TestCompare_CostDelta(t *testing.T) {
 	v1 := loadFixture(t, "testdata/v1.dip")
 	v2 := loadFixture(t, "testdata/v2.dip")
 
-	report := diff.Compare(v1, v2, cost.DefaultPricing())
+	report := diff.Compare(v1, v2)
 
 	// v2 has an extra node and downgraded Process, cost should change.
 	if report.CostDelta.OldCost.Expected == 0 && report.CostDelta.NewCost.Expected == 0 {
@@ -85,7 +84,7 @@ func TestCompare_CostDelta(t *testing.T) {
 func TestCompare_Identical(t *testing.T) {
 	v1 := loadFixture(t, "testdata/v1.dip")
 
-	report := diff.Compare(v1, v1, cost.DefaultPricing())
+	report := diff.Compare(v1, v1)
 
 	if len(report.NodesAdded) != 0 {
 		t.Errorf("expected no nodes added, got %v", report.NodesAdded)
@@ -108,7 +107,7 @@ func TestCompare_FieldChanges(t *testing.T) {
 	v1 := loadFixture(t, "testdata/v1.dip")
 	v2 := loadFixture(t, "testdata/v2.dip")
 
-	report := diff.Compare(v1, v2, cost.DefaultPricing())
+	report := diff.Compare(v1, v2)
 
 	for _, nd := range report.NodesModified {
 		for _, c := range nd.Changes {
@@ -143,7 +142,7 @@ func TestCompare_NodeModifiedConfigChanges(t *testing.T) {
 		Edges: []*ir.Edge{{From: "A", To: "B"}},
 	}
 
-	report := diff.Compare(old, new, cost.DefaultPricing())
+	report := diff.Compare(old, new)
 
 	if len(report.NodesModified) != 1 {
 		t.Fatalf("expected 1 modified node, got %d", len(report.NodesModified))
@@ -178,7 +177,7 @@ func TestCompare_LabelChange(t *testing.T) {
 		},
 	}
 
-	report := diff.Compare(old, new, cost.DefaultPricing())
+	report := diff.Compare(old, new)
 	if len(report.NodesModified) != 1 {
 		t.Fatalf("expected 1 modified node, got %d", len(report.NodesModified))
 	}
@@ -207,7 +206,7 @@ func TestCompare_KindChange(t *testing.T) {
 		},
 	}
 
-	report := diff.Compare(old, new, cost.DefaultPricing())
+	report := diff.Compare(old, new)
 	if len(report.NodesModified) != 1 {
 		t.Fatalf("expected 1 modified node, got %d", len(report.NodesModified))
 	}
@@ -244,7 +243,7 @@ func TestCompare_EdgeWithConditions(t *testing.T) {
 		},
 	}
 
-	report := diff.Compare(old, new, cost.DefaultPricing())
+	report := diff.Compare(old, new)
 	// Old edge removed, new edge added (different condition = different key).
 	if len(report.EdgesAdded) != 1 {
 		t.Errorf("expected 1 edge added, got %d", len(report.EdgesAdded))
@@ -268,7 +267,7 @@ func TestCompare_NonAgentConfigNotCompared(t *testing.T) {
 		},
 	}
 
-	report := diff.Compare(old, new, cost.DefaultPricing())
+	report := diff.Compare(old, new)
 	// compareConfigFields only handles AgentConfig, so ToolConfig diffs are not reported.
 	if len(report.NodesModified) != 0 {
 		t.Errorf("expected 0 modified nodes for tool config change, got %d", len(report.NodesModified))
@@ -295,7 +294,7 @@ func TestCompare_MultipleModifiedNodesSorted(t *testing.T) {
 		Edges: []*ir.Edge{{From: "A", To: "B"}, {From: "B", To: "C"}},
 	}
 
-	report := diff.Compare(old, new, cost.DefaultPricing())
+	report := diff.Compare(old, new)
 	if len(report.NodesModified) != 2 {
 		t.Fatalf("expected 2 modified nodes, got %d", len(report.NodesModified))
 	}

--- a/dipx/dipx_test.go
+++ b/dipx/dipx_test.go
@@ -210,13 +210,13 @@ func TestPack_RejectsOversizedSource(t *testing.T) {
 func TestOpen_RejectsTooManyFiles(t *testing.T) {
 	// Verify the maxFiles cap fires with ErrCapExceeded.
 	//
-	// We exercise verifyAllHashes directly rather than going through OpenReader:
+	// We exercise verifyAllHashesCtx directly rather than going through OpenReader:
 	// constructing a manifest with maxFiles+1 entries serialized as JSON would
 	// always exceed maxManifestSize (1MB) regardless of how short the paths
 	// are — 10001 entries each containing a 64-char SHA-256 plus the minimal
 	// JSON overhead and shortest valid "workflows/<N>.dip" path is ~1.06MB —
 	// so the manifest-size cap would intercept before the file-count cap could
-	// fire. Calling verifyAllHashes directly tests the intended branch without
+	// fire. Calling verifyAllHashesCtx directly tests the intended branch without
 	// hitting that ordering hazard.
 	files := make([]ManifestEntry, 0, maxFiles+1)
 	hash := hashOf([]byte("x"))
@@ -227,7 +227,7 @@ func TestOpen_RejectsTooManyFiles(t *testing.T) {
 		})
 	}
 	m := Manifest{FormatVersion: 1, Entry: "workflows/f0.dip", Files: files}
-	_, _, err := verifyAllHashes(nil, m, maxTotalUncompBytes)
+	_, _, err := verifyAllHashesCtx(context.Background(), nil, m, maxTotalUncompBytes)
 	if !errors.Is(err, ErrCapExceeded) {
 		t.Fatalf("err = %v, want ErrCapExceeded", err)
 	}

--- a/dipx/helpers.go
+++ b/dipx/helpers.go
@@ -55,8 +55,7 @@ func readManifestEntry(cz *constrainedZip) ([]byte, error) {
 // and the running total. The effective per-file cap is min(maxPerFileBytes,
 // totalCap-total), so the running total cap is enforced as a streaming bound
 // rather than after a per-file allocation has already happened. Checks ctx at
-// entry and before each entry in the loop (P10.10); most callers should prefer
-// this form over the bare verifyAllHashes wrapper.
+// entry and before each entry in the loop (P10.10).
 func verifyAllHashesCtx(ctx context.Context, cz *constrainedZip, m Manifest, totalCap int64) (map[string]verifiedBytes, int64, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, 0, err
@@ -85,12 +84,6 @@ func verifyEntriesLoop(ctx context.Context, cz *constrainedZip, files []Manifest
 		verified[e.Path] = vb
 	}
 	return verified, total, nil
-}
-
-// verifyAllHashes is the no-ctx form, retained for tests that don't need
-// cancellation. Prefer verifyAllHashesCtx in production code.
-func verifyAllHashes(cz *constrainedZip, m Manifest, totalCap int64) (map[string]verifiedBytes, int64, error) {
-	return verifyAllHashesCtx(context.Background(), cz, m, totalCap)
 }
 
 // verifyEntryWithBudget verifies a single manifest entry under an effective
@@ -123,16 +116,16 @@ func walkRefs(parsed map[string]*ir.Workflow, m Manifest) error {
 	if err := verifyRefsListed(graph, m); err != nil {
 		return err
 	}
-	return detectCyclesAll(graph, m, 64)
+	return detectCyclesAll(graph, m)
 }
 
 // detectCyclesAll runs detectCycles rooted at every manifest-listed
 // workflow. Each call uses a fresh color map; overlap across roots is
 // re-explored, which is acceptable at manifest-cap scale (≤ a few
 // hundred workflows in practice).
-func detectCyclesAll(graph map[string][]string, m Manifest, maxDepth int) error {
+func detectCyclesAll(graph map[string][]string, m Manifest) error {
 	for _, e := range m.Files {
-		if err := detectCycles(graph, e.Path, maxDepth); err != nil {
+		if err := detectCycles(graph, e.Path); err != nil {
 			return err
 		}
 	}

--- a/dipx/helpers_test.go
+++ b/dipx/helpers_test.go
@@ -56,7 +56,7 @@ func TestVerifyAllHashes_Happy(t *testing.T) {
 		"workflows/b.dip": contentB,
 		"manifest.json":   []byte("{}"),
 	})
-	verified, totalBytes, err := verifyAllHashes(cz, manifest, 100<<20)
+	verified, totalBytes, err := verifyAllHashesCtx(context.Background(), cz, manifest, 100<<20)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestVerifyAllHashes_TotalCap(t *testing.T) {
 		"workflows/b.dip": content,
 		"manifest.json":   []byte("{}"),
 	})
-	_, _, err := verifyAllHashes(cz, manifest, 15) // total cap below sum
+	_, _, err := verifyAllHashesCtx(context.Background(), cz, manifest, 15) // total cap below sum
 	if !errors.Is(err, ErrCapExceeded) {
 		t.Fatalf("err = %v, want ErrCapExceeded", err)
 	}

--- a/dipx/resolve.go
+++ b/dipx/resolve.go
@@ -199,27 +199,31 @@ const (
 	colorBlack = 2
 )
 
+// maxRefDepth bounds the ref-graph DFS depth. A de-facto constant: every
+// caller used the literal 64.
+const maxRefDepth = 64
+
 // detectCycles runs a tri-color DFS over the ref graph rooted at start.
 // Returns ErrRefCycle on the first cycle found, ErrCapExceeded when depth
-// exceeds maxDepth.
-func detectCycles(graph map[string][]string, start string, maxDepth int) error {
+// exceeds maxRefDepth.
+func detectCycles(graph map[string][]string, start string) error {
 	color := make(map[string]int, len(graph))
 	stack := make([]string, 0, 16)
-	return dfsVisit(graph, color, &stack, start, 0, maxDepth)
+	return dfsVisit(graph, color, &stack, start, 0)
 }
 
 // dfsVisit is the recursive worker for detectCycles. Hoisted to a top-level
 // helper so detectCycles stays under the project's complexity caps. The
 // stack tracks the active DFS path so cycle errors can include the full
 // path from the cycle entry node back to itself.
-func dfsVisit(graph map[string][]string, color map[string]int, stack *[]string, node string, depth, maxDepth int) error {
-	if depth > maxDepth {
-		return newError(ErrCapExceeded, node, fmt.Sprintf("ref-graph depth exceeds %d", maxDepth), nil)
+func dfsVisit(graph map[string][]string, color map[string]int, stack *[]string, node string, depth int) error {
+	if depth > maxRefDepth {
+		return newError(ErrCapExceeded, node, fmt.Sprintf("ref-graph depth exceeds %d", maxRefDepth), nil)
 	}
 	color[node] = colorGray
 	*stack = append(*stack, node)
 	for _, next := range graph[node] {
-		if err := dfsVisitEdge(graph, color, stack, next, depth, maxDepth); err != nil {
+		if err := dfsVisitEdge(graph, color, stack, next, depth); err != nil {
 			return err
 		}
 	}
@@ -232,12 +236,12 @@ func dfsVisit(graph map[string][]string, color map[string]int, stack *[]string, 
 // is unvisited and reporting a cycle when next is on the active path.
 // The reported error's Path field is the cycle entry node (next, where the
 // back-edge points), and Detail is the full cycle path "n1 -> n2 -> ... -> n1".
-func dfsVisitEdge(graph map[string][]string, color map[string]int, stack *[]string, next string, depth, maxDepth int) error {
+func dfsVisitEdge(graph map[string][]string, color map[string]int, stack *[]string, next string, depth int) error {
 	switch color[next] {
 	case colorGray:
 		return newError(ErrRefCycle, next, formatCycle(*stack, next), nil)
 	case colorWhite:
-		return dfsVisit(graph, color, stack, next, depth+1, maxDepth)
+		return dfsVisit(graph, color, stack, next, depth+1)
 	}
 	return nil
 }

--- a/dipx/resolve_test.go
+++ b/dipx/resolve_test.go
@@ -143,14 +143,14 @@ func TestDetectCycle_Acyclic(t *testing.T) {
 		"c": {"d"},
 		"d": {},
 	}
-	if err := detectCycles(graph, "a", 64); err != nil {
+	if err := detectCycles(graph, "a"); err != nil {
 		t.Fatalf("expected acyclic, got %v", err)
 	}
 }
 
 func TestDetectCycle_SelfLoop(t *testing.T) {
 	graph := map[string][]string{"a": {"a"}}
-	err := detectCycles(graph, "a", 64)
+	err := detectCycles(graph, "a")
 	if !errors.Is(err, ErrRefCycle) {
 		t.Fatalf("err = %v, want ErrRefCycle", err)
 	}
@@ -162,7 +162,7 @@ func TestDetectCycle_ThreeCycle(t *testing.T) {
 		"b": {"c"},
 		"c": {"a"},
 	}
-	err := detectCycles(graph, "a", 64)
+	err := detectCycles(graph, "a")
 	if !errors.Is(err, ErrRefCycle) {
 		t.Fatalf("err = %v, want ErrRefCycle", err)
 	}
@@ -178,7 +178,7 @@ func TestDetectCycle_DepthCap(t *testing.T) {
 		}
 		graph[key(i)] = next
 	}
-	err := detectCycles(graph, key(0), 64)
+	err := detectCycles(graph, key(0))
 	if !errors.Is(err, ErrCapExceeded) {
 		t.Fatalf("err = %v, want ErrCapExceeded", err)
 	}
@@ -192,7 +192,7 @@ func TestDetectCycle_FullCyclePath(t *testing.T) {
 		"b": {"c"},
 		"c": {"a"},
 	}
-	err := detectCycles(graph, "a", 64)
+	err := detectCycles(graph, "a")
 	if err == nil {
 		t.Fatal("expected ErrRefCycle")
 	}
@@ -219,13 +219,13 @@ func TestDetectCycle_AtCapDepthSucceeds(t *testing.T) {
 		}
 		graph[key(i)] = next
 	}
-	if err := detectCycles(graph, key(0), 64); err != nil {
+	if err := detectCycles(graph, key(0)); err != nil {
 		t.Fatalf("expected at-cap chain to succeed, got %v", err)
 	}
 }
 
 func TestDetectCycle_EmptyGraph(t *testing.T) {
-	if err := detectCycles(map[string][]string{}, "any", 64); err != nil {
+	if err := detectCycles(map[string][]string{}, "any"); err != nil {
 		t.Fatalf("expected empty graph to succeed, got %v", err)
 	}
 }

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -53,18 +53,18 @@ type Suggestion struct {
 
 // Diagnose produces a health Report for the given workflow using default lint
 // options.
-func Diagnose(w *ir.Workflow, pricing cost.PricingTable) *Report {
-	return DiagnoseWithOptions(w, pricing, validator.Options{})
+func Diagnose(w *ir.Workflow) *Report {
+	return DiagnoseWithOptions(w, validator.Options{})
 }
 
 // DiagnoseWithOptions produces a health Report, threading per-invocation lint
 // options (e.g. a scoped extra-models catalog) into the lint pass so doctor's
 // DIP108 summary matches `dippin lint --extra-models`.
-func DiagnoseWithOptions(w *ir.Workflow, pricing cost.PricingTable, opts validator.Options) *Report {
+func DiagnoseWithOptions(w *ir.Workflow, opts validator.Options) *Report {
 	valResult := validator.Validate(w)
 	lintResult := validator.LintWithOptions(w, opts)
 	covReport := coverage.Analyze(w)
-	costReport := cost.Analyze(w, pricing)
+	costReport := cost.Analyze(w, cost.DefaultPricing())
 
 	r := &Report{}
 	r.Lint = buildLintSummary(valResult, lintResult)

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/2389-research/dippin-lang/cost"
 	"github.com/2389-research/dippin-lang/doctor"
 	"github.com/2389-research/dippin-lang/ir"
 	"github.com/2389-research/dippin-lang/parser"
@@ -26,7 +25,7 @@ func loadFixture(t *testing.T, path string) *ir.Workflow {
 
 func TestDiagnose_Healthy(t *testing.T) {
 	w := loadFixture(t, "testdata/healthy.dip")
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Grade != "A" {
 		t.Errorf("expected grade A, got %s (score=%d)", report.Grade, report.Score)
@@ -41,7 +40,7 @@ func TestDiagnose_Healthy(t *testing.T) {
 
 func TestDiagnose_Unhealthy(t *testing.T) {
 	w := loadFixture(t, "testdata/unhealthy.dip")
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Score >= 90 {
 		t.Errorf("expected score < 90 for unhealthy workflow, got %d", report.Score)
@@ -53,7 +52,7 @@ func TestDiagnose_Unhealthy(t *testing.T) {
 
 func TestScoreFloor(t *testing.T) {
 	w := loadFixture(t, "testdata/unhealthy.dip")
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Score < 0 {
 		t.Errorf("score should not go below 0, got %d", report.Score)
@@ -62,7 +61,7 @@ func TestScoreFloor(t *testing.T) {
 
 func TestReportHasAllFields(t *testing.T) {
 	w := loadFixture(t, "testdata/healthy.dip")
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Grade == "" {
 		t.Error("grade should not be empty")
@@ -74,7 +73,7 @@ func TestReportHasAllFields(t *testing.T) {
 
 func TestDiagnose_SevereWorkflow(t *testing.T) {
 	w := loadFixture(t, "testdata/severe.dip")
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	// Severe workflow has orphan nodes and dead ends — should score low.
 	if report.Score >= 80 {
@@ -121,7 +120,7 @@ func TestDiagnose_WithUncoveredTools(t *testing.T) {
 			}},
 		},
 	}
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Coverage.UncoveredTools == 0 {
 		t.Error("expected uncovered tools > 0 for partial tool coverage")
@@ -161,7 +160,7 @@ func TestDiagnose_GradeRanges(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			report := doctor.Diagnose(tt.w, cost.DefaultPricing())
+			report := doctor.Diagnose(tt.w)
 			if report.Grade != tt.wantGrade {
 				t.Errorf("grade = %q (score=%d), want %q", report.Grade, report.Score, tt.wantGrade)
 			}
@@ -177,7 +176,7 @@ func TestDiagnose_LintErrorsDeductScore(t *testing.T) {
 			{ID: "A", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "Do."}},
 		},
 	}
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Lint.Errors == 0 {
 		t.Error("expected lint errors for workflow missing start/exit")
@@ -209,7 +208,7 @@ func TestDiagnose_LintWarnings(t *testing.T) {
 			{From: "A", To: "B"},
 		},
 	}
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Lint.Warnings == 0 {
 		t.Error("expected lint warnings for empty prompt / no timeout")
@@ -230,7 +229,7 @@ func TestDiagnose_ScoreFloorAtZero(t *testing.T) {
 			{ID: "F", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "Do."}},
 		},
 	}
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Score != 0 {
 		t.Errorf("score should be floored at 0, got %d", report.Score)
@@ -242,7 +241,7 @@ func TestDiagnose_ScoreFloorAtZero(t *testing.T) {
 
 func TestDiagnose_SuggestionsAreSorted(t *testing.T) {
 	w := loadFixture(t, "testdata/unhealthy.dip")
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	for i := 1; i < len(report.Suggestions); i++ {
 		if report.Suggestions[i-1].Category > report.Suggestions[i].Category {
@@ -268,7 +267,7 @@ func TestDiagnose_GradeBWorkflow(t *testing.T) {
 	}
 	// Instead of trying to precisely control score, just verify the severe.dip
 	// fixture produces a grade between B and D to cover those scoreToGrade branches.
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	// This healthy workflow should be A. The actual B/C/D tests are below.
 	if report.Grade != "A" {
@@ -277,7 +276,7 @@ func TestDiagnose_GradeBWorkflow(t *testing.T) {
 
 	// Now test severe workflow for B/C/D grade coverage.
 	severe := loadFixture(t, "testdata/severe.dip")
-	severeReport := doctor.Diagnose(severe, cost.DefaultPricing())
+	severeReport := doctor.Diagnose(severe)
 	// Severe should be below A.
 	if severeReport.Grade == "A" {
 		t.Errorf("expected grade below A for severe workflow, got %s (score=%d)", severeReport.Grade, severeReport.Score)
@@ -307,7 +306,7 @@ func TestDiagnose_GradeCDWorkflow(t *testing.T) {
 			{From: "F", To: "G"},
 		},
 	}
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	// Should be C or D (score 60-79).
 	if report.Grade == "A" || report.Grade == "B" || report.Grade == "F" {
@@ -326,7 +325,7 @@ func TestDiagnose_GradeDWithManyIssues(t *testing.T) {
 		},
 		Edges: []*ir.Edge{{From: "A", To: "B"}},
 	}
-	report := doctor.Diagnose(w, cost.DefaultPricing())
+	report := doctor.Diagnose(w)
 
 	if report.Lint.Errors == 0 {
 		t.Error("expected lint errors")

--- a/export/dot.go
+++ b/export/dot.go
@@ -7,6 +7,7 @@ package export
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -141,7 +142,7 @@ func addGraphVarsAttrs(attrs *[]string, vars map[string]string) {
 			keys = append(keys, k)
 		}
 	}
-	sortStrings(keys)
+	sort.Strings(keys)
 	for _, k := range keys {
 		*attrs = append(*attrs, fmt.Sprintf("%s=%s", dotID(k), dotQuote(vars[k])))
 	}
@@ -611,7 +612,7 @@ func formatDOTAttrs(attrs map[string]string) string {
 	for k := range attrs {
 		keys = append(keys, k)
 	}
-	sortStrings(keys)
+	sort.Strings(keys)
 
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
@@ -790,16 +791,6 @@ func appendDurationParts(parts []string, d time.Duration) ([]string, time.Durati
 	return parts, d
 }
 
-// sortStrings sorts a string slice in place. Avoids importing sort for this
-// single use.
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j] < s[j-1]; j-- {
-			s[j], s[j-1] = s[j-1], s[j]
-		}
-	}
-}
-
 // applyManagerLoopScalarAttrs writes scalar manager_loop config fields as DOT node attributes.
 func applyManagerLoopScalarAttrs(attrs map[string]string, cfg ir.ManagerLoopConfig) {
 	if cfg.SubgraphRef != "" {
@@ -882,7 +873,7 @@ func flattenSteerContext(m map[string]string) string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sortStrings(keys)
+	sort.Strings(keys)
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
 		parts = append(parts, encodeSteerContextToken(k)+"="+encodeSteerContextToken(m[k]))

--- a/export/dot_test.go
+++ b/export/dot_test.go
@@ -1217,33 +1217,6 @@ func TestFormatConditionExport(t *testing.T) {
 	}
 }
 
-func TestSortStrings(t *testing.T) {
-	tests := []struct {
-		input []string
-		want  []string
-	}{
-		{[]string{"c", "a", "b"}, []string{"a", "b", "c"}},
-		{[]string{"z"}, []string{"z"}},
-		{nil, nil},
-		{[]string{}, []string{}},
-		{[]string{"a", "a"}, []string{"a", "a"}},
-	}
-	for _, tt := range tests {
-		got := make([]string, len(tt.input))
-		copy(got, tt.input)
-		sortStrings(got)
-		if len(got) != len(tt.want) {
-			t.Errorf("sortStrings(%v) length = %d, want %d", tt.input, len(got), len(tt.want))
-			continue
-		}
-		for i := range got {
-			if got[i] != tt.want[i] {
-				t.Errorf("sortStrings(%v)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
-			}
-		}
-	}
-}
-
 func TestIsSimpleDOTID(t *testing.T) {
 	tests := []struct {
 		input string

--- a/flatten/flatten.go
+++ b/flatten/flatten.go
@@ -4,6 +4,7 @@ package flatten
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
@@ -125,7 +126,7 @@ func processNode(n *ir.Node, resolve Resolver, maxDepth, depth int, seen []strin
 
 // inlineSubgraph resolves a subgraph ref and splices the child's nodes/edges into out.
 func inlineSubgraph(n *ir.Node, cfg ir.SubgraphConfig, resolve Resolver, maxDepth, depth int, seen []string, out *ir.Workflow) (*rewire, error) {
-	if containsStr(seen, cfg.Ref) {
+	if slices.Contains(seen, cfg.Ref) {
 		return nil, fmt.Errorf("flatten: cycle detected: %s", formatCycle(seen, cfg.Ref))
 	}
 
@@ -187,16 +188,6 @@ func rewireParentEdges(edges []*ir.Edge, rewires map[string]rewire, out *ir.Work
 		}
 		out.Edges = append(out.Edges, &ne)
 	}
-}
-
-// containsStr returns true if s is in the slice ss.
-func containsStr(ss []string, s string) bool {
-	for _, v := range ss {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }
 
 // formatCycle formats the seen path plus the cyclic ref for error messages.

--- a/ir/lookup.go
+++ b/ir/lookup.go
@@ -1,5 +1,7 @@
 package ir
 
+import "slices"
+
 // Node returns the node with the given ID, or nil if not found.
 func (w *Workflow) Node(id string) *Node {
 	for _, n := range w.Nodes {
@@ -193,22 +195,12 @@ func (w *Workflow) parallelEdgesTo(id string, out []*Edge, seen map[string]bool)
 		if !ok {
 			continue
 		}
-		if w.parallelTargetsNode(cfg.Targets, id) && !seen[n.ID] {
+		if slices.Contains(cfg.Targets, id) && !seen[n.ID] {
 			out = append(out, &Edge{From: n.ID, To: id})
 			seen[n.ID] = true
 		}
 	}
 	return out
-}
-
-// parallelTargetsNode returns true if targets contains id.
-func (w *Workflow) parallelTargetsNode(targets []string, id string) bool {
-	for _, t := range targets {
-		if t == id {
-			return true
-		}
-	}
-	return false
 }
 
 // fanInEdgesTo adds implicit edges from fan-in sources to id, if id is a fan-in node.

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -90,7 +90,7 @@ func formatNodeConfig(n *ir.Node, w *ir.Workflow) string {
 // formatToolHover formats tool-specific hover info.
 func formatToolHover(cfg ir.ToolConfig) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Command: `%s`\n", truncateStr(cfg.Command, 80))
+	fmt.Fprintf(&b, "Command: `%s`\n", truncateStr(cfg.Command))
 	if cfg.MarkerGrep != "" {
 		fmt.Fprintf(&b, "marker_grep: `%s`\n", cfg.MarkerGrep)
 	}
@@ -121,10 +121,13 @@ func formatAgentHover(cfg ir.AgentConfig, w *ir.Workflow) string {
 	return b.String()
 }
 
+// hoverCommandMaxLen bounds the command preview shown in tool hovers.
+const hoverCommandMaxLen = 80
+
 // truncateStr shortens a string for display.
-func truncateStr(s string, max int) string {
-	if len(s) <= max {
+func truncateStr(s string) string {
+	if len(s) <= hoverCommandMaxLen {
 		return s
 	}
-	return s[:max] + "..."
+	return s[:hoverCommandMaxLen] + "..."
 }

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -623,10 +623,11 @@ func TestResolveDefinition_MissingDoc(t *testing.T) {
 }
 
 func TestTruncateStr(t *testing.T) {
-	if got := truncateStr("hello", 10); got != "hello" {
+	if got := truncateStr("hello"); got != "hello" {
 		t.Errorf("expected hello, got %s", got)
 	}
-	if got := truncateStr("hello world this is long", 5); got != "hello..." {
-		t.Errorf("expected hello..., got %s", got)
+	long := strings.Repeat("x", 100)
+	if got := truncateStr(long); got != long[:80]+"..." {
+		t.Errorf("expected first 80 chars + ..., got %s", got)
 	}
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -762,26 +762,20 @@ func applyManagerLoopScalarMigrate(cfg *ir.ManagerLoopConfig, attrs map[string]s
 	if v, ok := attrs["subgraph_ref"]; ok {
 		cfg.SubgraphRef = v
 	}
-	applyScalarDuration(&cfg.PollInterval, attrs, "poll_interval")
-	applyScalarInt(&cfg.MaxCycles, attrs, "max_cycles")
+	applyManagerLoopNumericMigrate(cfg, attrs)
 	if v, ok := attrs["steer_context"]; ok && v != "" {
 		cfg.SteerContext = parseFlattenedSteerContext(v)
 	}
 }
 
-// applyScalarDuration reads attrs[key] and parses into *target if present and valid.
-// Thin wrapper over tryApplyDurationDefault that also handles the attr-lookup.
-func applyScalarDuration(target *time.Duration, attrs map[string]string, key string) {
-	if v, ok := attrs[key]; ok {
-		_ = tryApplyDurationDefault(v, target)
+// applyManagerLoopNumericMigrate populates the numeric scalars (poll_interval,
+// max_cycles) from DOT attrs.
+func applyManagerLoopNumericMigrate(cfg *ir.ManagerLoopConfig, attrs map[string]string) {
+	if v, ok := attrs["poll_interval"]; ok {
+		_ = tryApplyDurationDefault(v, &cfg.PollInterval)
 	}
-}
-
-// applyScalarInt reads attrs[key] and parses into *target if present and valid.
-// Thin wrapper over tryApplyIntDefault that also handles the attr-lookup.
-func applyScalarInt(target *int, attrs map[string]string, key string) {
-	if v, ok := attrs[key]; ok {
-		_ = tryApplyIntDefault(v, target)
+	if v, ok := attrs["max_cycles"]; ok {
+		_ = tryApplyIntDefault(v, &cfg.MaxCycles)
 	}
 }
 

--- a/migrate/parity.go
+++ b/migrate/parity.go
@@ -442,20 +442,20 @@ func promptsEqual(a, b string) bool {
 // compareDefaults reports differences between workflow defaults.
 func compareDefaults(a, b ir.WorkflowDefaults) []Difference {
 	var diffs []Difference
-	diffs = append(diffs, compareDefaultField(a.Model, b.Model, "defaults.model", "%q")...)
-	diffs = append(diffs, compareDefaultField(a.Provider, b.Provider, "defaults.provider", "%q")...)
+	diffs = append(diffs, compareDefaultField(a.Model, b.Model, "defaults.model")...)
+	diffs = append(diffs, compareDefaultField(a.Provider, b.Provider, "defaults.provider")...)
 	diffs = append(diffs, compareDefaultIntField(a.MaxRetries, b.MaxRetries, "defaults.max_retries")...)
 	diffs = append(diffs, compareDefaultIntField(a.MaxRestarts, b.MaxRestarts, "defaults.max_restarts")...)
-	diffs = append(diffs, compareDefaultField(a.Fidelity, b.Fidelity, "defaults.fidelity", "%q")...)
+	diffs = append(diffs, compareDefaultField(a.Fidelity, b.Fidelity, "defaults.fidelity")...)
 	return diffs
 }
 
 // compareDefaultField compares a single string field in workflow defaults.
-func compareDefaultField(a, b string, field, format string) []Difference {
+func compareDefaultField(a, b string, field string) []Difference {
 	if a == b {
 		return nil
 	}
-	fmtStr := field + ": " + format + " vs " + format
+	fmtStr := field + ": %q vs %q"
 	return []Difference{{
 		Kind:    "defaults_mismatch",
 		Message: fmt.Sprintf(fmtStr, a, b),

--- a/parser/parse_bool_test.go
+++ b/parser/parse_bool_test.go
@@ -70,6 +70,52 @@ func TestParseBoolAttrFields(t *testing.T) {
 	}
 }
 
+// TestDefaultCacheToolsBool verifies the workflow-level cache_tools default
+// routes through parseBoolAttr: it accepts the same truthy/falsy forms as the
+// node-level field and emits a diagnostic on invalid input.
+func TestDefaultCacheToolsBool(t *testing.T) {
+	cases := []struct {
+		name        string
+		val         string
+		wantBool    bool
+		wantDiagSub string
+	}{
+		{"yes", "yes", true, ""},
+		{"on", "on", true, ""},
+		{"1", "1", true, ""},
+		{"off", "off", false, ""},
+		{"invalid", "nope", false, "invalid boolean"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "workflow X\n" +
+				"  start: A\n" +
+				"  exit: A\n" +
+				"\n" +
+				"  defaults\n" +
+				"    cache_tools: " + tc.val + "\n" +
+				"\n" +
+				"  agent A\n" +
+				"    prompt: \"Do it.\"\n"
+			p := NewParser(src, "test.dip")
+			w, _ := p.Parse()
+			if got := w.Defaults.CacheTools; got != tc.wantBool {
+				t.Errorf("Defaults.CacheTools = %v, want %v", got, tc.wantBool)
+			}
+			joined := strings.Join(p.Diagnostics(), "\n")
+			if tc.wantDiagSub == "" {
+				if joined != "" {
+					t.Errorf("expected no diagnostics, got: %s", joined)
+				}
+				return
+			}
+			if !strings.Contains(joined, tc.wantDiagSub) {
+				t.Errorf("expected diagnostic containing %q, got: %s", tc.wantDiagSub, joined)
+			}
+		})
+	}
+}
+
 // buildBoolFieldDip produces a minimal valid .dip workflow that exercises
 // one of the four bool fields. The agent / tool node is the start node so
 // the workflow always has at least one node.

--- a/parser/parse_defaults.go
+++ b/parser/parse_defaults.go
@@ -124,7 +124,7 @@ func (p *Parser) applyDefaultComplexField(key, val string, loc ir.SourceLocation
 	case "max_restarts":
 		p.workflow.Defaults.MaxRestarts = p.parseInt(val, key, loc)
 	case "cache_tools":
-		p.workflow.Defaults.CacheTools = (val == "true")
+		p.workflow.Defaults.CacheTools = p.parseBoolAttr(val, key, loc)
 	default:
 		p.applyDefaultBudgetField(key, val, loc)
 	}

--- a/simulate/coverage_test.go
+++ b/simulate/coverage_test.go
@@ -277,7 +277,7 @@ func TestHumanInteractive_NilStderr(t *testing.T) {
 func TestRunAllPaths_NoExit(t *testing.T) {
 	ResetRunCounter()
 	w := &ir.Workflow{Name: "bad2", Start: "A"}
-	_, err := RunAllPaths(w, Options{})
+	_, err := RunAllPaths(w, nil)
 	if err == nil {
 		t.Fatal("expected error for missing exit node")
 	}
@@ -297,7 +297,7 @@ func TestRunAllPaths_BadCondition(t *testing.T) {
 			{From: "A", To: "B", Condition: &ir.Condition{Raw: "bad missing op"}},
 		},
 	}
-	_, err := RunAllPaths(w, Options{})
+	_, err := RunAllPaths(w, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid condition")
 	}
@@ -400,17 +400,17 @@ func TestAssignRunID_NoPipelineStartEvt(t *testing.T) {
 // --- shouldExplore ---
 
 func TestShouldExplore_Limits(t *testing.T) {
-	pe := &pathEnumerator{maxResults: 1, results: make([]*Result, 1), maxDepth: 200}
+	pe := &pathEnumerator{results: make([]*Result, maxPathResults)}
 	if pe.shouldExplore(&pathState{nodeID: "A", depth: 0, visited: make(map[string]int)}) {
-		t.Error("should not explore when maxResults reached")
+		t.Error("should not explore when maxPathResults reached")
 	}
 
-	pe2 := &pathEnumerator{maxResults: 100, maxDepth: 5}
-	if pe2.shouldExplore(&pathState{nodeID: "A", depth: 6, visited: make(map[string]int)}) {
-		t.Error("should not explore when maxDepth exceeded")
+	pe2 := &pathEnumerator{}
+	if pe2.shouldExplore(&pathState{nodeID: "A", depth: maxPathDepth + 1, visited: make(map[string]int)}) {
+		t.Error("should not explore when maxPathDepth exceeded")
 	}
 
-	pe3 := &pathEnumerator{maxResults: 100, maxDepth: 200}
+	pe3 := &pathEnumerator{}
 	if pe3.shouldExplore(&pathState{nodeID: "A", depth: 0, visited: map[string]int{"A": 2}}) {
 		t.Error("should not explore when node visited 2 times")
 	}

--- a/simulate/path_enumerator.go
+++ b/simulate/path_enumerator.go
@@ -8,10 +8,19 @@ import (
 	"github.com/2389-research/dippin-lang/ir"
 )
 
+// All-paths enumeration bounds. De-facto constants: every instance used these
+// literals. They mirror the single-path simulator's maxSteps safety valve.
+const (
+	maxPathDepth   = 200
+	maxPathResults = 100
+)
+
 // RunAllPaths enumerates all distinct execution paths through the workflow.
 // Each Result represents one complete path from start to exit (or a dead end).
-// Each path has a unique run ID.
-func RunAllPaths(w *ir.Workflow, opts Options) ([]*Result, error) {
+// Each path has a unique run ID. Only the scenario context is honored; the
+// single-path Options (interactivity, visit caps, branch selection) do not
+// apply to exhaustive enumeration.
+func RunAllPaths(w *ir.Workflow, scenario map[string]string) ([]*Result, error) {
 	if err := validateSimInput(w); err != nil {
 		return nil, err
 	}
@@ -22,10 +31,8 @@ func RunAllPaths(w *ir.Workflow, opts Options) ([]*Result, error) {
 	}
 
 	e := &pathEnumerator{
-		workflow:   w,
-		opts:       opts,
-		maxDepth:   200,
-		maxResults: 100,
+		workflow: w,
+		scenario: scenario,
 	}
 
 	return e.enumerate()
@@ -34,12 +41,10 @@ func RunAllPaths(w *ir.Workflow, opts Options) ([]*Result, error) {
 // pathEnumerator performs depth-first search over all graph edges to enumerate
 // every distinct execution path from start to exit (or dead end).
 type pathEnumerator struct {
-	workflow   *ir.Workflow
-	opts       Options
-	maxDepth   int
-	maxResults int
-	results    []*Result
-	pathCount  int // used to assign unique run IDs
+	workflow  *ir.Workflow
+	scenario  map[string]string
+	results   []*Result
+	pathCount int // used to assign unique run IDs
 }
 
 // pathState is an immutable snapshot of simulator state passed down the DFS tree.
@@ -68,7 +73,7 @@ func (pe *pathEnumerator) enumerate() ([]*Result, error) {
 	}
 
 	// Seed context with scenario values.
-	for k, v := range pe.opts.Scenario {
+	for k, v := range pe.scenario {
 		initial.ctx[k] = v
 	}
 
@@ -118,10 +123,10 @@ func (pe *pathEnumerator) explore(state *pathState) {
 
 // shouldExplore checks whether the path should continue to be explored.
 func (pe *pathEnumerator) shouldExplore(state *pathState) bool {
-	if len(pe.results) >= pe.maxResults {
+	if len(pe.results) >= maxPathResults {
 		return false
 	}
-	if state.depth > pe.maxDepth {
+	if state.depth > maxPathDepth {
 		return false
 	}
 	// Loop detection: allow revisiting a node up to 2 times (for retry loops).

--- a/simulate/simulate.go
+++ b/simulate/simulate.go
@@ -32,11 +32,6 @@ type Options struct {
 	// (via Stdin) rather than auto-succeeding.
 	Interactive bool
 
-	// AllPaths enumerates all possible execution paths through the graph
-	// rather than following a single path. Each path is a separate run
-	// reported with a distinct run ID suffix.
-	AllPaths bool
-
 	// MaxNodeVisits limits how many times a single node can be visited.
 	// When exceeded, the simulator forces the loop-exit edge (the first
 	// conditional edge that doesn't match). 0 means unlimited (use maxSteps only).

--- a/simulate/simulate_test.go
+++ b/simulate/simulate_test.go
@@ -588,7 +588,7 @@ func TestRunAllPaths_Conditional(t *testing.T) {
 	ResetRunCounter()
 	w := conditionalWorkflow()
 
-	results, err := RunAllPaths(w, Options{})
+	results, err := RunAllPaths(w, nil)
 	if err != nil {
 		t.Fatalf("RunAllPaths() error: %v", err)
 	}
@@ -621,7 +621,7 @@ func TestRunAllPaths_Minimal(t *testing.T) {
 	ResetRunCounter()
 	w := minimalWorkflow()
 
-	results, err := RunAllPaths(w, Options{})
+	results, err := RunAllPaths(w, nil)
 	if err != nil {
 		t.Fatalf("RunAllPaths() error: %v", err)
 	}
@@ -1182,7 +1182,7 @@ func TestRunAllPaths_OrCondition(t *testing.T) {
 	ResetRunCounter()
 	w := orConditionWorkflow()
 
-	results, err := RunAllPaths(w, Options{})
+	results, err := RunAllPaths(w, nil)
 	if err != nil {
 		t.Fatalf("RunAllPaths() error: %v", err)
 	}
@@ -1196,7 +1196,7 @@ func TestRunAllPaths_InCondition(t *testing.T) {
 	ResetRunCounter()
 	w := inConditionWorkflow()
 
-	results, err := RunAllPaths(w, Options{})
+	results, err := RunAllPaths(w, nil)
 	if err != nil {
 		t.Fatalf("RunAllPaths() error: %v", err)
 	}
@@ -1209,7 +1209,7 @@ func TestRunAllPaths_ComplexCondition(t *testing.T) {
 	ResetRunCounter()
 	w := complexConditionWorkflow()
 
-	results, err := RunAllPaths(w, Options{})
+	results, err := RunAllPaths(w, nil)
 	if err != nil {
 		t.Fatalf("RunAllPaths() error: %v", err)
 	}
@@ -1222,7 +1222,7 @@ func TestRunAllPaths_RestartLoop(t *testing.T) {
 	ResetRunCounter()
 	w := restartWorkflow()
 
-	results, err := RunAllPaths(w, Options{})
+	results, err := RunAllPaths(w, nil)
 	if err != nil {
 		t.Fatalf("RunAllPaths() error: %v", err)
 	}
@@ -1236,7 +1236,7 @@ func TestRunAllPaths_Parallel(t *testing.T) {
 	ResetRunCounter()
 	w := parallelWorkflow()
 
-	results, err := RunAllPaths(w, Options{})
+	results, err := RunAllPaths(w, nil)
 	if err != nil {
 		t.Fatalf("RunAllPaths() error: %v", err)
 	}
@@ -1266,7 +1266,7 @@ func TestRunAllPaths_Parallel(t *testing.T) {
 func TestRunAllPaths_MissingStart(t *testing.T) {
 	ResetRunCounter()
 	w := &ir.Workflow{Name: "bad", Exit: "Done"}
-	_, err := RunAllPaths(w, Options{})
+	_, err := RunAllPaths(w, nil)
 	if err == nil {
 		t.Fatal("expected error for missing start node")
 	}
@@ -1667,7 +1667,7 @@ func TestRunAllPaths_NotCondition(t *testing.T) {
 		},
 	}
 
-	results, err := RunAllPaths(w, Options{})
+	results, err := RunAllPaths(w, nil)
 	if err != nil {
 		t.Fatalf("RunAllPaths() error: %v", err)
 	}

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -35,7 +35,7 @@ func RunCase(w *ir.Workflow, tc TestCase) CaseResult {
 	result, err := simulate.Run(w, simulate.Options{
 		Scenario:      tc.Scenario,
 		MaxNodeVisits: defaultMaxNodeVisits,
-		Branch:        toBoolMap(tc.Branch),
+		Branch:        toSet(tc.Branch),
 	})
 	if err != nil {
 		cr.Errors = append(cr.Errors, fmt.Sprintf("simulation error: %v", err))
@@ -154,17 +154,6 @@ func findInPath(path []string, target string, offset int) int {
 		}
 	}
 	return -1
-}
-
-func toBoolMap(items []string) map[string]bool {
-	if len(items) == 0 {
-		return nil
-	}
-	m := make(map[string]bool, len(items))
-	for _, item := range items {
-		m[item] = true
-	}
-	return m
 }
 
 func toSet(items []string) map[string]bool {

--- a/unused/unused.go
+++ b/unused/unused.go
@@ -38,7 +38,7 @@ func buildReport(w *ir.Workflow, sinks []string, costs *cost.Report) *Report {
 	for _, id := range sinks {
 		node := buildUnusedNode(w, id, costs)
 		r.UnusedNodes = append(r.UnusedNodes, node)
-		r.TotalWasted = addCostRange(r.TotalWasted, node.WastedCost)
+		r.TotalWasted = cost.AddCostRange(r.TotalWasted, node.WastedCost)
 	}
 	return r
 }
@@ -54,13 +54,4 @@ func buildUnusedNode(w *ir.Workflow, id string, costs *cost.Report) UnusedNode {
 		un.WastedCost = nc.Cost
 	}
 	return un
-}
-
-// addCostRange sums two CostRange values.
-func addCostRange(a, b cost.CostRange) cost.CostRange {
-	return cost.CostRange{
-		Min:      a.Min + b.Min,
-		Expected: a.Expected + b.Expected,
-		Max:      a.Max + b.Max,
-	}
 }

--- a/validator/lint_coverage_test.go
+++ b/validator/lint_coverage_test.go
@@ -229,20 +229,3 @@ func TestStripNamespace(t *testing.T) {
 		}
 	}
 }
-
-// --- slicesEqual edge case ---
-
-func TestSlicesEqual_BothEmpty(t *testing.T) {
-	if !slicesEqual(nil, nil) {
-		t.Error("nil slices should be equal")
-	}
-	if !slicesEqual([]string{}, []string{}) {
-		t.Error("empty slices should be equal")
-	}
-}
-
-func TestSlicesEqual_DifferentLength(t *testing.T) {
-	if slicesEqual([]string{"a"}, []string{"a", "b"}) {
-		t.Error("different length slices should not be equal")
-	}
-}

--- a/validator/validate.go
+++ b/validator/validate.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -346,20 +347,13 @@ func reconstructCycle(parent map[string]string, from, to string) []string {
 		maxSteps--
 	}
 	path = append(path, to)
-	reversePath(path)
+	slices.Reverse(path)
 	return path
 }
 
 // canWalk checks whether the cycle reconstruction loop should continue.
 func canWalk(curr, target string, seen map[string]bool, maxSteps int) bool {
 	return curr != target && curr != "" && !seen[curr] && maxSteps > 0
-}
-
-// reversePath reverses a string slice in place.
-func reversePath(path []string) {
-	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
-		path[i], path[j] = path[j], path[i]
-	}
 }
 
 // checkExitNoOutgoing verifies DIP006: the exit node has no outgoing edges.
@@ -425,7 +419,7 @@ func collectParallelFanIn(w *ir.Workflow) (parallels, fanIns []nodeTargets) {
 // hasMatch checks if any entry in candidates has sorted list equal to target.
 func hasMatch(target []string, candidates []nodeTargets) bool {
 	for _, c := range candidates {
-		if slicesEqual(target, c.sorted) {
+		if slices.Equal(target, c.sorted) {
 			return true
 		}
 	}
@@ -577,33 +571,8 @@ func fillLevenshteinRow(a, b string, i int, prev, curr []int) {
 		if a[i-1] == b[j-1] {
 			cost = 0
 		}
-		curr[j] = min3(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		curr[j] = min(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
 	}
-}
-
-// min3 returns the minimum of three integers.
-func min3(a, b, c int) int {
-	m := a
-	if b < m {
-		m = b
-	}
-	if c < m {
-		m = c
-	}
-	return m
-}
-
-// slicesEqual returns true if two sorted string slices are element-wise equal.
-func slicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // locFile returns the file from a SourceLocation, defaulting to "<unknown>".


### PR DESCRIPTION
## Summary

Removes flexibility surface that never delivered flexibility, working through the machine-generated inventory in #164. Each item was re-grounded at its cited `file:line` before editing; every changed line traces to a confirmed inventory entry. Behavior is preserved across all swaps (verified for edge cases: `strconv.Itoa` matches the old recursive `itoa` for 0/negatives; `slices.Contains/Equal/Reverse` and `min`/`max` builtins are drop-in; `toSet`'s non-nil empty map is equivalent to `toBoolMap`'s nil because the simulator keys off `len(Branch)==0`).

## Inventory checklist

**Fixed (22 items):**

Stdlib / builtin swaps (behavior-identical):
- [x] `diff.go` — `itoa`/`intToStr` → `strconv.Itoa`
- [x] `export/dot.go` — `sortStrings` → `sort.Strings` (3 call sites)
- [x] `flatten.go` — `containsStr` → `slices.Contains`
- [x] `ir/lookup.go` — `parallelTargetsNode` → `slices.Contains`
- [x] `validator/validate.go` — `min3` → `min`, `slicesEqual` → `slices.Equal`, `reversePath` → `slices.Reverse`
- [x] `cmd_explain.go` — `maxInt` → `max`

Single-use params → named consts / inlined:
- [x] `diff.truncate(maxLen)` → `const promptDiffMaxLen`
- [x] `lsp/hover.truncateStr(max)` → `const hoverCommandMaxLen`
- [x] `cost.sortTopCosts(limit)` → `const topCostLimit`
- [x] `migrate/parity.compareDefaultField(format)` → inlined `"%q"`
- [x] `migrate.applyScalarDuration`/`applyScalarInt` wrappers → inlined (extracted `applyManagerLoopNumericMigrate` to stay under complexity caps)
- [x] `dipx` `maxDepth` param chain (`walkRefs`→`detectCyclesAll`→`detectCycles`→`dfsVisit`→`dfsVisitEdge`) → `const maxRefDepth`
- [x] `diff.Compare(pricing)` → drop, use `cost.DefaultPricing()` internally
- [x] `doctor.Diagnose`/`DiagnoseWithOptions(pricing)` → drop, use `cost.DefaultPricing()` internally

Duplicate collapse:
- [x] `unused.addCostRange` → exported `cost.AddCostRange`
- [x] `testrunner.toBoolMap` → `toSet`
- [x] `dipx.verifyAllHashes` test-only wrapper → tests call `verifyAllHashesCtx` directly

Dead / inert knobs removed:
- [x] `simulate.Options.AllPaths` — written at `cmd_simulate.go:69`, never read; dispatch keys off the CLI flag. Removed field + assignment (and the now-unused `allPaths` param on `prepareSimulation`).
- [x] `pathEnumerator.maxDepth`/`maxResults` → `const maxPathDepth`/`maxPathResults`
- [x] `RunAllPaths`/`pathEnumerator.opts` — narrowed signature to `RunAllPaths(w, scenario map[string]string)` since `Scenario` was the only honored field (the rest were silently dropped)

Behavioral fix:
- [x] `parser/parse_defaults.go` — workflow-default `cache_tools` now routes through `parseBoolAttr` instead of `(val == "true")`, so it accepts `yes`/`1`/`on`/`off` and emits a diagnostic on invalid input, matching the node-level field. New `TestDefaultCacheToolsBool` covers truthy/falsy forms and the invalid-input diagnostic.

**Skipped (2 items — flagged by the issue as needing product intent / "decide first"):**
- [ ] `export.ExportOptions.HighlightGoalGates` — **skipped.** Not dead in the clear-cut way `AllPaths` was: it has dedicated tests for enabled/disabled and a non-agent guard, i.e. a plausibly-intended feature on public-ish surface. Removing it means rewriting tests to call an unexported helper. The issue itself says "confirm intent before deleting." Left for a human call.
- [ ] `flatten.Options.MaxDepth` — **skipped.** The issue's explicitly weakest item ("`Options` is public package API… Otherwise leave as-is"). It's exported API consumed by `cmd_export`. Left as-is.

## Verification

Full pre-commit gate passed (golangci-lint, vet, gofmt, all tests, release checks, cyclomatic ≤5, cognitive ≤7, validate-examples).

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784741469&installation_id=131176874&pr_number=170&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F170&signature=1dbd8d0a74bf434c34ca9ea8d6f719d6887e7449b4967c4a4e35a24097bfbdc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->