### PR TITLE
docs: full accuracy sweep — website, docs, editor grammars, LLM spec vs current language

### DIFF
--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -488,7 +488,7 @@ Runtime state: `stack.child.cycles`, `stack.child.outcome`, `stack.child.status`
 | condition | `when <expr>` | Guard expression |
 | outcome shorthand | `on <token>` | Sugar for `when ctx.outcome = <token>` (agent) or `when ctx.tool_marker = <token>` (tool + `marker_grep`); `fmt` rewrites eligible `when` to `on`. Not for human gates (route on choice/label) or marker-less tools — use `when` |
 | label | `label: <text>` | Display text / human choice button |
-| choice | `choice: <key>` | Human-gate routing key; carried, not interpreted — marks the load-bearing routing key so `label:` stays display-only (DIP150) |
+| choice | `choice: <key>` | Human-gate routing key; carried, not interpreted — `choice:` is preferred when present, and `label:` remains the fallback routing key when `choice:` is absent (DIP150) |
 | weight | `weight: <int>` | Soft-deprecated (DIP151) — parsed but ignored by routing; removal slated for dip 2 |
 | override | `override: true` | Carried, not interpreted by the parser |
 | else default | `else -> <NodeID>` | Section-level success-side default route; at most one per `edges` block; no source node and no attributes (#157) |

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -40,7 +40,7 @@ workflow <Name>
   fan_in <ID> <- <Source1>, <Source2>[, ...]
 
   edges
-    <From> -> <To> [on <token> | when <condition>] [label: <text>] [weight: <int>] [loop] [override: true]
+    <From> -> <To> [on <token> | when <condition>] [label: <text>] [choice: <key>] [weight: <int>] [loop] [override: true]
     [else -> <NodeID>]   # success-side default for any node with no matching guard / unconditional edge; at most one per block
 ```
 
@@ -488,7 +488,10 @@ Runtime state: `stack.child.cycles`, `stack.child.outcome`, `stack.child.status`
 | condition | `when <expr>` | Guard expression |
 | outcome shorthand | `on <token>` | Sugar for `when ctx.outcome = <token>` (agent) or `when ctx.tool_marker = <token>` (tool + `marker_grep`); `fmt` rewrites eligible `when` to `on`. Not for human gates (route on choice/label) or marker-less tools — use `when` |
 | label | `label: <text>` | Display text / human choice button |
-| weight | `weight: <int>` | Priority (higher wins) |
+| choice | `choice: <key>` | Human-gate routing key; carried, not interpreted — marks the load-bearing routing key so `label:` stays display-only (DIP150) |
+| weight | `weight: <int>` | Soft-deprecated (DIP151) — parsed but ignored by routing; removal slated for dip 2 |
+| override | `override: true` | Carried, not interpreted by the parser |
+| else default | `else -> <NodeID>` | Section-level success-side default route; at most one per `edges` block; no source node and no attributes (#157) |
 | loop | `loop` | Bare keyword marking a back-edge; **required on back-edges** to avoid DIP005 (unconditional cycle). Legacy `restart: true` still parses; `fmt` rewrites it to `loop` |
 
 ### Conditions

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -1,6 +1,6 @@
 # Analysis Commands
 
-Dippin includes six analysis commands that inspect workflows for cost, coverage, health, optimization opportunities, and change impact. All produce human-readable text output by default.
+Dippin includes eight analysis commands that inspect workflows for cost, coverage, health, optimization opportunities, dead code, change impact, calibration, and dry-run behavior. All produce human-readable text output by default.
 
 ```mermaid
 graph LR
@@ -10,6 +10,8 @@ graph LR
     IR --> Doc["dippin doctor"]
     IR --> Opt["dippin optimize"]
     IR --> Sim["dippin simulate"]
+    IR --> Unused["dippin unused"]
+    IR --> Feedback["dippin feedback"]
     DIP2[".dip file (v2)"] --> IR2["ir.Workflow"]
     IR --> Diff["dippin diff"]
     IR2 --> Diff
@@ -165,7 +167,6 @@ dippin doctor pipeline.dip
 ─── Coverage ──────────────────────────────────────────────
   Reachable: 21/21 nodes
   ✓ All paths terminate
-  ✓ All tool outputs covered
 
 ─── Cost ──────────────────────────────────────────────────
   Expected: $2.10  (range: $1.50 – $8.40)
@@ -342,10 +343,10 @@ Unlike text-based `diff`, this compares graph structure: nodes added/removed, ed
 Compare predicted costs against actual execution telemetry to calibrate estimates.
 
 ```sh
-dippin feedback pipeline.dip telemetry.csv
+dippin feedback pipeline.dip telemetry.jsonl
 ```
 
-**Input:** The workflow file (for predicted costs) and a CSV telemetry file with columns: `node_id`, `input_tokens`, `output_tokens`, `cost_usd`.
+**Input:** The workflow file (for predicted costs) and a JSONL telemetry file. Each line is a JSON object with fields: `event`, `node`, `model`, `provider`, `tokens_in`, `tokens_out`, `actual_cost`, `turns`, `timestamp`.
 
 **When to use:** After running a pipeline in production, export telemetry and feed it back to see how accurate the cost predictions were. Outliers (>2x or <0.5x ratio) are flagged for investigation.
 
@@ -374,6 +375,50 @@ dippin feedback pipeline.dip telemetry.csv
 
 ---
 
+## unused
+
+Detect dead-branch nodes (reachable from start but with no path to exit) and the cost wasted running them.
+
+```sh
+dippin unused pipeline.dip
+```
+
+**Output:**
+
+```
+═══ Unused Nodes ══════════════════════════════════════════
+  ✗ AbandonedReview              agent (Abandoned Review)
+  ✗ OrphanCleanup                tool
+
+─── Wasted Cost ───────────────────────────────────────────
+  $0.00 - $1.20 estimated wasted per run
+
+─── Summary ───────────────────────────────────────────────
+  2 unused node(s) found
+```
+
+**What it checks:** A node is "unused" if it is reachable from the start node but has no path to exit (a sink). The package combines coverage analysis (which finds sinks) with cost analysis to estimate the wasted cost of reaching each dead-branch node.
+
+**When to use:** After editing routing to confirm every reachable node can still reach exit. Unused nodes either indicate a missing edge or genuinely dead code that should be removed.
+
+**JSON schema:**
+
+```json
+{
+  "unused_nodes": [
+    {
+      "node_id": "AbandonedReview",
+      "label": "Abandoned Review",
+      "kind": "agent",
+      "wasted_cost": {"min": 0.0, "expected": 0.6, "max": 1.2}
+    }
+  ],
+  "total_wasted": {"min": 0.0, "expected": 0.6, "max": 1.2}
+}
+```
+
+---
+
 ## Composing Analysis Commands
 
 A typical analysis workflow:
@@ -394,5 +439,5 @@ dippin optimize pipeline.dip
 dippin diff old.dip new.dip
 
 # 5. After production runs, calibrate
-dippin feedback pipeline.dip telemetry.csv
+dippin feedback pipeline.dip telemetry.jsonl
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,12 @@ dippin-lang/
 │   ├── lint_writable_paths.go # DIP141, DIP142 (writable_paths safety)
 │   ├── lint_subgraph_tool_access.go # DIP143 (subgraph tool_access inheritance)
 │   ├── lint_failure_route.go # DIP144 (agent node missing failure route)
-│   └── lint_budget.go        # DIP145 (negative budget default)
+│   ├── lint_budget.go        # DIP145 (negative budget default)
+│   ├── lint_chain_attack.go  # DIP146, DIP147 (response-injection chain attack)
+│   ├── lint_last_response_truncate.go # DIP148 (last_response truncation mitigation)
+│   ├── lint_routing.go       # DIP149, DIP151 (edge routing / unused weight)
+│   ├── lint_human.go         # DIP150 (human-gate choice keys)
+│   └── ...                   # further lint_*.go files cover DIP110–DIP134 (response, subgraph, tool_cmd, etc.)
 │
 ├── formatter/          # Canonical .dip source formatter
 │   └── format.go       # IR → canonical .dip text (idempotent)
@@ -151,15 +156,21 @@ dippin-lang/
 ├── scaffold/           # Template scaffolding for `dippin new`
 │   └── scaffold.go     # Build(template, name) → *ir.Workflow
 │
+├── flatten/            # Subgraph ref inlining
+│   ├── flatten.go      # Inline referenced workflows into one flat ir.Workflow
+│   └── resolver.go     # Resolver interface + disk-backed ref loading (imports parser)
+│
 └── cmd/dippin/         # CLI entry point
     ├── main.go         # os.Args → Run()
     ├── cli.go          # Command dispatch and global flag handling
     ├── cmd_parse.go    # parse command
     ├── cmd_validate.go # validate command
     ├── cmd_check.go    # check command
+    ├── cmd_watch.go    # watch command (re-lint on file change)
     ├── cmd_fmt.go      # fmt command
     ├── cmd_new.go      # new command
     ├── cmd_export.go   # export-dot command
+    ├── cmd_export_dip.go # export-dip command (flattened workflow → .dip)
     ├── cmd_migrate.go  # migrate + validate-migration commands
     ├── cmd_simulate.go # simulate command
     ├── cmd_cost.go     # cost command
@@ -175,7 +186,8 @@ dippin-lang/
     ├── cmd_lsp.go      # lsp command
     ├── cmd_pack.go     # pack command (.dipx producer)
     ├── cmd_unpack.go   # unpack command (.dipx → directory)
-    └── cmd_inspect.go  # inspect command (.dipx → manifest summary)
+    ├── cmd_inspect.go  # inspect command (.dipx → manifest summary)
+    └── cmd_spec.go     # spec command (print full language specification)
 ```
 
 ### Loader Tier (dipx)
@@ -213,6 +225,8 @@ graph BT
     unused --> coverage
     unused --> cost
     graph["graph"] --> ir
+    flatten["flatten"] --> ir
+    flatten --> parser
     testrunner["testrunner"] --> ir
     testrunner --> simulate
     lsp["lsp"] --> ir
@@ -237,6 +251,7 @@ graph BT
     cmd --> lsp
     cmd --> unused
     cmd --> graph
+    cmd --> flatten
     cmd --> testrunner
     cmd --> dipx
 ```
@@ -355,6 +370,12 @@ Checks semantic quality — patterns that are likely bugs. Decomposed into focus
 - **Subgraph tool access** (`lint_subgraph_tool_access.go`): DIP143 — subgraph does not inherit parent tool_access restrictions
 - **Failure route** (`lint_failure_route.go`): DIP144 — agent node missing failure route
 - **Budget** (`lint_budget.go`): DIP145 — negative graph budget default
+- **Chain attack** (`lint_chain_attack.go`): DIP146, DIP147 — response-injection / cross-node chain-attack detection
+- **Last-response truncate** (`lint_last_response_truncate.go`): DIP148 — `last_response_truncate` mitigation hint
+- **Routing** (`lint_routing.go`): DIP149, DIP151 — edge routing validity and unused `weight:` soft-deprecation
+- **Human** (`lint_human.go`): DIP150 — human-gate `choice:` edge keys
+
+(Further modules — `lint_response.go`, `lint_subgraph.go`, `lint_tool_cmd.go`, etc. — cover DIP110–DIP134.)
 
 ### The Diagnostic Type
 
@@ -470,7 +491,7 @@ The `event` package defines the canonical event types (`pipeline_start`, `node_e
 
 ## The Analysis Packages
 
-Five packages provide analysis over IR workflows. They compose each other:
+Six packages provide analysis over IR workflows. They compose each other:
 
 ```mermaid
 graph BT

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -515,7 +515,7 @@ graph BT
 - **doctor** — Aggregation layer. Computes a score from lint + coverage + cost, maps to grade A–F, generates suggestions.
 - **optimize** — Rule-based model substitution. Identifies simple prompts, retry-loop nodes, and bookkeeping tasks that can use cheaper models.
 - **diff** — Structural comparison between two workflows with field-level change tracking and cost delta.
-- **feedback** — Reads CSV telemetry, compares against predicted costs, flags outliers.
+- **feedback** — Reads JSONL telemetry, compares against predicted costs, flags outliers.
 - **unused** — Detects dead-branch nodes (reachable from start but with no path to exit) and estimates their wasted cost by combining coverage and cost analysis.
 
 See [analysis.md](analysis.md) for output formats and JSON schemas.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,10 +72,10 @@ dippin-lang/
 │   ├── lint_subgraph_tool_access.go # DIP143 (subgraph tool_access inheritance)
 │   ├── lint_failure_route.go # DIP144 (agent node missing failure route)
 │   ├── lint_budget.go        # DIP145 (negative budget default)
-│   ├── lint_chain_attack.go  # DIP146, DIP147 (response-injection chain attack)
-│   ├── lint_last_response_truncate.go # DIP148 (last_response truncation mitigation)
-│   ├── lint_routing.go       # DIP149, DIP151 (edge routing / unused weight)
-│   ├── lint_human.go         # DIP150 (human-gate choice keys)
+│   ├── lint_chain_attack.go  # DIP112, DIP139, DIP143, DIP146, DIP147 (response-injection chain attack)
+│   ├── lint_last_response_truncate.go # DIP147, DIP148 (last_response truncation mitigation)
+│   ├── lint_routing.go       # DIP103, DIP149, DIP151 (edge routing / unused weight)
+│   ├── lint_human.go         # DIP127, DIP128, DIP129, DIP150 (human-gate modes + choice keys)
 │   └── ...                   # further lint_*.go files cover DIP110–DIP134 (response, subgraph, tool_cmd, etc.)
 │
 ├── formatter/          # Canonical .dip source formatter
@@ -370,12 +370,14 @@ Checks semantic quality — patterns that are likely bugs. Decomposed into focus
 - **Subgraph tool access** (`lint_subgraph_tool_access.go`): DIP143 — subgraph does not inherit parent tool_access restrictions
 - **Failure route** (`lint_failure_route.go`): DIP144 — agent node missing failure route
 - **Budget** (`lint_budget.go`): DIP145 — negative graph budget default
-- **Chain attack** (`lint_chain_attack.go`): DIP146, DIP147 — response-injection / cross-node chain-attack detection
-- **Last-response truncate** (`lint_last_response_truncate.go`): DIP148 — `last_response_truncate` mitigation hint
-- **Routing** (`lint_routing.go`): DIP149, DIP151 — edge routing validity and unused `weight:` soft-deprecation
-- **Human** (`lint_human.go`): DIP150 — human-gate `choice:` edge keys
+- **Chain attack** (`lint_chain_attack.go`): DIP112, DIP139, DIP143, DIP146, DIP147 — response-injection / cross-node chain-attack detection
+- **Last-response truncate** (`lint_last_response_truncate.go`): DIP147, DIP148 — `last_response_truncate` mitigation hint
+- **Routing** (`lint_routing.go`): DIP103, DIP149, DIP151 — edge routing validity and unused `weight:` soft-deprecation
+- **Human** (`lint_human.go`): DIP127, DIP128, DIP129, DIP150 — human-gate interaction modes + `choice:` edge keys
 
 (Further modules — `lint_response.go`, `lint_subgraph.go`, `lint_tool_cmd.go`, etc. — cover DIP110–DIP134.)
+
+**DIP138 is reserved** — it has no firing logic and is excluded by `lint.go`'s `Lint()`, so it is never emitted.
 
 ### The Diagnostic Type
 
@@ -491,7 +493,7 @@ The `event` package defines the canonical event types (`pipeline_start`, `node_e
 
 ## The Analysis Packages
 
-Six packages provide analysis over IR workflows. They compose each other:
+Seven packages provide analysis over IR workflows. They compose each other:
 
 ```mermaid
 graph BT
@@ -504,6 +506,8 @@ graph BT
     optimize["optimize"] --> cost
     diff["diff"] --> cost
     feedback["feedback"] --> cost
+    unused["unused"] --> cost
+    unused --> coverage
 ```
 
 - **cost** — Heuristic token counting, turn estimation, per-model pricing. Pure analysis, no side effects.
@@ -512,6 +516,7 @@ graph BT
 - **optimize** — Rule-based model substitution. Identifies simple prompts, retry-loop nodes, and bookkeeping tasks that can use cheaper models.
 - **diff** — Structural comparison between two workflows with field-level change tracking and cost delta.
 - **feedback** — Reads CSV telemetry, compares against predicted costs, flags outliers.
+- **unused** — Detects dead-branch nodes (reachable from start but with no path to exit) and estimates their wasted cost by combining coverage and cost analysis.
 
 See [analysis.md](analysis.md) for output formats and JSON schemas.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -556,7 +556,7 @@ $ dippin explain DIP101
   Example:
     A -> B when ctx.outcome = success
     A -> C when ctx.outcome = fail
-    A -> D  // unreachable
+    A -> D  # unreachable
 ```
 
 In JSON mode, outputs the `Explanation` struct with `code`, `summary`, `trigger`, `fix`, and `example` fields.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -551,11 +551,11 @@ $ dippin explain DIP101
   unreachable node after conditional branches
 
   Trigger: A node follows conditional branches that already cover all outcomes.
-  Fix:     Route the node through a condition, or remove it if unreachable.
+  Fix:     Route the node through a condition, add a section `else -> <node>` default that covers it, or remove it if unreachable.
 
   Example:
-    A -> B [success]
-    A -> C [failure]
+    A -> B when ctx.outcome = success
+    A -> C when ctx.outcome = fail
     A -> D  // unreachable
 ```
 

--- a/docs/edges.md
+++ b/docs/edges.md
@@ -210,7 +210,10 @@ states "everything not handled above goes here" once.
   nodes without one.
 
 dippin validates that the `else` target node exists (DIP003) and treats it as reachable
-(DIP004); the runtime resolves an unmatched node to the `else` target. See
+(DIP004); the runtime resolves an unmatched node to the `else` target. Note: `dippin
+simulate` / `dippin test` do not yet traverse the `else` default (tracked in
+[#158](https://github.com/2389-research/dippin-lang/issues/158)); a paired runtime
+resolves it. See
 [the error-funnel decision](proposals/2026-06-16-error-funnel-default.md).
 
 ---

--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -89,6 +89,7 @@ Or use a generic LSP client extension (like vscode-languageclient) with this con
 | Comments | `# comment` | comment |
 | Arrows | `->`, `<-` | operator |
 | Conditions | `when`, `and`, `or`, `not` | keyword |
+| Edge keywords | `on`, `loop`, `choice:`, `weight:`, `override:`, `restart:`, `else` | keyword |
 | Variables | `ctx.outcome`, `graph.goal` | variable |
 | Interpolation | `${ctx.var}` | variable |
 | Booleans | `true`, `false` | constant |

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -38,7 +38,7 @@ workflow <Name>
   fan_in <ID> <- <Source1>, <Source2>[, ...]
 
   edges
-    <From> -> <To> [on <token> | when <condition>] [label: <text>] [weight: <int>] [loop] [override: true]
+    <From> -> <To> [on <token> | when <condition>] [label: <text>] [choice: <key>] [weight: <int>] [loop] [override: true]
     [else -> <NodeID>]   # success-side default for any node with no matching guard / unconditional edge; at most one per block
 ```
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -177,7 +177,7 @@ If you use a field name that is not recognized for the current node type, the pa
 
 ## Human Nodes
 
-Human nodes pause execution and wait for human input. They support three interaction modes.
+Human nodes pause execution and wait for human input. They support four interaction modes.
 
 ```dippin
   human Approve
@@ -195,7 +195,7 @@ Human nodes pause execution and wait for human input. They support three interac
 | `questions_key` | String | `interview_questions` | Context key to read questions from. Interview mode only. |
 | `answers_key` | String | `interview_answers` | Context key to write answers to. Interview mode only. |
 | `timeout` | Duration | — | How long to wait for human input before the `timeout_action` fires (e.g. `5m`, `30s`). `0`/unset = wait indefinitely. |
-| `timeout_action` | String | — | What to do when `timeout` elapses: `fail` (the node fails) or `default` (use the `default` selection). Empty = no timeout behavior. Any other value is a parse error. |
+| `timeout_action` | String | — | What to do when `timeout` elapses: `fail` (the node fails), `default` (use the `default` selection), or empty. Empty falls back to the node's `default` answer if one is set, otherwise fails. Any other value is a parse error. |
 
 ### Choice Mode
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -120,6 +120,7 @@ Agent nodes invoke an LLM. They are the most configurable node kind.
 | `cache_tools` | Boolean | workflow default | Whether to cache tool call results for this agent. Useful for expensive, deterministic tools. |
 | `compaction` | String | workflow default | Context compaction mode for managing long context windows. |
 | `compaction_threshold` | Float | — | Threshold value that triggers compaction (provider-specific semantics). |
+| `last_response_truncate` | Integer | — | Caps how much of the prior node's response is carried into this agent's context, in characters. `0`/unset = no truncation. Bounds the context-chaining attack surface; a negative value raises DIP148. |
 | `reasoning_effort` | String | — | Extended thinking effort level (provider-specific, e.g., `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`). Controls how much reasoning budget the LLM spends. |
 | `fidelity` | String | workflow default | Checkpoint fidelity level for this node's state. |
 | `auto_status` | Boolean | false | When true, the engine parses `STATUS: <status>` from the LLM response to set `ctx.outcome`. This enables automatic routing based on the agent's self-assessment. |
@@ -193,6 +194,8 @@ Human nodes pause execution and wait for human input. They support three interac
 | `default` | String | — | Default selection if no input. Only meaningful for `"choice"` mode. |
 | `questions_key` | String | `interview_questions` | Context key to read questions from. Interview mode only. |
 | `answers_key` | String | `interview_answers` | Context key to write answers to. Interview mode only. |
+| `timeout` | Duration | — | How long to wait for human input before the `timeout_action` fires (e.g. `5m`, `30s`). `0`/unset = wait indefinitely. |
+| `timeout_action` | String | — | What to do when `timeout` elapses: `fail` (the node fails) or `default` (use the `default` selection). Empty = no timeout behavior. Any other value is a parse error. |
 
 ### Choice Mode
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -255,7 +255,7 @@ Add `when <expression>` to gate an edge on a runtime condition:
 | `loop` | Flag | Bare keyword marking a back-edge (loop restart). Legacy `restart: true` is an accepted synonym that `dippin fmt` rewrites to `loop` |
 | `override: true` | Boolean | Carried, not interpreted by dippin — marks a human-authored validation override for a paired runtime to act on |
 
-A single `else -> <node>` line at the bottom of the `edges` block sets the graph's success-side default destination — any node whose guard edges all fail to match, and which has no unconditional edge of its own, routes there. At most one per edges block; it has no source node. See [edges.md](edges.md).
+A single `else -> <node>` line at the bottom of the `edges` block sets the graph's success-side default destination — any node whose guard edges all fail to match, and which has no unconditional edge of its own, routes there. At most one per edges block; it has no source node. See [edges.md](edges.md). Note: `dippin simulate` / `dippin test` do not yet traverse the `else` default (tracked in [#158](https://github.com/2389-research/dippin-lang/issues/158)); a paired runtime resolves it.
 
 Attributes can be combined on a single line:
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -221,7 +221,7 @@ An omitted field inherits the target agent's value. An inline-form parallel (`->
 The `edges` block defines connections between nodes. Every edge is a line of the form:
 
 ```
-<FromID> -> <ToID> [when <condition>] [label: <text>] [weight: <int>] [restart: true]
+<FromID> -> <ToID> [on <token> | when <condition>] [label: <text>] [choice: <key>] [weight: <int>] [loop] [override: true]
 ```
 
 ### Basic edges
@@ -247,15 +247,20 @@ Add `when <expression>` to gate an edge on a runtime condition:
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
+| `on <token>` | Token | Shorthand equality guard against the source node's outcome channel — agent (`ctx.outcome`) or tool+`marker_grep` (`ctx.tool_marker`) |
 | `when <expr>` | Condition | Boolean guard — edge only traversed if true |
-| `label: <text>` | String | Human-readable label (used for human gate choices) |
-| `weight: <int>` | Integer | Priority hint — higher wins among competing edges |
-| `restart: true` | Boolean | Marks this as a back-edge (loop restart) |
+| `label: <text>` | String | Human-readable label (used for human gate choices when no `choice:` is set) |
+| `choice: <key>` | String | Carried, not interpreted by dippin — explicit human-gate routing key the paired runtime matches the user's selection against, leaving `label:` for display |
+| `weight: <int>` | Integer | **Soft-deprecated** (raises DIP151). Parsed but **unused by routing**; slated for removal in `dip 2`. Historically a priority hint, but the cascade never consults it — guard edges with `when` / `on` instead |
+| `loop` | Flag | Bare keyword marking a back-edge (loop restart). Legacy `restart: true` is an accepted synonym that `dippin fmt` rewrites to `loop` |
+| `override: true` | Boolean | Carried, not interpreted by dippin — marks a human-authored validation override for a paired runtime to act on |
+
+A single `else -> <node>` line at the bottom of the `edges` block sets the graph's success-side default destination — any node whose guard edges all fail to match, and which has no unconditional edge of its own, routes there. At most one per edges block; it has no source node. See [edges.md](edges.md).
 
 Attributes can be combined on a single line:
 
 ```dippin
-    Task -> Start when ctx.outcome = fail label: "retry" restart: true
+    Task -> Start when ctx.outcome = fail label: "retry" loop
 ```
 
 See [edges.md](edges.md) for full details on conditions, routing, and restart semantics.
@@ -507,6 +512,6 @@ workflow ask_and_execute
     Interpret -> FanOut
     Join -> Validate
     Validate -> Approve      when ctx.outcome = success
-    Validate -> Interpret    when ctx.outcome = fail    restart: true
+    Validate -> Interpret    when ctx.outcome = fail    loop
     Approve -> Done
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,6 +53,7 @@ src/flow.dip       → src/flow.test.json
 | `tests` | array | yes | List of test cases |
 | `tests[].name` | string | yes | Human-readable test name (shown in output) |
 | `tests[].scenario` | object | no | Context key/value pairs injected into the simulator. These determine which conditional edges are taken. |
+| `tests[].branch` | string[] | no | Restricts which parallel-branch targets the simulator walks. When set, only the listed branch targets are explored; omit to walk all branches. |
 | `tests[].expect` | object | yes | Assertions to check against the simulation result |
 
 ### Expectation Fields
@@ -61,7 +62,7 @@ All expectation fields are optional. Only specified fields are checked.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | string | Expected simulation status: `"success"` (reached exit), `"fail"`, or `"dead_end"` |
+| `status` | string | Expected simulation status: `"success"` (reached exit) or `"dead_end"` |
 | `visited` | string[] | Node IDs that must appear in the execution path |
 | `not_visited` | string[] | Node IDs that must NOT appear in the execution path |
 | `path_contains` | string[] | Node IDs that must appear **in order** in the execution path. Non-contiguous matches are allowed (other nodes may appear between them). |
@@ -190,6 +191,26 @@ The simulator resolves conditions by looking up `ctx.<key>` in the scenario cont
 
 ---
 
+## Edge Coverage
+
+Pass `--coverage` to report which workflow edges were exercised across all test scenarios:
+
+```bash
+$ dippin test --coverage gate.dip
+═══ Test Results ═════════════════════════════════════════════
+  PASS  success path
+  PASS  failure path
+─── Summary ───────────────────────────────────────────────────
+  2 tests: 2 passed, 0 failed
+
+─── Edge Coverage ─────────────────────────────────────────────
+  4/4 edges covered (100.0%)
+```
+
+This is **edge** coverage only — there is no node-coverage report. Any uncovered edges are listed beneath the summary so you can add scenarios that exercise them.
+
+---
+
 ## CI Integration
 
 Use `--format json` for machine-readable output:
@@ -202,7 +223,7 @@ dippin --format json test pipeline.dip
 {
   "results": [
     {"name": "happy path", "passed": true, "path": ["Start", "Gate", "Pass", "Exit"]},
-    {"name": "error path", "passed": false, "errors": ["expected status \"fail\", got \"success\""]}
+    {"name": "error path", "passed": false, "errors": ["expected status \"dead_end\", got \"success\""]}
   ],
   "passed": 1,
   "failed": 1,

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -357,20 +357,20 @@ warning[DIP105]: no success path from start to exit
 
 ---
 
-### DIP106: Undefined Variable in Prompt
+### DIP106: Unrecognized variable reference
 
 **Severity**: Warning
 
-A prompt references a variable that no upstream node is known to produce.
+A prompt template has a `${...}` reference that lacks a known namespace prefix or isn't a valid node-scoped ref.
 
 ```
-warning[DIP106]: undefined variable reference in prompt
+warning[DIP106]: unrecognized variable reference ${user}
   --> pipeline.dip:22:5
 ```
 
-**What triggers it**: The prompt contains `${ctx.something}` or `${params.key}` where `something` is not a reserved key and no upstream node declares it in `writes`.
+**What triggers it**: A prompt contains a `${...}` reference that lacks a known namespace prefix (`ctx.`, `graph.`, `params.`, `stack.`) and is not a recognized node-scoped ref (`node.<id>.<key>` or `ctx.node.<id>.<key>` pointing at an existing node). This is a shape/namespace check only — it does **not** verify the key was actually written upstream.
 
-**How to fix**: Either add the key to an upstream node's `writes`, or verify the variable name is correct.
+**How to fix**: Namespace the reference (e.g. `${ctx.user}`), or for a node-scoped ref use `${node.<id>.<key>}` with an existing node ID.
 
 ---
 
@@ -412,16 +412,16 @@ warning[DIP108]: unknown model/provider combination
 
 **Severity**: Warning
 
-A subgraph parameter name conflicts with an existing context key.
+Two `subgraph` nodes reference the same imported file, which may cause namespace collisions.
 
 ```
-warning[DIP109]: namespace collision in imports
+warning[DIP109]: nodes "A" and "B" both reference subgraph "lib.dip", which may cause namespace collisions
   --> pipeline.dip:28:5
 ```
 
-**What triggers it**: A `subgraph` node's `params` map contains a key that shadows an existing context variable.
+**What triggers it**: Two `subgraph` nodes share the same `ref:` file. After expansion, the imported names from both nodes may collide.
 
-**How to fix**: Rename the parameter to avoid the collision.
+**How to fix**: Use distinct node IDs and ensure imported names do not collide after expansion.
 
 ---
 
@@ -617,7 +617,7 @@ warning[DIP118]: stylesheet references node ID "Analize" which does not exist
 A node specifies a `reasoning_effort` value that isn't recognized.
 
 ```
-warning[DIP119]: node "Analyze" has reasoning_effort "max" which is not a recognized level
+warning[DIP119]: node "Analyze" has reasoning_effort "extreme" which is not a recognized level
   --> pipeline.dip:12:3
   = help: valid levels: none, minimal, low, medium, high, xhigh, max
 ```
@@ -1300,7 +1300,7 @@ re-execution channel, not a forward-routing competitor.
 guard the others with a `when` condition, or remove the extra edge. A guarded
 edge plus a single unconditional fallback is the intended pattern and is **not**
 flagged. Conservative by design — duplicate same-variable/same-value guards are
-covered by [DIP103](#dip103-overlapping-or-contradictory-conditions) instead.
+covered by [DIP103](#dip103-overlapping-conditions) instead.
 
 ---
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -408,20 +408,20 @@ warning[DIP108]: unknown model/provider combination
 
 ---
 
-### DIP109: Namespace Collision in Imports
+### DIP109: Duplicate Subgraph Reference
 
 **Severity**: Warning
 
-Two `subgraph` nodes reference the same imported file, which may cause namespace collisions.
+Two `subgraph` nodes reference the same `ref:` file, which can collide their context keys.
 
 ```
-warning[DIP109]: nodes "A" and "B" both reference subgraph "lib.dip", which may cause namespace collisions
+warning[DIP109]: duplicate subgraph reference
   --> pipeline.dip:28:5
 ```
 
-**What triggers it**: Two `subgraph` nodes share the same `ref:` file. After expansion, the imported names from both nodes may collide.
+**What triggers it**: Two `subgraph` nodes reference the same `ref:` file. The rule keys only on the `ref:` value, so distinct params do **not** silence it.
 
-**How to fix**: Use distinct node IDs and ensure imported names do not collide after expansion.
+**How to fix**: Use a different `ref:` for each, or consolidate the duplicate subgraph nodes into one.
 
 ---
 

--- a/editors/tree-sitter-dippin/queries/highlights.scm
+++ b/editors/tree-sitter-dippin/queries/highlights.scm
@@ -3,6 +3,7 @@
   "workflow"
   "defaults"
   "edges"
+  "else"
   "stylesheet"
 ] @keyword
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "dippin-lang",
   "displayName": "Dippin",
   "description": "Language support for Dippin (.dip) AI pipeline workflow files",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "2389-research",
   "repository": {
     "type": "git",

--- a/editors/vscode/syntaxes/dippin.tmLanguage.json
+++ b/editors/vscode/syntaxes/dippin.tmLanguage.json
@@ -106,6 +106,10 @@
           "name": "keyword.control.loop.dippin"
         },
         {
+          "match": "\\b(else)\\b",
+          "name": "keyword.control.else.dippin"
+        },
+        {
           "match": "\\b(restart)\\s*:",
           "captures": {
             "1": { "name": "keyword.other.edge-attr.dippin" }

--- a/editors/zed-dippin/extension.toml
+++ b/editors/zed-dippin/extension.toml
@@ -1,6 +1,6 @@
 id = "dippin"
 name = "Dippin"
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = ["2389 Research"]
 description = "Dippin workflow language support with syntax highlighting and LSP."
@@ -9,7 +9,7 @@ repository = "https://github.com/2389-research/dippin-lang"
 [grammars.dippin]
 repository = "https://github.com/2389-research/dippin-lang"
 path = "editors/tree-sitter-dippin"
-commit = "10cc50feec20ab87895eb4ccd93a245c9c893250"
+commit = "d6573695c3665696c68b93b396d5965e89032b9b"
 
 [language_servers.dippin-lsp]
 languages = ["Dippin"]

--- a/editors/zed-dippin/languages/dippin/highlights.scm
+++ b/editors/zed-dippin/languages/dippin/highlights.scm
@@ -3,6 +3,7 @@
   "workflow"
   "defaults"
   "edges"
+  "else"
   "stylesheet"
 ] @keyword
 

--- a/site/content/analysis.md
+++ b/site/content/analysis.md
@@ -7,7 +7,7 @@ subtitle: "Cost, coverage, health, optimization, and change tracking."
 
 ## Overview
 
-Dippin includes six analysis commands that inspect workflows for cost, coverage, health, optimization opportunities, and change impact. `doctor` aggregates cost + coverage + lint into a single grade. Run it first for an overview, then drill into specific commands for details.
+Dippin includes eight analysis commands that inspect workflows for cost, coverage, health, optimization opportunities, dead code, change impact, calibration, and dry-run behavior. `doctor` aggregates cost + coverage + lint into a single grade. Run it first for an overview, then drill into specific commands for details.
 
 <div class="flow-diagram">
   <div class="flow-step">dippin doctor</div>
@@ -100,7 +100,6 @@ Health report card — a single grade (A-F) aggregating lint, coverage, and cost
 <span class="dim">&#9472;&#9472;&#9472; Coverage &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   Reachable: <span class="pass">21/21 nodes</span>
   <span class="pass">&#10003;</span> All paths terminate
-  <span class="pass">&#10003;</span> All tool outputs covered
 
 <span class="dim">&#9472;&#9472;&#9472; Cost &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   Expected: $2.10  <span class="dim">(range: $1.50 - $8.40)</span>
@@ -115,11 +114,11 @@ Starts at 100 points, with deductions for issues:
 
 | Issue | Deduction |
 |-------|-----------|
-| Each lint error | -15 points |
+| Each lint error | -20 points |
 | Each lint warning | -5 points |
-| Unreachable node | -10 per node |
-| Non-terminating paths | -20 |
-| Uncovered tool outputs | -5 per tool |
+| Unreachable node | -15 per node |
+| Non-terminating paths | -15 |
+| Uncovered tool outputs | -10 per tool |
 
 ### Grades
 
@@ -156,6 +155,16 @@ Suggest cheaper model substitutions without sacrificing quality. Rules include: 
 
 **When to use:** After `dippin cost` shows high costs. Review each suggestion — some "simple" prompts may actually need a capable model.
 
+## simulate
+
+Dry-run a workflow without real side effects, emitting JSONL events to stdout. It walks the IR graph from start to exit, logging each node visited — no LLM calls and no shell commands run. Use `--scenario key=val` to inject context and explore conditional branches, `--all-paths` to enumerate every reachable path, and `--interactive` to prompt at human nodes.
+
+```
+$ dippin simulate pipeline.dip --scenario outcome=fail
+```
+
+**When to use:** Verify routing logic before running the real pipeline — confirm a scenario reaches the expected node sequence, or audit every branch with `--all-paths`.
+
 ## diff
 
 Semantic comparison between two workflow versions. Unlike text-based `diff`, this compares graph structure: nodes added/removed, edges changed, field-level modifications, and cost impact.
@@ -184,10 +193,10 @@ Semantic comparison between two workflow versions. Unlike text-based `diff`, thi
 
 ## feedback
 
-Compare predicted costs against actual execution telemetry to calibrate estimates. Takes the workflow file (for predicted costs) and a CSV telemetry file with columns: `node_id`, `input_tokens`, `output_tokens`, `cost_usd`.
+Compare predicted costs against actual execution telemetry to calibrate estimates. Takes the workflow file (for predicted costs) and a JSONL telemetry file — one JSON object per line with fields: `event`, `node`, `model`, `provider`, `tokens_in`, `tokens_out`, `actual_cost`, `turns`, `timestamp`.
 
 ```
-$ dippin feedback pipeline.dip telemetry.csv
+$ dippin feedback pipeline.dip telemetry.jsonl
 ```
 
 After running a pipeline in production, export telemetry and feed it back to see how accurate the cost predictions were. Outliers (>2x or <0.5x ratio) are flagged for investigation.

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -68,7 +68,7 @@ dippin-lang/
 │
 ├── validator/          # Graph validation + semantic linting
 │   ├── validate.go     # 10 structural checks (DIP001-DIP010)
-│   ├── lint.go         # Lint orchestration (DIP101-DIP146)
+│   ├── lint.go         # Lint orchestration (DIP101-DIP151)
 │   └── diagnostic.go   # Diagnostic type, Result, Severity
 │
 ├── formatter/          # Canonical .dip source formatter
@@ -103,7 +103,7 @@ dippin-lang/
   </div>
   <div class="decision-card">
     <h4>No short-circuiting validation</h4>
-    <p>All 10 structural checks and all 46 semantic checks run unconditionally. A single call reports every issue, not just the first. This enables batch fixing.</p>
+    <p>All 10 structural checks and all 51 semantic checks run unconditionally. A single call reports every issue, not just the first. This enables batch fixing.</p>
   </div>
   <div class="decision-card">
     <h4>Zero external dependencies</h4>

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -143,8 +143,8 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 
 <div class="cmd-card">
   <h3>watch</h3>
-  <div class="cmd-usage">dippin watch [--lint] [--test] &lt;file.dip&gt;</div>
-  <p>Watch a workflow file for changes and re-run validation automatically. Use <code>--lint</code> to include semantic linting on each change, or <code>--test</code> to re-run scenario tests. Debounces rapid saves.</p>
+  <div class="cmd-usage">dippin watch &lt;file-or-dir&gt; [...]</div>
+  <p>Watch <code>.dip</code> files or directories for changes. On each change it parses, validates, and lints the affected file. Debounces rapid saves (200ms).</p>
 </div>
 
 ## Bundle Commands
@@ -165,6 +165,6 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 
 <div class="cmd-card">
   <h3>inspect</h3>
-  <div class="cmd-usage">dippin inspect [--format text|json] &lt;bundle.dipx&gt;</div>
-  <p>Print a bundle's manifest, identity hash (SHA-256 over the manifest bytes-as-stored), and per-file checksums. Always integrity-verifies in v1.</p>
+  <div class="cmd-usage">dippin inspect [--no-verify] [--format text|json] &lt;bundle.dipx&gt;</div>
+  <p>Print a bundle's manifest, identity hash (SHA-256 over the manifest bytes-as-stored), and per-file checksums. Integrity-verifies by default; <code>--no-verify</code> skips hash verification (forensic mode).</p>
 </div>

--- a/site/content/editors.md
+++ b/site/content/editors.md
@@ -11,7 +11,7 @@ The built-in LSP server (`dippin lsp`) provides rich editing features for any LS
 
 | Feature | Description |
 |---------|-------------|
-| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001-DIP126) |
+| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001-DIP010 structural, DIP101-DIP151 semantic) |
 | **Hover** | Tooltip showing node kind, model, provider, prompt preview, and field summary |
 | **Go-to-definition** | Jump from a node reference in an edge to the node's declaration |
 | **Autocomplete** | Node IDs in edges, field names within node blocks, keywords |
@@ -69,10 +69,11 @@ Or use a generic LSP client extension with this configuration:
 | Keywords | `workflow`, `agent`, `tool`, `human`, `edges` | keyword |
 | Node names | `agent MyNode` | function |
 | Field keys | `model:`, `prompt:`, `timeout:` | tag |
-| Strings | `"quoted value"` | string |
+| Strings | `"quoted value"`, `'quoted value'` | string |
 | Comments | `# comment` | comment |
 | Arrows | `->`, `<-` | operator |
 | Conditions | `when`, `and`, `or`, `not` | keyword |
+| Edge keywords | `on`, `loop`, `choice:`, `weight:`, `override:`, `restart:`, `else` | keyword |
 | Variables | `ctx.outcome`, `graph.goal` | variable |
 | Interpolation | `${ctx.var}` | variable |
 | Booleans | `true`, `false` | constant |

--- a/site/content/glossary.md
+++ b/site/content/glossary.md
@@ -13,7 +13,7 @@ subtitle: "Terms you'll encounter authoring .dip files and using the dippin tool
 
 **Edge** — A connection between two nodes, written `A -> B` in the `edges` block. May carry a `when` condition (or the `on <token>` shorthand), a `loop` keyword for back-edges, a `label:`, a `choice:` routing key, a `restart:` flag, and an `override:` flag. (`weight:` is still parsed but soft-deprecated — DIP151.)
 
-**Condition** — A predicate attached to an edge using the `when` keyword. Syntax: `ctx.<field> <op> <value>` with operators `=`, `!=`, `contains`, `not contains`, `startswith`, `endswith`, and `in`. Complementary pairs (success/fail, contains/not-contains) are detected as exhaustive automatically.
+**Condition** — A predicate attached to an edge using the `when` keyword. Syntax: `ctx.<field> <op> <value>` with operators `=`, `==` (synonym for `=`), `!=`, `contains`, `not contains`, `startswith`, `endswith`, and `in`. Complementary pairs (success/fail, contains/not-contains) are detected as exhaustive automatically.
 
 **on / loop** — Edge shorthand keywords. `on <token>` desugars into an equality test against the source node's outcome channel (`ctx.outcome` for agents, `ctx.tool_marker` for tools with `marker_grep`) — equivalent to the matching `when`. `loop` marks a back-edge (a deliberate cycle) so reachability lint treats it as intentional.
 

--- a/site/content/glossary.md
+++ b/site/content/glossary.md
@@ -11,9 +11,17 @@ subtitle: "Terms you'll encounter authoring .dip files and using the dippin tool
 
 **Node** — A step in the pipeline. Every node has an ID and a kind. Kinds include `agent`, `human`, `tool`, `conditional`, `parallel`, `fan_in`, `subgraph`, and `manager_loop`.
 
-**Edge** — A connection between two nodes, written `A -> B` in the `edges` block. May carry a `when` condition, a label, a weight, and a `restart:` flag.
+**Edge** — A connection between two nodes, written `A -> B` in the `edges` block. May carry a `when` condition (or the `on <token>` shorthand), a `loop` keyword for back-edges, a `label:`, a `choice:` routing key, a `restart:` flag, and an `override:` flag. (`weight:` is still parsed but soft-deprecated — DIP151.)
 
-**Condition** — A predicate attached to an edge using the `when` keyword. Syntax: `ctx.<field> <op> <value>` with operators `=`, `!=`, `contains`, and `not contains`. Complementary pairs (success/fail, contains/not-contains) are detected as exhaustive automatically.
+**Condition** — A predicate attached to an edge using the `when` keyword. Syntax: `ctx.<field> <op> <value>` with operators `=`, `!=`, `contains`, `not contains`, `startswith`, `endswith`, and `in`. Complementary pairs (success/fail, contains/not-contains) are detected as exhaustive automatically.
+
+**on / loop** — Edge shorthand keywords. `on <token>` desugars into an equality test against the source node's outcome channel (`ctx.outcome` for agents, `ctx.tool_marker` for tools with `marker_grep`) — equivalent to the matching `when`. `loop` marks a back-edge (a deliberate cycle) so reachability lint treats it as intentional.
+
+**else** — A section-level funnel default in the `edges` block, written `else -> <NodeID>`. Provides the success-side default route when no other outbound edge from the current section matches. At most one `else` per edges block; it takes no source node and no attributes (#154 / #157).
+
+**choice:** — An edge attribute carrying a human-gate routing key, written `choice: <key>`. The value is carried, not interpreted — it marks the load-bearing routing key so a `label:` can stay display-only (DIP150). Distinct from a `human` node's `mode: choice`, which selects the gate's interaction style.
+
+**marker_grep / ctx.tool_marker** — `marker_grep` is a regex on a `tool` node, matched line-by-line against the command's stdout; the matched value populates `ctx.tool_marker`, the tool's outcome channel for routing (e.g. via `on` or `when`).
 
 **Defaults** — A workflow-wide block setting values inherited by all nodes unless overridden. Common keys: `model`, `provider`, `fidelity`, `retry`, `tool_commands_allow`, `tool_denylist_add`.
 
@@ -45,13 +53,15 @@ subtitle: "Terms you'll encounter authoring .dip files and using the dippin tool
 
 **.dip** — The source file extension. Plain text, indentation-based, parsed by the `dippin` CLI.
 
+**dip N** — An optional leading format-version declaration (e.g. `dip 1`) at the top of a `.dip` file. Defaults to version 1 when absent.
+
 **.dipx** — A bundle format introduced in v0.24 that packs a workflow tree (root .dip + referenced subgraphs) into a single verifiable file. Created with `dippin pack`, expanded with `dippin unpack`.
 
 **.test.json** — A scenario test file. Injects context values, asserts on execution paths, and reports edge coverage. Run with `dippin test`.
 
 ## Diagnostics
 
-**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP010 are structural errors (parse / shape failures). DIP101–DIP146 are semantic warnings (style, correctness hints, model catalog issues).
+**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP010 are structural errors (parse / shape failures). DIP101–DIP151 are semantic warnings (style, correctness hints, model catalog issues).
 
 **Exhaustive conditions** — A pair of edge conditions detected as covering all outcomes (e.g., `when ctx.status = success` + `when ctx.status = fail`). Suppresses DIP101 / DIP102 warnings.
 

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -189,8 +189,8 @@ Agent nodes invoke an LLM. They are the most configurable node kind. Key fields 
 | `cache_tools` | Boolean | Whether to cache tool call results for this agent. Overrides the workflow default. |
 | `compaction` | String | Context compaction mode for managing long context windows. Overrides the workflow default. |
 | `compaction_threshold` | Float | Threshold value that triggers compaction (provider-specific semantics). |
-| `reads` | String | Context key this node reads as input (advisory metadata) |
-| `writes` | String | Context key this node writes as output (advisory metadata) |
+| `reads` | CSV | Context keys this node reads as input (advisory metadata) |
+| `writes` | CSV | Context keys this node writes as output (advisory metadata) |
 | `response_format` | String | Structured output mode: `json_object` or `json_schema`. Instructs the model to return valid JSON. |
 | `response_schema` | Block | JSON Schema definition enforced when `response_format: json_schema` is set. Must be valid JSON. |
 | `params` | Block | Arbitrary key-value pairs forwarded to the provider API. Keys must not duplicate first-class fields (see DIP133). |

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -72,8 +72,13 @@ The optional `defaults` block sets graph-level configuration that applies to all
 | `max_retries` | Integer | Default max retry attempts per node |
 | `fidelity` | String | Default checkpoint fidelity level |
 | `max_restarts` | Integer | Max loop restarts before pipeline failure (default: 5) |
+| `restart_target` | String | Node ID to jump to on restart loops |
 | `cache_tools` | Boolean | Whether to cache tool call results |
 | `compaction` | String | Context compaction mode for long pipelines |
+| `on_resume` | String | Fidelity behavior when a run resumes: `preserve` (keep the checkpoint fidelity level) or `degrade` (downgrade on resume). Only meaningful when `fidelity` is also set. |
+| `max_total_tokens` | Integer | Hard ceiling on total tokens across the run. `0`/unset = no limit. |
+| `max_cost_cents` | Integer | Hard ceiling on total cost, in **US cents** (e.g. `1000` = $10.00). `0`/unset = no limit. |
+| `max_wall_time` | Duration | Hard ceiling on **wall-clock** run time (e.g. `30m`, `2h`). `0`/unset = no limit. |
 | `stall_timeout` | Duration | Abort/route when no forward progress is made for a wall-clock span (e.g. `30s`, `5m`); `0`/unset = no limit. Enforced by the runtime. |
 | `on_failure` | NodeID | Graph-level catch-all failure route — the runtime sends a failing node here when no more specific route (fail edge → bounded retry → `fallback_target`) matches. Carried + linted by dippin; enforced by the runtime. |
 
@@ -129,6 +134,22 @@ There are 8 node kinds, each with its own syntax and configuration:
   <div class="pipeline-box lavender">manager_loop<br>Child supervisor</div>
 </div>
 
+### Common Fields
+
+These fields are available on **all** block-style node kinds (agent, human, tool, subgraph):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `label` | String | Human-readable display name. Defaults to the node ID if omitted. |
+| `class` | CSV | Comma-separated stylesheet class names for theming (reserved for post-v1). |
+| `reads` | CSV | Context keys this node expects to read. Advisory — used for linting (DIP112), not enforced at runtime. |
+| `writes` | CSV | Context keys this node will produce. Advisory — used for linting (DIP107), not enforced at runtime. |
+| `retry_policy` | String | Named retry strategy: `standard`, `aggressive`, `patient`, `linear`, `none`. Overrides the workflow default. |
+| `max_retries` | Integer | Maximum retry attempts before giving up. Overrides the workflow default. |
+| `base_delay` | Duration | Override the retry policy's default base delay (e.g. `500ms`, `2s`, `1m`). |
+| `retry_target` | String | Node ID to jump to when retrying (instead of re-executing the current node). |
+| `fallback_target` | String | Node ID to jump to if all retries are exhausted. |
+
 ### agent
 
 Agent nodes invoke an LLM. They are the most configurable node kind. Key fields include `model`, `provider`, `prompt`, `system_prompt`, `max_turns`, `auto_status`, and `goal_gate`.
@@ -154,12 +175,20 @@ Agent nodes invoke an LLM. They are the most configurable node kind. Key fields 
 | `backend` | String | Per-node backend override (e.g., `native`, `claude-code`, `acp`) |
 | `working_dir` | String | Per-node working directory override for isolated execution. |
 | `prompt` | Block | Multiline prompt text sent to the model |
+| `prompt_file` | String | Path (relative to the `.dip` dir) to an external file whose contents become the prompt. Mutually exclusive with `prompt:` — setting both is a parse error. |
 | `system_prompt` | Block | System-level instructions prepended before the prompt |
+| `system_prompt_file` | String | Path (relative to the `.dip` dir) to an external file whose contents become the system prompt. Mutually exclusive with `system_prompt:` — setting both is a parse error. |
+| `tool_access` | String | LLM tool-catalog gate. Set to `none` to strip the model's tool registry on this agent. DIP139 warns on unknown values; the runtime fail-closes. |
+| `writable_paths` | CSV (globs) | Comma-separated glob list bounding where this agent's tools may write (e.g. `workspace/**, .ai/sprints/**`). Absent = unbounded; a present-but-empty value is rejected by `dippin validate`/`pack`. Enforced by the runtime. |
+| `last_response_truncate` | Integer | Caps how much of the prior node's response is carried into this agent's context, in characters. `0`/unset = no truncation (a negative value raises DIP148). |
 | `reasoning_effort` | String | Extended thinking effort level: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. Controls how much reasoning budget the LLM spends. |
 | `fidelity` | String | Checkpoint fidelity level for state persistence. |
 | `max_turns` | Integer | Maximum conversation turns before the node exits |
 | `auto_status` | Boolean | Automatically extract `STATUS: success/fail` from model output into `ctx.outcome` |
 | `goal_gate` | Boolean | Marks this node as a goal gate — requires `retry_target` or `fallback_target` for recovery |
+| `cache_tools` | Boolean | Whether to cache tool call results for this agent. Overrides the workflow default. |
+| `compaction` | String | Context compaction mode for managing long context windows. Overrides the workflow default. |
+| `compaction_threshold` | Float | Threshold value that triggers compaction (provider-specific semantics). |
 | `reads` | String | Context key this node reads as input (advisory metadata) |
 | `writes` | String | Context key this node writes as output (advisory metadata) |
 | `response_format` | String | Structured output mode: `json_object` or `json_schema`. Instructs the model to return valid JSON. |
@@ -169,7 +198,7 @@ Agent nodes invoke an LLM. They are the most configurable node kind. Key fields 
 
 ### human
 
-Human nodes pause execution and wait for human input. Two modes: `choice` (predefined options from edge labels) and `freeform` (open text input).
+Human nodes pause execution and wait for human input. Four modes: `choice` (predefined options from edge labels), `freeform` (open text input), `interview` (structured Q&A from upstream agent output), and `yes_no` (binary Y/N prompt).
 
 ```
   human Approve
@@ -177,6 +206,16 @@ Human nodes pause execution and wait for human input. Two modes: `choice` (prede
     mode: choice
     default: "yes"
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | String | Interaction mode: `choice`, `freeform`, `interview`, or `yes_no`. |
+| `default` | String | Default selection if no input. Only meaningful for `choice` mode. |
+| `prompt` | Block | Prompt text shown to the human (also the interview fallback when no questions are detected). |
+| `questions_key` | String | Context key to read questions from. Interview mode only (default `interview_questions`). |
+| `answers_key` | String | Context key to write answers to. Interview mode only (default `interview_answers`). |
+| `timeout` | Duration | How long to wait for input before `timeout_action` fires (e.g. `5m`). `0`/unset = wait indefinitely. |
+| `timeout_action` | String | What to do when `timeout` elapses: `fail` (the node fails) or `default` (use the `default` selection). Empty = no timeout behavior. |
 
 ### tool
 
@@ -192,7 +231,7 @@ Tool nodes execute shell commands. The command's stdout is captured as `ctx.tool
       pytest --tb=short
 ```
 
-Declare `marker_grep` for typed routing (populates `ctx.tool_marker`); `route_required: true` makes the node fail if the command emits no routing signal recognized by the runtime; `output_limit` overrides the captured-stdout byte cap.
+Declare `marker_grep` for typed routing (populates `ctx.tool_marker`); `route_required: true` makes the node fail if the command emits no routing signal recognized by the runtime; `output_limit` overrides the captured-stdout byte cap. Use `command_file` (a path relative to the `.dip` dir) instead of inline `command:` to load the script from an external file — the two are mutually exclusive.
 
 ### parallel
 
@@ -200,6 +239,20 @@ Parallel nodes fan execution out to multiple branches that run concurrently. Eve
 
 ```
   parallel FanOut -> TaskA, TaskB, TaskC
+```
+
+Use **block form** when branches need different models, providers, fidelity levels, or tool access. Each `branch:` entry declares a fan-out target (equivalent to an inline `->` target) and attaches per-branch overrides for `model`, `provider`, `fidelity`, `tool_access`, `writable_paths`, and `last_response_truncate`. The fan-in node must still list the same target IDs. An omitted branch `tool_access` or `writable_paths` inherits the target agent's setting — it never re-grants the full catalog or resets to unbounded.
+
+```
+  parallel split
+    branch: fast
+      model: claude-haiku-4-5
+      provider: anthropic
+      fidelity: summary
+    branch: accurate
+      model: claude-opus-4-7
+      provider: anthropic
+      fidelity: full
 ```
 
 ### fan_in
@@ -270,7 +323,7 @@ Conditional nodes accept only common fields (`label`, `class`, `reads`, `writes`
 The `edges` block defines connections between nodes. Each edge is a single line:
 
 ```
-<FromID> -> <ToID> [on <token> | when <condition>] [label: <text>] [choice: <key>] [weight: <int>] [loop]
+<FromID> -> <ToID> [on <token> | when <condition>] [label: <text>] [choice: <key>] [weight: <int>] [loop] [override: true]
 ```
 
 ### Basic and Conditional Edges
@@ -291,7 +344,7 @@ The `edges` block defines connections between nodes. Each edge is a single line:
 | `when <expr>` | Condition | Boolean guard — edge only traversed if true |
 | `label: <text>` | String | Human-readable label (used for human gate choices when no `choice:` is set) |
 | `choice: <key>` | String | Carried, not interpreted by dippin — explicit human-gate routing key the paired runtime matches the user's selection against, leaving `label:` for display. Wins over `label:` when present; runtime falls back to `label:` when absent |
-| `weight: <int>` | Integer | Priority hint — higher wins among competing edges |
+| `weight: <int>` | Integer | **Soft-deprecated** (raises DIP151). Parsed but **unused by routing**; slated for removal in `dip 2`. Historically a priority hint, but the cascade never consults it — guard edges with `when` / `on` instead |
 | `loop` | Flag | Bare keyword marking a back-edge (loop restart). Legacy `restart: true` is an accepted synonym that `dippin fmt` rewrites to `loop` |
 | `override: true` | Boolean | Carried, not interpreted by dippin — marks a human-authored validation override for a paired runtime to act on |
 
@@ -316,6 +369,19 @@ A `loop` edge creates a controlled back-edge. When followed, the engine incremen
 ```
 
 `loop` is a bare keyword; the legacy `restart: true` still parses and `dippin fmt` rewrites it to `loop`. Because `loop` is a reserved bare keyword, write `when ctx.x = "loop"` (quoted) for the literal value on a condition's right-hand side.
+
+### Section-Level Default (`else`)
+
+A single `else -> <node>` line, written at the bottom of the `edges` block, is the graph's **success-side default destination**: any node whose guard edges all fail to match, and which has no explicit unconditional edge of its own, routes there.
+
+```
+  edges
+    SetupRun -> FetchIssues  on setup-ok
+    RunTests -> Package      on tests-ok
+    else -> Cleanup
+```
+
+At most one `else` per edges block (a second is a parse error), and `else ->` requires a target node. It has no source node. `else` is success-side only — it never intercepts a genuine node *failure*, which routes via the failure cascade (`on fail` edge → `defaults.on_failure`). A node covered by `else` is not flagged DIP101 or DIP102.
 
 ## Conditions
 

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -136,7 +136,7 @@ There are 8 node kinds, each with its own syntax and configuration:
 
 ### Common Fields
 
-These fields are available on **all** block-style node kinds (agent, human, tool, subgraph):
+These fields (`label`, `class`, `reads`, `writes`, and the retry fields) are accepted by **all** block-style node kinds — agent, human, tool, subgraph, `conditional`, and `manager_loop` — since they share the node-field parser:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -215,7 +215,7 @@ Human nodes pause execution and wait for human input. Four modes: `choice` (pred
 | `questions_key` | String | Context key to read questions from. Interview mode only (default `interview_questions`). |
 | `answers_key` | String | Context key to write answers to. Interview mode only (default `interview_answers`). |
 | `timeout` | Duration | How long to wait for input before `timeout_action` fires (e.g. `5m`). `0`/unset = wait indefinitely. |
-| `timeout_action` | String | What to do when `timeout` elapses: `fail` (the node fails) or `default` (use the `default` selection). Empty = no timeout behavior. |
+| `timeout_action` | String | What to do when `timeout` elapses: `fail` (the node fails), `default` (use the `default` selection), or empty. Empty falls back to the node's `default` answer if one is set, otherwise fails. Any other value is a parse error. |
 
 ### tool
 
@@ -382,6 +382,8 @@ A single `else -> <node>` line, written at the bottom of the `edges` block, is t
 ```
 
 At most one `else` per edges block (a second is a parse error), and `else ->` requires a target node. It has no source node. `else` is success-side only — it never intercepts a genuine node *failure*, which routes via the failure cascade (`on fail` edge → `defaults.on_failure`). A node covered by `else` is not flagged DIP101 or DIP102.
+
+> **Note:** `dippin simulate` / `dippin test` do not yet traverse the `else` default (tracked in [#158](https://github.com/2389-research/dippin-lang/issues/158)); a paired runtime resolves it.
 
 ## Conditions
 

--- a/site/content/testing.md
+++ b/site/content/testing.md
@@ -60,7 +60,7 @@ All expectation fields are optional. Only specified fields are checked.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | string | Expected simulation status: `"success"` (reached exit), `"fail"`, or `"dead_end"` |
+| `status` | string | Expected simulation status: `"success"` (reached exit) or `"dead_end"` |
 | `visited` | string[] | Node IDs that must appear in the execution path |
 | `not_visited` | string[] | Node IDs that must NOT appear in the execution path |
 | `path_contains` | string[] | Node IDs that must appear in order (non-contiguous matches allowed) |
@@ -182,16 +182,17 @@ The `scenario` object maps context keys to values. The simulator resolves condit
 
 ## Coverage Flag
 
-Use `--coverage` to report node and edge coverage across all test scenarios:
+Use `--coverage` to report edge coverage across all test scenarios:
 
 ```
 $ dippin test --coverage gate.dip
   PASS  success path
   PASS  failure path
-  Coverage: 4/4 nodes (100%), 4/4 edges (100%)
+─── Edge Coverage ───
+  4/4 edges covered (100.0%)
 ```
 
-This helps identify nodes or edges that no test scenario exercises.
+This helps identify edges that no test scenario exercises. (Coverage is edge-only; there is no node-coverage report.)
 
 ## CI Integration
 
@@ -202,7 +203,7 @@ $ dippin --format json test pipeline.dip
 {
   "results": [
     {"name": "happy path", "passed": true, "path": ["Start", "Gate", "Pass", "Exit"]},
-    {"name": "error path", "passed": false, "errors": ["expected status \"fail\", got \"success\""]}
+    {"name": "error path", "passed": false, "errors": ["expected status \"dead_end\", got \"success\""]}
   ],
   "passed": 1,
   "failed": 1,

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -301,7 +301,10 @@ Runtime state: `stack.child.cycles`, `stack.child.outcome`, `stack.child.status`
 | condition | `when <expr>` | Guard expression |
 | outcome shorthand | `on <token>` | Sugar for `when ctx.outcome = <token>` (agent) or `when ctx.tool_marker = <token>` (tool + `marker_grep`); `fmt` rewrites eligible `when` to `on`. Not for human gates (route on choice/label) or marker-less tools — use `when` |
 | label | `label: <text>` | Display text / human choice button |
-| weight | `weight: <int>` | Priority (higher wins) |
+| choice | `choice: <key>` | Human-gate routing key; carried, not interpreted — marks the load-bearing routing key so `label:` stays display-only (DIP150) |
+| weight | `weight: <int>` | Soft-deprecated (DIP151) — parsed but ignored by routing; removal slated for dip 2 |
+| override | `override: true` | Carried, not interpreted by the parser |
+| else default | `else -> <NodeID>` | Section-level success-side default route; at most one per `edges` block; no source node and no attributes (#157) |
 | loop | `loop` | Bare keyword marking a back-edge; **required on back-edges** to avoid DIP005 (unconditional cycle). Legacy `restart: true` still parses; `fmt` rewrites it to `loop` |
 
 ### Conditions

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -301,7 +301,7 @@ Runtime state: `stack.child.cycles`, `stack.child.outcome`, `stack.child.status`
 | condition | `when <expr>` | Guard expression |
 | outcome shorthand | `on <token>` | Sugar for `when ctx.outcome = <token>` (agent) or `when ctx.tool_marker = <token>` (tool + `marker_grep`); `fmt` rewrites eligible `when` to `on`. Not for human gates (route on choice/label) or marker-less tools — use `when` |
 | label | `label: <text>` | Display text / human choice button |
-| choice | `choice: <key>` | Human-gate routing key; carried, not interpreted — marks the load-bearing routing key so `label:` stays display-only (DIP150) |
+| choice | `choice: <key>` | Human-gate routing key; carried, not interpreted — `choice:` is preferred when present, and `label:` remains the fallback routing key when `choice:` is absent (DIP150) |
 | weight | `weight: <int>` | Soft-deprecated (DIP151) — parsed but ignored by routing; removal slated for dip 2 |
 | override | `override: true` | Carried, not interpreted by the parser |
 | else default | `else -> <NodeID>` | Section-level success-side default route; at most one per `edges` block; no source node and no attributes (#157) |


### PR DESCRIPTION
## Summary

Content-only accuracy sweep bringing every hand-maintained surface (public website, canonical `docs/`, editor grammars, LLM reference/skill) into line with the **actual** language as defined by the parser/validator/CLI. Triggered by `language.md` never documenting the `*_file:` directives — an audit then found the drift was broad, including errors in the canonical docs themselves.

**Zero `.go` behavior changes. No new DIP code. No release.** Verified against parser/validator/cmd source, not cross-doc. Full `scripts/pre-commit` suite passes; generated-spec regenerated via `scripts/gen-spec.sh` (not hand-edited); tree-sitter 13/13; tmLanguage JSON valid.

## What was fixed, by surface

**Language reference** (`site/content/language.md`, `docs/syntax.md`, `docs/nodes.md`)
- Added the entire missing `*_file:` family (`prompt_file`/`system_prompt_file`/`command_file`) + mutual-exclusion note; plus `tool_access`, `writable_paths`, `compaction`/`compaction_threshold`, `cache_tools`, `last_response_truncate`.
- Human node: corrected "two modes" → **four** (`choice`/`freeform`/`interview`/`yes_no`) + added `prompt`/`questions_key`/`answers_key`/`timeout`/`timeout_action`.
- Added common-fields group, missing `defaults` rows (`restart_target`/`on_resume`/`max_total_tokens`/`max_cost_cents`/`max_wall_time`), parallel **block form** + per-branch overrides, `else ->` subsection, `override:` in the edge signature.
- `weight:` corrected to soft-deprecated (DIP151, unused by routing); `docs/syntax.md` edge tables modernized (`on`/`choice`/`loop`/`override`, `restart: true`→`loop`).

**Validation** (`docs/validation.md`)
- DIP106 retitled/retriggered to the real shape/namespace check (post-#168 "unrecognized variable reference").
- DIP119 example fixed (`max` is a *valid* level → use `extreme`); DIP109 trigger corrected (real rule = two `subgraph` nodes sharing `ref:`); broken DIP149→DIP103 anchor fixed.

**Analysis** (`docs/analysis.md`, `site/content/analysis.md`)
- "six commands" → **eight**; feedback input corrected **CSV → JSONL** (real fields); removed the phantom `✓ All tool outputs covered` doctor line; added `unused` section + `simulate` mention; corrected the website doctor **scoring table** (4 of 5 deductions were wrong → `-20/-5/-15/-15/-10`).

**Architecture** (`docs/architecture.md`, `site/content/architecture.md`)
- Stale DIP ranges (`DIP146`→`DIP151`, `46`→`51` semantic), "Five packages"→**Six**, validator file list extended through DIP151, added missing CLI files + the `flatten/` package.

**CLI** (`docs/cli.md`, `site/content/cli.md`)
- `watch` no longer documents non-existent `--lint`/`--test` flags; `inspect` gains `--no-verify`; `explain` sample output uses real `when` syntax (post-#168).

**Testing** (`docs/testing.md`, `site/content/testing.md`)
- Removed the impossible `status: "fail"` (simulator only emits `success`/`dead_end`); `--coverage` corrected to **edge-only** (was claiming node coverage); documented the `branch` test field.

**Editors / glossary / grammar** (`editors/*`, `site/content/editors.md`, `docs/editor-setup.md`, `site/content/glossary.md`)
- Added `else` highlighting to tree-sitter, Zed, and VS Code; bumped the **stale Zed grammar commit pin** (its `choice` query was inert) + extension versions; refreshed DIP ranges and edge-keyword/term coverage.

**LLM reference** (`site/static/skill.md`, `docs/llm-reference.md`, regenerated `cmd/dippin/generated-spec.md`)
- Edge table gained `choice:`/`else ->`/`override:`; `weight` marked DIP151-deprecated; signature line gained `[choice: <key>]`; spec regenerated.

Source features reflected: `choice:`/DIP150 (#130/#151), `weight:`/DIP151 (#131/#152), `else ->` (#154/#157), diagnostic-text accuracy (#168). `site/static/llms-full.txt` self-corrects on CI (`cp` of the spec).

## Out of scope — follow-up code bugs the audit surfaced
These make `dippin explain` actively wrong and need `.go` fixes + explanation-parity test updates (filing separately):
- `validator/explanations.go` Fix strings for **DIP113** (retry policy), **DIP114** (fidelity), **DIP116** (on_resume) list invalid values.
- **DIP109** title/explanation in `lint_codes.go`/`explanations.go` mis-describe the rule.
- `simulate/simulate.go:61` stale `Status` doc comment ("fail" never emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784750783&installation_id=131176874&pr_number=171&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F171&signature=7323cff998f3c308d634f5df14bf93bbd95361bd5b97ec73f889fcb0b9e23bcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Comprehensive updates to syntax, command, and configuration documentation
  * Enhanced edge attributes with new default routing and routing key options

* **New Features**
  * Added `else` keyword for section-level default edge routing
  * Introduced `choice:` attribute for routing key specification
  * Added timeout controls for human node interactions
  * New analysis commands for unused code detection and feedback processing

* **Language Enhancements**
  * Refined edge syntax with improved attribute semantics
  * Clarified `weight` as deprecated with planned future removal
  * Added `loop` as canonical back-edge marker

<!-- end of auto-generated comment: release notes by coderabbit.ai -->