### PR TITLE
feat(pack): --no-inline / --include file-shipping pack mode (#73)

### DIFF
--- a/cmd/dippin/cmd_pack.go
+++ b/cmd/dippin/cmd_pack.go
@@ -158,7 +158,10 @@ func parsePackArgs(stderr io.Writer, args []string) (packArgs, int) {
 		return packArgs{}, exitDipxUserError
 	}
 	entry := rest[0]
-	if !strings.EqualFold(filepath.Ext(entry), ".dip") {
+	// Case-sensitive: the bundle format requires a literal lowercase ".dip"
+	// suffix (checkPathPolicy), so reject e.g. "foo.DIP" here rather than let it
+	// fail later with a confusing pack-time policy error.
+	if filepath.Ext(entry) != ".dip" {
 		fmt.Fprintf(stderr, "error: entry must be a .dip file (got %q)\n", entry)
 		return packArgs{}, exitDipxUserError
 	}

--- a/cmd/dippin/cmd_pack.go
+++ b/cmd/dippin/cmd_pack.go
@@ -35,14 +35,16 @@ func (c *CLI) CmdPack(args []string) ExitCode {
 	return ExitCode(runPack(c.Stdout, c.Stderr, args))
 }
 
-// runPack implements `dippin pack <entry.dip> [-o output] [--dry-run]`.
-// Returns one of exitDipx* per the .dipx CLI contract.
+// runPack implements `dippin pack <entry.dip> [-o output] [--dry-run]
+// [--no-inline] [--include <path>...]`. Returns one of exitDipx* per the .dipx
+// CLI contract.
 //
-// Before invoking dipx.Pack on the user-supplied entry, we build a shadow
-// source tree with all command_file: directives resolved to inline command:
-// blocks. dipx.Pack then walks the shadow tree, so the produced bundle is
-// self-contained and does not require the referenced script files to exist
-// when the bundle is later opened.
+// Default (inline) mode builds a shadow source tree with every command_file: /
+// prompt_file: / system_prompt_file: directive resolved to an inline block (see
+// runPackInline), so the bundle is self-contained and needs no referenced files
+// on disk when later opened. --no-inline instead packs the real entry, shipping
+// the directive targets and any --include assets as separate bundle entries and
+// keeping the *_file: directives (dipx.PackOptions).
 func runPack(stdout, stderr io.Writer, args []string) int {
 	pargs, code := parsePackArgs(stderr, args)
 	if code != -1 {

--- a/cmd/dippin/cmd_pack.go
+++ b/cmd/dippin/cmd_pack.go
@@ -44,36 +44,59 @@ func (c *CLI) CmdPack(args []string) ExitCode {
 // self-contained and does not require the referenced script files to exist
 // when the bundle is later opened.
 func runPack(stdout, stderr io.Writer, args []string) int {
-	entry, dest, dryRun, code := parsePackArgs(stderr, args)
+	pargs, code := parsePackArgs(stderr, args)
 	if code != -1 {
 		return code
 	}
-	if code := validateEntryPrePack(stderr, entry); code != exitDipxOK {
+	if code := validatePackIncludes(stderr, pargs); code != exitDipxOK {
 		return code
 	}
-	shadowEntry, cleanup, err := prepShadowSourceTree(entry)
+	if code := validateEntryPrePack(stderr, pargs.entry); code != exitDipxOK {
+		return code
+	}
+	opts := dipx.PackOptions{NoInline: pargs.noInline, Include: pargs.includes}
+	if pargs.noInline {
+		return dispatchPack(stdout, stderr, pargs.entry, pargs.dest, pargs.dryRun, opts)
+	}
+	return runPackInline(stdout, stderr, pargs)
+}
+
+// runPackInline handles the default (inline) path: build a shadow source tree
+// with inlined directives, then dispatch to dipx.Pack with zero options.
+func runPackInline(stdout, stderr io.Writer, pargs packArgs) int {
+	shadowEntry, cleanup, err := prepShadowSourceTree(pargs.entry)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return exitDipxUserError
 	}
 	defer cleanup()
-	return dispatchPack(stdout, stderr, shadowEntry, dest, dryRun)
+	return dispatchPack(stdout, stderr, shadowEntry, pargs.dest, pargs.dryRun, dipx.PackOptions{})
 }
 
-// dispatchPack routes the resolved shadow entry to the right dipx.Pack sink
-// (dry-run discard, stdout, or atomic file). Extracted so runPack stays under
-// the project's cyclomatic-5 cap.
-func dispatchPack(stdout, stderr io.Writer, shadowEntry, dest string, dryRun bool) int {
+// validatePackIncludes rejects --include used without --no-inline (an
+// incoherent hybrid: inlined bodies plus loose assets).
+func validatePackIncludes(stderr io.Writer, pargs packArgs) int {
+	if len(pargs.includes) > 0 && !pargs.noInline {
+		fmt.Fprintln(stderr, "error: --include requires --no-inline")
+		return exitDipxUserError
+	}
+	return exitDipxOK
+}
+
+// dispatchPack routes the resolved entry to the right dipx.Pack sink (dry-run
+// discard, stdout, or atomic file). Extracted so runPack stays under the
+// project's cyclomatic-5 cap.
+func dispatchPack(stdout, stderr io.Writer, entry, dest string, dryRun bool, opts dipx.PackOptions) int {
 	ctx := context.Background()
 	if dryRun {
-		_, err := dipx.Pack(ctx, shadowEntry, io.Discard)
+		_, err := dipx.Pack(ctx, entry, io.Discard, opts)
 		return classifyExit(stderr, err)
 	}
 	if dest == "-" {
-		_, err := dipx.Pack(ctx, shadowEntry, stdout)
+		_, err := dipx.Pack(ctx, entry, stdout, opts)
 		return classifyExit(stderr, err)
 	}
-	return packToFile(stderr, ctx, shadowEntry, dest)
+	return packToFile(stderr, ctx, entry, dest, opts)
 }
 
 // validateEntryPrePack runs structural validation (DIP001-DIP010) on the entry
@@ -99,45 +122,63 @@ func validateEntryPrePack(stderr io.Writer, entry string) int {
 	return exitDipxUserError
 }
 
-// parsePackArgs parses pack flags. On success returns (-1) so the caller knows
-// to proceed; otherwise returns one of the exitDipx* codes.
-func parsePackArgs(stderr io.Writer, args []string) (entry, dest string, dryRun bool, code int) {
+// packArgs holds the parsed result of parsePackArgs.
+type packArgs struct {
+	entry, dest string
+	dryRun      bool
+	noInline    bool
+	includes    []string
+}
+
+// multiStringFlag is a flag.Value that appends each -flag use to a string slice
+// (implements the repeatable --include flag).
+type multiStringFlag []string
+
+func (f *multiStringFlag) String() string     { return strings.Join(*f, ",") }
+func (f *multiStringFlag) Set(v string) error { *f = append(*f, v); return nil }
+
+// parsePackArgs parses pack flags. On success returns code -1 so the caller
+// knows to proceed; otherwise returns one of the exitDipx* codes.
+func parsePackArgs(stderr io.Writer, args []string) (packArgs, int) {
 	fs := flag.NewFlagSet("pack", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	output := fs.String("o", "", "output path (default: <entry>.dipx; '-' for stdout)")
 	dry := fs.Bool("dry-run", false, "validate without writing output")
+	noInline := fs.Bool("no-inline", false, "ship directive targets as assets; keep *_file: directives")
+	var includes multiStringFlag
+	fs.Var(&includes, "include", "extra file or directory to ship (repeatable; requires --no-inline)")
 	if err := fs.Parse(args); err != nil {
-		return "", "", false, exitDipxUserError
+		return packArgs{}, exitDipxUserError
 	}
 	rest := fs.Args()
 	if len(rest) != 1 {
-		fmt.Fprintln(stderr, "usage: dippin pack <entry.dip> [-o output.dipx] [--dry-run]")
-		return "", "", false, exitDipxUserError
+		fmt.Fprintln(stderr, "usage: dippin pack <entry.dip> [-o output.dipx] [--dry-run] [--no-inline] [--include path]")
+		return packArgs{}, exitDipxUserError
 	}
-	entry = rest[0]
+	entry := rest[0]
 	if !strings.EqualFold(filepath.Ext(entry), ".dip") {
 		fmt.Fprintf(stderr, "error: entry must be a .dip file (got %q)\n", entry)
-		return "", "", false, exitDipxUserError
+		return packArgs{}, exitDipxUserError
 	}
-	dest = *output
+	dest := *output
 	if dest == "" {
 		dest = strings.TrimSuffix(entry, filepath.Ext(entry)) + ".dipx"
 	}
-	return entry, dest, *dry, -1
+	return packArgs{entry: entry, dest: dest, dryRun: *dry, noInline: *noInline, includes: []string(includes)}, -1
 }
 
 // packToFile writes the bundle to a unique temp file alongside dest and
 // atomically renames into place on success. Failures clean up the temp file.
 // The unique-name pattern (os.CreateTemp) avoids clobbers between concurrent
 // `dippin pack -o foo.dipx` invocations sharing the same dest.
-func packToFile(stderr io.Writer, ctx context.Context, entry, dest string) int {
+func packToFile(stderr io.Writer, ctx context.Context, entry, dest string, opts dipx.PackOptions) int {
 	f, err := os.CreateTemp(filepath.Dir(dest), filepath.Base(dest)+".*.tmp")
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return exitDipxIOError
 	}
 	tmp := f.Name()
-	if _, err := dipx.Pack(ctx, entry, f); err != nil {
+	if _, err := dipx.Pack(ctx, entry, f, opts); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
 		return classifyExit(stderr, err)

--- a/cmd/dippin/cmd_pack_test.go
+++ b/cmd/dippin/cmd_pack_test.go
@@ -75,6 +75,21 @@ func TestRunPack_MissingEntry(t *testing.T) {
 	}
 }
 
+// TestRunPack_RejectsUppercaseDipExtension guards that the entry-extension
+// check is case-sensitive: the bundle format requires a literal lowercase
+// ".dip", so "foo.DIP" must be rejected up front with a clear error rather than
+// failing later in pack-time policy.
+func TestRunPack_RejectsUppercaseDipExtension(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runPack(&stdout, &stderr, []string{"foo.DIP"})
+	if code != exitDipxUserError {
+		t.Fatalf("code = %d, want %d", code, exitDipxUserError)
+	}
+	if !strings.Contains(stderr.String(), "must be a .dip file") {
+		t.Errorf("stderr = %q, want .dip file error", stderr.String())
+	}
+}
+
 func TestRunPack_DryRun(t *testing.T) {
 	dir, entry := writeMinimalEntry(t)
 	var stdout, stderr bytes.Buffer

--- a/cmd/dippin/cmd_pack_test.go
+++ b/cmd/dippin/cmd_pack_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -340,6 +341,117 @@ func TestRunPack_RejectsSubgraphRefEscape(t *testing.T) {
 	if !strings.Contains(combined, "escapes source root") {
 		t.Errorf("expected 'escapes source root' in error; got: %s", combined)
 	}
+}
+
+// TestRunPack_NoInlineProducesV2 confirms --no-inline yields a format_version 2
+// bundle that keeps the command_file: directive and ships the asset.
+func TestRunPack_NoInlineProducesV2(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "scripts", "run.sh"), []byte("#!/bin/sh\necho hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := `workflow A
+  goal: "no-inline"
+  start: Run
+  exit: Done
+
+  tool Run
+    timeout: 30s
+    command_file: scripts/run.sh
+
+  agent Done
+    prompt:
+      Done.
+
+  edges
+    Run -> Done
+`
+	entry := filepath.Join(dir, "a.dip")
+	if err := os.WriteFile(entry, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "a.dipx")
+	var stdout, stderr bytes.Buffer
+	if code := runPack(&stdout, &stderr, []string{"--no-inline", "-o", out, entry}); code != exitDipxOK {
+		t.Fatalf("pack exit = %d; stderr=%s", code, stderr.String())
+	}
+	if v := readBundleFormatVersion(t, out); v != 2 {
+		t.Fatalf("FormatVersion = %d, want 2", v)
+	}
+	if !strings.Contains(readBundledDip(t, out, "workflows/a.dip"), "command_file:") {
+		t.Error("bundled .dip lost command_file: directive under --no-inline")
+	}
+	found := false
+	for _, name := range listBundleEntries(t, out) {
+		if name == "workflows/scripts/run.sh" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("asset workflows/scripts/run.sh missing: %v", listBundleEntries(t, out))
+	}
+}
+
+// TestRunPack_DefaultStillV1 is the backward-compat regression guard: default
+// pack stays format_version 1 and byte-deterministic.
+func TestRunPack_DefaultStillV1(t *testing.T) {
+	dir := t.TempDir()
+	entry := filepath.Join(dir, "a.dip")
+	if err := os.WriteFile(entry, []byte(minimalDip), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out1 := filepath.Join(dir, "a1.dipx")
+	out2 := filepath.Join(dir, "a2.dipx")
+	var sout, serr bytes.Buffer
+	if code := runPack(&sout, &serr, []string{"-o", out1, entry}); code != exitDipxOK {
+		t.Fatalf("pack1 exit = %d; %s", code, serr.String())
+	}
+	if code := runPack(&sout, &serr, []string{"-o", out2, entry}); code != exitDipxOK {
+		t.Fatalf("pack2 exit = %d; %s", code, serr.String())
+	}
+	b1, _ := os.ReadFile(out1)
+	b2, _ := os.ReadFile(out2)
+	if !bytes.Equal(b1, b2) {
+		t.Fatal("default pack is not byte-deterministic")
+	}
+	if v := readBundleFormatVersion(t, out1); v != 1 {
+		t.Fatalf("FormatVersion = %d, want 1", v)
+	}
+}
+
+// TestRunPack_IncludeRequiresNoInline confirms --include without --no-inline is
+// a usage error.
+func TestRunPack_IncludeRequiresNoInline(t *testing.T) {
+	dir := t.TempDir()
+	entry := filepath.Join(dir, "a.dip")
+	if err := os.WriteFile(entry, []byte(minimalDip), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runPack(&stdout, &stderr, []string{"--include", "scripts/", "-o", filepath.Join(dir, "a.dipx"), entry})
+	if code != exitDipxUserError {
+		t.Fatalf("exit = %d, want %d", code, exitDipxUserError)
+	}
+	if !strings.Contains(stderr.String(), "--include requires --no-inline") {
+		t.Errorf("stderr missing usage message: %s", stderr.String())
+	}
+}
+
+// readBundleFormatVersion reads manifest.json from a bundle and returns its
+// format_version.
+func readBundleFormatVersion(t *testing.T, bundlePath string) int {
+	t.Helper()
+	raw := readBundledDip(t, bundlePath, "manifest.json")
+	var m struct {
+		FormatVersion int `json:"format_version"`
+	}
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	return m.FormatVersion
 }
 
 // readBundledDip extracts the named .dip file from the bundle and returns

--- a/dipx/dipx.go
+++ b/dipx/dipx.go
@@ -196,12 +196,25 @@ func buildBundle(m Manifest, manifestBytes []byte, parsed map[string]*ir.Workflo
 	}
 }
 
+// PackOptions controls Pack's file-shipping behavior. The zero value
+// reproduces the default inline behavior exactly (format_version 1).
+type PackOptions struct {
+	// NoInline ships directive targets (command_file:/prompt_file:/
+	// system_prompt_file:) as opaque asset entries and keeps the *_file:
+	// directives in the packed .dip text. Produces format_version 2.
+	NoInline bool
+	// Include lists extra sibling files or directories (relative to the entry
+	// .dip's directory) to ship as assets. Requires NoInline.
+	Include []string
+}
+
 // Pack builds a .dipx from an entry .dip on disk and writes it to w. Walks
 // every transitively-reachable subgraph ref. Validates structurally, applies
 // all path-safety and ZIP-feature constraints, and produces a deterministic
-// byte stream. Returns the resulting Manifest.
-func Pack(ctx context.Context, entryPath string, w io.Writer) (Manifest, error) {
-	manifest, all, err := preparePackManifest(ctx, entryPath)
+// byte stream. Returns the resulting Manifest. The zero-value PackOptions
+// reproduces the default inline behavior (format_version 1).
+func Pack(ctx context.Context, entryPath string, w io.Writer, opts PackOptions) (Manifest, error) {
+	manifest, all, err := preparePackManifest(ctx, entryPath, opts)
 	if err != nil {
 		return Manifest{}, err
 	}
@@ -217,15 +230,18 @@ func Pack(ctx context.Context, entryPath string, w io.Writer) (Manifest, error) 
 // preparePackManifest walks the source tree and assembles a verified Manifest
 // alongside the packed-file slice ready to write. Split out from Pack so each
 // half stays under the project's complexity caps.
-func preparePackManifest(ctx context.Context, entryPath string) (Manifest, []packedFile, error) {
+func preparePackManifest(ctx context.Context, entryPath string, opts PackOptions) (Manifest, []packedFile, error) {
 	if err := ctx.Err(); err != nil {
 		return Manifest{}, nil, err
 	}
-	entry, all, err := walkSourceTree(ctx, entryPath)
+	entry, all, err := walkSourceTree(ctx, entryPath, opts)
 	if err != nil {
 		return Manifest{}, nil, err
 	}
-	manifest := buildManifestForPack(entry, all)
+	manifest, err := buildPackManifest(entry, all, opts.NoInline)
+	if err != nil {
+		return Manifest{}, nil, err
+	}
 	if err := verifyManifestShape(manifest); err != nil {
 		return Manifest{}, nil, err
 	}

--- a/dipx/dipx.go
+++ b/dipx/dipx.go
@@ -208,12 +208,25 @@ type PackOptions struct {
 	Include []string
 }
 
+// validatePackOptions rejects incoherent option combinations. Include is only
+// meaningful with NoInline (the inline walk never collects assets), so setting
+// it without NoInline is a caller error rather than a silent no-op.
+func validatePackOptions(opts PackOptions) error {
+	if len(opts.Include) > 0 && !opts.NoInline {
+		return newError(ErrPathUnsafe, "", "PackOptions.Include requires NoInline", nil)
+	}
+	return nil
+}
+
 // Pack builds a .dipx from an entry .dip on disk and writes it to w. Walks
 // every transitively-reachable subgraph ref. Validates structurally, applies
 // all path-safety and ZIP-feature constraints, and produces a deterministic
 // byte stream. Returns the resulting Manifest. The zero-value PackOptions
 // reproduces the default inline behavior (format_version 1).
 func Pack(ctx context.Context, entryPath string, w io.Writer, opts PackOptions) (Manifest, error) {
+	if err := validatePackOptions(opts); err != nil {
+		return Manifest{}, err
+	}
 	manifest, all, err := preparePackManifest(ctx, entryPath, opts)
 	if err != nil {
 		return Manifest{}, err

--- a/dipx/dipx_test.go
+++ b/dipx/dipx_test.go
@@ -148,7 +148,7 @@ func TestPack_RoundTrip(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	manifest, err := Pack(context.Background(), filepath.Join(dir, "parent.dip"), &buf)
+	manifest, err := Pack(context.Background(), filepath.Join(dir, "parent.dip"), &buf, PackOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,10 +181,10 @@ func TestPack_Reproducible(t *testing.T) {
 		t.Fatal(err)
 	}
 	var buf1, buf2 bytes.Buffer
-	if _, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf1); err != nil {
+	if _, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf1, PackOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf2); err != nil {
+	if _, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf2, PackOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(buf1.Bytes(), buf2.Bytes()) {
@@ -201,7 +201,7 @@ func TestPack_RejectsOversizedSource(t *testing.T) {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
-	_, err := Pack(context.Background(), filepath.Join(dir, "big.dip"), &buf)
+	_, err := Pack(context.Background(), filepath.Join(dir, "big.dip"), &buf, PackOptions{})
 	if !errors.Is(err, ErrCapExceeded) {
 		t.Fatalf("err = %v, want ErrCapExceeded", err)
 	}
@@ -288,7 +288,7 @@ func TestPack_RejectsSymlink(t *testing.T) {
 		t.Skip("symlinks not supported on this platform")
 	}
 	var buf bytes.Buffer
-	_, err := Pack(context.Background(), link, &buf)
+	_, err := Pack(context.Background(), link, &buf, PackOptions{})
 	if !errors.Is(err, ErrPathUnsafe) {
 		t.Fatalf("err = %v, want ErrPathUnsafe", err)
 	}
@@ -328,7 +328,7 @@ func TestPack_RejectsParentSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
-	_, err := Pack(context.Background(), entryPath, &buf)
+	_, err := Pack(context.Background(), entryPath, &buf, PackOptions{})
 	if !errors.Is(err, ErrPathUnsafe) {
 		t.Fatalf("err = %v, want ErrPathUnsafe", err)
 	}
@@ -362,7 +362,7 @@ func TestPack_AcceptsDoubleDotPrefixDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
-	if _, err := Pack(context.Background(), entryPath, &buf); err != nil {
+	if _, err := Pack(context.Background(), entryPath, &buf, PackOptions{}); err != nil {
 		t.Fatalf("unexpected error packing legitimate '..foo' subdir: %v", err)
 	}
 }
@@ -481,7 +481,7 @@ func TestPack_BadSubgraph_ReportsErrSubgraphParse(t *testing.T) {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
-	_, err := Pack(context.Background(), entryPath, &buf)
+	_, err := Pack(context.Background(), entryPath, &buf, PackOptions{})
 	if err == nil {
 		t.Fatal("Pack returned nil, want ErrSubgraphParse")
 	}
@@ -577,7 +577,7 @@ func mustBuildValidBundle(t *testing.T, dst string) {
 		t.Fatal(err)
 	}
 	var buf bytes.Buffer
-	if _, err := Pack(context.Background(), entryPath, &buf); err != nil {
+	if _, err := Pack(context.Background(), entryPath, &buf, PackOptions{}); err != nil {
 		t.Fatalf("Pack: %v", err)
 	}
 	if err := os.WriteFile(dst, buf.Bytes(), 0o644); err != nil {
@@ -619,7 +619,7 @@ func TestPack_HonorsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	var buf bytes.Buffer
-	_, err := Pack(ctx, entryPath, &buf)
+	_, err := Pack(ctx, entryPath, &buf, PackOptions{})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Pack err = %v, want context.Canceled", err)
 	}

--- a/dipx/helpers.go
+++ b/dipx/helpers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -125,6 +126,9 @@ func walkRefs(parsed map[string]*ir.Workflow, m Manifest) error {
 // hundred workflows in practice).
 func detectCyclesAll(graph map[string][]string, m Manifest) error {
 	for _, e := range m.Files {
+		if !strings.HasSuffix(e.Path, ".dip") {
+			continue // asset entries have no ref graph; cycle-check workflows only
+		}
 		if err := detectCycles(graph, e.Path); err != nil {
 			return err
 		}
@@ -219,18 +223,32 @@ func normalizeConditions(parsed map[string]*ir.Workflow) error {
 func parseAllWorkflows(verified map[string]verifiedBytes, entryPath string) (map[string]*ir.Workflow, error) {
 	out := make(map[string]*ir.Workflow, len(verified))
 	for path, vb := range verified {
-		p := parser.NewParser(string(vb.Bytes()), path)
-		wf, err := p.Parse()
+		if !strings.HasSuffix(path, ".dip") {
+			continue // non-.dip entries are opaque assets (format_version 2)
+		}
+		wf, err := parseOneVerifiedWorkflow(path, vb, entryPath)
 		if err != nil {
-			sentinel := ErrSubgraphParse
-			if path == entryPath {
-				sentinel = ErrEntryParse
-			}
-			return nil, newError(sentinel, path, "parse failed", err)
+			return nil, err
 		}
 		out[path] = wf
 	}
 	return out, nil
+}
+
+// parseOneVerifiedWorkflow parses a single verified .dip entry, attributing a
+// parse failure to ErrEntryParse for the entry and ErrSubgraphParse otherwise.
+// This is the verifiedBytes-pathway call site of parser.NewParser (site 1 of
+// the three-site inventory documented on parseAllWorkflows).
+func parseOneVerifiedWorkflow(path string, vb verifiedBytes, entryPath string) (*ir.Workflow, error) {
+	wf, err := parser.NewParser(string(vb.Bytes()), path).Parse()
+	if err != nil {
+		sentinel := ErrSubgraphParse
+		if path == entryPath {
+			sentinel = ErrEntryParse
+		}
+		return nil, newError(sentinel, path, "parse failed", err)
+	}
+	return wf, nil
 }
 
 // packedFile is one source file collected by walkSourceTree.
@@ -242,23 +260,53 @@ type packedFile struct {
 
 // walkSourceTree collects the entry workflow plus every transitively-referenced
 // subgraph from disk. Refuses to follow symlinks. Refuses if any ref escapes
-// the entry's source root.
-func walkSourceTree(ctx context.Context, entryPath string) (packedFile, []packedFile, error) {
-	entryAbs, err := filepath.Abs(entryPath)
+// the entry's source root. When opts.NoInline is set it also collects directive
+// and --include asset files as non-.dip bundle entries.
+func walkSourceTree(ctx context.Context, entryPath string, opts PackOptions) (packedFile, []packedFile, error) {
+	st, err := initPackWalkState(entryPath, opts.NoInline)
 	if err != nil {
 		return packedFile{}, nil, err
 	}
-	rootDir := filepath.Dir(entryAbs)
-	st := newPackWalkState(entryAbs, rootDir)
+	if err := runWalkLoop(ctx, st); err != nil {
+		return packedFile{}, nil, err
+	}
+	return assemblePackFiles(st, opts.Include)
+}
+
+// initPackWalkState absolutizes entryPath and constructs the walk state.
+func initPackWalkState(entryPath string, trackWfs bool) (*packWalkState, error) {
+	entryAbs, err := filepath.Abs(entryPath)
+	if err != nil {
+		return nil, err
+	}
+	return newPackWalkState(entryAbs, filepath.Dir(entryAbs), trackWfs), nil
+}
+
+// runWalkLoop drives the BFS until the queue is empty, checking ctx per step.
+func runWalkLoop(ctx context.Context, st *packWalkState) error {
 	for st.hasMore() {
 		if err := ctx.Err(); err != nil {
-			return packedFile{}, nil, err
+			return err
 		}
 		if err := st.visitNext(); err != nil {
-			return packedFile{}, nil, err
+			return err
 		}
 	}
-	return st.entry, st.all, nil
+	return nil
+}
+
+// assemblePackFiles returns the entry plus every packed file. In NoInline mode
+// it appends the collected directive/--include assets before returning; the
+// combined slice is sorted by path later in writeBundle/buildManifestForPack.
+func assemblePackFiles(st *packWalkState, includes []string) (packedFile, []packedFile, error) {
+	if !st.trackWfs {
+		return st.entry, st.all, nil
+	}
+	assets, err := collectAllAssets(st, includes)
+	if err != nil {
+		return packedFile{}, nil, err
+	}
+	return st.entry, append(st.all, assets...), nil
 }
 
 // packWalkState carries iteration state for walkSourceTree so each step can be
@@ -270,15 +318,22 @@ type packWalkState struct {
 	queue    []string
 	entry    packedFile
 	all      []packedFile
+	trackWfs bool                    // NoInline: record parsed workflows for asset collection
+	wfMap    map[string]*ir.Workflow // populated only when trackWfs; key = absPath
 }
 
-func newPackWalkState(entryAbs, rootDir string) *packWalkState {
-	return &packWalkState{
+func newPackWalkState(entryAbs, rootDir string, trackWfs bool) *packWalkState {
+	st := &packWalkState{
 		entryAbs: entryAbs,
 		rootDir:  rootDir,
 		visited:  map[string]struct{}{},
 		queue:    []string{entryAbs},
+		trackWfs: trackWfs,
 	}
+	if trackWfs {
+		st.wfMap = map[string]*ir.Workflow{}
+	}
+	return st
 }
 
 func (s *packWalkState) hasMore() bool { return len(s.queue) > 0 }
@@ -300,6 +355,9 @@ func (s *packWalkState) visitNext() error {
 		s.entry = pf
 	}
 	s.all = append(s.all, pf)
+	if s.trackWfs {
+		s.wfMap[cur] = wf
+	}
 	return s.enqueueRefs(cur, wf)
 }
 
@@ -466,6 +524,246 @@ func buildManifestForPack(entry packedFile, all []packedFile) Manifest {
 		Entry:         entry.bundlePath,
 		Files:         files,
 	}
+}
+
+// buildPackManifest enforces pack-time caps then routes to the v1 (inline) or
+// v2 (no-inline) manifest builder.
+func buildPackManifest(entry packedFile, all []packedFile, noInline bool) (Manifest, error) {
+	if err := checkPackCaps(all); err != nil {
+		return Manifest{}, err
+	}
+	if noInline {
+		return buildManifestForPackV2(entry, all), nil
+	}
+	return buildManifestForPack(entry, all), nil
+}
+
+// buildManifestForPackV2 emits format_version 2. Kept separate from the v1
+// builder so the v1 path stays byte-identical (goldens and Identity() stable).
+func buildManifestForPackV2(entry packedFile, all []packedFile) Manifest {
+	files := make([]ManifestEntry, 0, len(all))
+	for _, pf := range all {
+		files = append(files, ManifestEntry{Path: pf.bundlePath, SHA256: pf.hash})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return Manifest{
+		FormatVersion: 2,
+		Entry:         entry.bundlePath,
+		Files:         files,
+	}
+}
+
+// checkPackCaps enforces the 10 000-file and 100 MB-total caps at pack time so
+// the producer cannot emit a bundle that fails its own Open (spec § Security 2).
+func checkPackCaps(all []packedFile) error {
+	if len(all) > maxFiles {
+		return newError(ErrCapExceeded, "", fmt.Sprintf("files exceeds %d", maxFiles), nil)
+	}
+	var total int64
+	for _, pf := range all {
+		total += int64(len(pf.bytes))
+	}
+	if total > maxTotalUncompBytes {
+		return newError(ErrCapExceeded, "", fmt.Sprintf("total uncompressed bytes would exceed %d", maxTotalUncompBytes), nil)
+	}
+	return nil
+}
+
+// ensureAssetUnderRoot rejects an absolute path that escapes rootDir, using the
+// same lexical `..`-component check as resolveRefOnDisk.
+func ensureAssetUnderRoot(abs, rootDir string) error {
+	rel, err := filepath.Rel(rootDir, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return newError(ErrPathUnsafe, abs, "path escapes source root", nil)
+	}
+	return nil
+}
+
+// readAssetFile reads a non-.dip asset through ReadNoFollowSymlinks (which
+// refuses symlink leaves/ancestors and non-regular files), enforces the
+// per-file cap, and returns a packedFile at its mirrored workflows/ bundle
+// path. Callers MUST run ensureAssetUnderRoot first (ReadNoFollowSymlinks
+// assumes containment).
+func readAssetFile(abs, rootDir string) (packedFile, error) {
+	raw, err := ReadNoFollowSymlinks(abs, rootDir)
+	if err != nil {
+		return packedFile{}, err
+	}
+	if int64(len(raw)) > maxPerFileBytes {
+		return packedFile{}, newError(ErrCapExceeded, abs, fmt.Sprintf("asset file exceeds %d bytes", maxPerFileBytes), nil)
+	}
+	bp, err := bundlePathFor(abs, rootDir)
+	if err != nil {
+		return packedFile{}, err
+	}
+	return packedFile{bundlePath: bp, bytes: raw, hash: hashHex(raw)}, nil
+}
+
+// agentFileDirectives returns the non-empty file-directive paths on an agent
+// config (prompt_file, system_prompt_file).
+func agentFileDirectives(cfg ir.AgentConfig) []string {
+	var out []string
+	if cfg.PromptFile != "" {
+		out = append(out, cfg.PromptFile)
+	}
+	if cfg.SystemPromptFile != "" {
+		out = append(out, cfg.SystemPromptFile)
+	}
+	return out
+}
+
+// fileDirectivesForNode returns the file-directive source paths for a node:
+// command_file for tool nodes, prompt_file/system_prompt_file for agent nodes.
+func fileDirectivesForNode(n *ir.Node) []string {
+	switch cfg := n.Config.(type) {
+	case ir.ToolConfig:
+		if cfg.CommandFile != "" {
+			return []string{cfg.CommandFile}
+		}
+	case ir.AgentConfig:
+		return agentFileDirectives(cfg)
+	}
+	return nil
+}
+
+// collectDirectiveFile resolves one file-directive path (relative to wfDir),
+// checks containment, deduplicates via visited, and reads the file as an asset.
+func collectDirectiveFile(rel, wfDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+	if rel == "" {
+		return nil, nil
+	}
+	abs := filepath.Clean(filepath.Join(wfDir, rel))
+	if err := ensureAssetUnderRoot(abs, rootDir); err != nil {
+		return nil, err
+	}
+	if _, ok := visited[abs]; ok {
+		return nil, nil
+	}
+	pf, err := readAssetFile(abs, rootDir)
+	if err != nil {
+		return nil, err
+	}
+	visited[abs] = struct{}{}
+	return []packedFile{pf}, nil
+}
+
+// collectNodeDirectiveFiles gathers all directive assets referenced by one node.
+func collectNodeDirectiveFiles(n *ir.Node, wfDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+	var results []packedFile
+	for _, rel := range fileDirectivesForNode(n) {
+		pfs, err := collectDirectiveFile(rel, wfDir, rootDir, visited)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, pfs...)
+	}
+	return results, nil
+}
+
+// collectDirectiveAssets walks all nodes in wf collecting command_file /
+// prompt_file / system_prompt_file targets, resolved relative to the
+// workflow's own directory (wfAbsPath's dir).
+func collectDirectiveAssets(wf *ir.Workflow, wfAbsPath, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+	wfDir := filepath.Dir(wfAbsPath)
+	var results []packedFile
+	for _, n := range wf.Nodes {
+		pfs, err := collectNodeDirectiveFiles(n, wfDir, rootDir, visited)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, pfs...)
+	}
+	return results, nil
+}
+
+// collectIncludeFile reads one --include leaf file as an asset, rejecting .dip
+// targets and skipping already-visited paths.
+func collectIncludeFile(abs, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+	if strings.HasSuffix(abs, ".dip") {
+		return nil, newError(ErrPathUnsafe, abs, "assets may not end in .dip", nil)
+	}
+	if _, ok := visited[abs]; ok {
+		return nil, nil
+	}
+	pf, err := readAssetFile(abs, rootDir)
+	if err != nil {
+		return nil, err
+	}
+	visited[abs] = struct{}{}
+	return []packedFile{pf}, nil
+}
+
+// walkIncludeEntry is the filepath.WalkDir callback for resolveIncludeDir. It
+// skips directory entries; file entries (including symlink leaves, which
+// readAssetFile rejects) route through collectIncludeFile.
+func walkIncludeEntry(path string, d fs.DirEntry, err error, rootDir string, visited map[string]struct{}, results *[]packedFile) error {
+	if err != nil {
+		return err
+	}
+	if d.IsDir() {
+		return nil
+	}
+	pfs, err := collectIncludeFile(path, rootDir, visited)
+	if err != nil {
+		return err
+	}
+	*results = append(*results, pfs...)
+	return nil
+}
+
+// resolveIncludeDir safely walks absDir collecting non-.dip files. WalkDir does
+// not descend into symlinked directories; symlink leaves are re-validated by
+// ReadNoFollowSymlinks inside readAssetFile.
+func resolveIncludeDir(absDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+	var results []packedFile
+	err := filepath.WalkDir(absDir, func(path string, d fs.DirEntry, err error) error {
+		return walkIncludeEntry(path, d, err, rootDir, visited, &results)
+	})
+	return results, err
+}
+
+// resolveIncludePath resolves one --include value (file or directory) relative
+// to entryDir, validates containment, then delegates to the dir or file reader.
+func resolveIncludePath(rel, entryDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+	if rel == "" {
+		return nil, newError(ErrPathUnsafe, rel, "empty --include path", nil)
+	}
+	abs := filepath.Clean(filepath.Join(entryDir, rel))
+	if err := ensureAssetUnderRoot(abs, rootDir); err != nil {
+		return nil, err
+	}
+	info, err := os.Lstat(abs)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return resolveIncludeDir(abs, rootDir, visited)
+	}
+	return collectIncludeFile(abs, rootDir, visited)
+}
+
+// collectAllAssets gathers directive assets from every walked workflow plus each
+// --include path, deduplicating via st.visited, then sorts by bundle path for
+// determinism (WalkDir and map iteration order are not guaranteed).
+func collectAllAssets(st *packWalkState, includes []string) ([]packedFile, error) {
+	entryDir := filepath.Dir(st.entryAbs)
+	var assets []packedFile
+	for absPath, wf := range st.wfMap {
+		pfs, err := collectDirectiveAssets(wf, absPath, st.rootDir, st.visited)
+		if err != nil {
+			return nil, err
+		}
+		assets = append(assets, pfs...)
+	}
+	for _, inc := range includes {
+		pfs, err := resolveIncludePath(inc, entryDir, st.rootDir, st.visited)
+		if err != nil {
+			return nil, err
+		}
+		assets = append(assets, pfs...)
+	}
+	sort.Slice(assets, func(i, j int) bool { return assets[i].bundlePath < assets[j].bundlePath })
+	return assets, nil
 }
 
 // writeBundle writes a deterministic .dipx to w. manifest.json is always the

--- a/dipx/helpers.go
+++ b/dipx/helpers.go
@@ -629,14 +629,34 @@ func fileDirectivesForNode(n *ir.Node) []string {
 	return nil
 }
 
+// resolveDirectiveTarget validates one file-directive path the same way
+// parser.ResolveFileDirectives does for source/inline packs: it rejects
+// absolute paths and any target that escapes the declaring workflow's own
+// directory (wfDir). Without this, --no-inline could ship a file the source
+// run rejects and preserve a directive that later resolution fails. It also
+// enforces the assets-may-not-end-in-.dip rule before any dedup fast-path.
+func resolveDirectiveTarget(rel, wfDir string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", newError(ErrPathUnsafe, rel, "file directive must be a relative path", nil)
+	}
+	abs := filepath.Clean(filepath.Join(wfDir, rel))
+	if err := ensureAssetUnderRoot(abs, wfDir); err != nil {
+		return "", err
+	}
+	if strings.HasSuffix(abs, ".dip") {
+		return "", newError(ErrPathUnsafe, abs, "assets may not end in .dip", nil)
+	}
+	return abs, nil
+}
+
 // collectDirectiveFile resolves one file-directive path (relative to wfDir),
 // checks containment, deduplicates via visited, and reads the file as an asset.
 func collectDirectiveFile(rel, wfDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
 	if rel == "" {
 		return nil, nil
 	}
-	abs := filepath.Clean(filepath.Join(wfDir, rel))
-	if err := ensureAssetUnderRoot(abs, rootDir); err != nil {
+	abs, err := resolveDirectiveTarget(rel, wfDir)
+	if err != nil {
 		return nil, err
 	}
 	if _, ok := visited[abs]; ok {
@@ -679,9 +699,14 @@ func collectDirectiveAssets(wf *ir.Workflow, wfAbsPath, rootDir string, visited 
 	return results, nil
 }
 
-// collectIncludeFile reads one --include leaf file as an asset (readAssetFile
-// rejects .dip targets) and skips already-visited paths.
+// collectIncludeFile reads one --include leaf file as an asset and skips
+// already-visited paths. The .dip rejection runs before the visited fast-path
+// so an --include of a .dip already reachable as a subgraph still errors
+// (rather than silently returning via dedup).
 func collectIncludeFile(abs, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+	if strings.HasSuffix(abs, ".dip") {
+		return nil, newError(ErrPathUnsafe, abs, "assets may not end in .dip", nil)
+	}
 	if _, ok := visited[abs]; ok {
 		return nil, nil
 	}
@@ -696,13 +721,14 @@ func collectIncludeFile(abs, rootDir string, visited map[string]struct{}) ([]pac
 // walkIncludeEntry is the filepath.WalkDir callback for resolveIncludeDir. It
 // skips directory entries; file entries (including symlink leaves, which
 // readAssetFile rejects) route through collectIncludeFile.
-func walkIncludeEntry(path string, d fs.DirEntry, err error, rootDir string, visited map[string]struct{}, results *[]packedFile) error {
+func walkIncludeEntry(path string, d fs.DirEntry, err error, rootDir string, visited map[string]struct{}, results *[]packedFile, found *int) error {
 	if err != nil {
 		return err
 	}
 	if d.IsDir() {
 		return nil
 	}
+	*found++
 	pfs, err := collectIncludeFile(path, rootDir, visited)
 	if err != nil {
 		return err
@@ -713,13 +739,23 @@ func walkIncludeEntry(path string, d fs.DirEntry, err error, rootDir string, vis
 
 // resolveIncludeDir safely walks absDir collecting non-.dip files. WalkDir does
 // not descend into symlinked directories; symlink leaves are re-validated by
-// ReadNoFollowSymlinks inside readAssetFile.
+// ReadNoFollowSymlinks inside readAssetFile. An include directory holding no
+// files (empty, or only subdirectories) is an error, to catch typos rather
+// than silently shipping nothing. `found` counts files before dedup, so a
+// directory whose files are all already shipped does not spuriously error.
 func resolveIncludeDir(absDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
 	var results []packedFile
+	found := 0
 	err := filepath.WalkDir(absDir, func(path string, d fs.DirEntry, err error) error {
-		return walkIncludeEntry(path, d, err, rootDir, visited, &results)
+		return walkIncludeEntry(path, d, err, rootDir, visited, &results, &found)
 	})
-	return results, err
+	if err != nil {
+		return nil, err
+	}
+	if found == 0 {
+		return nil, newError(ErrPathUnsafe, absDir, "included directory contains no files", nil)
+	}
+	return results, nil
 }
 
 // resolveIncludePath resolves one --include value (file or directory) relative

--- a/dipx/helpers.go
+++ b/dipx/helpers.go
@@ -270,7 +270,7 @@ func walkSourceTree(ctx context.Context, entryPath string, opts PackOptions) (pa
 	if err := runWalkLoop(ctx, st); err != nil {
 		return packedFile{}, nil, err
 	}
-	return assemblePackFiles(st, opts.Include)
+	return assemblePackFiles(ctx, st, opts.Include)
 }
 
 // initPackWalkState absolutizes entryPath and constructs the walk state.
@@ -298,11 +298,11 @@ func runWalkLoop(ctx context.Context, st *packWalkState) error {
 // assemblePackFiles returns the entry plus every packed file. In NoInline mode
 // it appends the collected directive/--include assets before returning; the
 // combined slice is sorted by path later in writeBundle/buildManifestForPack.
-func assemblePackFiles(st *packWalkState, includes []string) (packedFile, []packedFile, error) {
+func assemblePackFiles(ctx context.Context, st *packWalkState, includes []string) (packedFile, []packedFile, error) {
 	if !st.trackWfs {
 		return st.entry, st.all, nil
 	}
-	assets, err := collectAllAssets(st, includes)
+	assets, err := collectAllAssets(ctx, st, includes)
 	if err != nil {
 		return packedFile{}, nil, err
 	}
@@ -721,9 +721,12 @@ func collectIncludeFile(abs, rootDir string, visited map[string]struct{}) ([]pac
 // walkIncludeEntry is the filepath.WalkDir callback for resolveIncludeDir. It
 // skips directory entries; file entries (including symlink leaves, which
 // readAssetFile rejects) route through collectIncludeFile.
-func walkIncludeEntry(path string, d fs.DirEntry, err error, rootDir string, visited map[string]struct{}, results *[]packedFile, found *int) error {
+func walkIncludeEntry(ctx context.Context, path string, d fs.DirEntry, err error, rootDir string, visited map[string]struct{}, results *[]packedFile, found *int) error {
 	if err != nil {
 		return err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
 	}
 	if d.IsDir() {
 		return nil
@@ -743,11 +746,11 @@ func walkIncludeEntry(path string, d fs.DirEntry, err error, rootDir string, vis
 // files (empty, or only subdirectories) is an error, to catch typos rather
 // than silently shipping nothing. `found` counts files before dedup, so a
 // directory whose files are all already shipped does not spuriously error.
-func resolveIncludeDir(absDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+func resolveIncludeDir(ctx context.Context, absDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
 	var results []packedFile
 	found := 0
 	err := filepath.WalkDir(absDir, func(path string, d fs.DirEntry, err error) error {
-		return walkIncludeEntry(path, d, err, rootDir, visited, &results, &found)
+		return walkIncludeEntry(ctx, path, d, err, rootDir, visited, &results, &found)
 	})
 	if err != nil {
 		return nil, err
@@ -760,7 +763,7 @@ func resolveIncludeDir(absDir, rootDir string, visited map[string]struct{}) ([]p
 
 // resolveIncludePath resolves one --include value (file or directory) relative
 // to entryDir, validates containment, then delegates to the dir or file reader.
-func resolveIncludePath(rel, entryDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
+func resolveIncludePath(ctx context.Context, rel, entryDir, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
 	if rel == "" {
 		return nil, newError(ErrPathUnsafe, rel, "empty --include path", nil)
 	}
@@ -773,31 +776,59 @@ func resolveIncludePath(rel, entryDir, rootDir string, visited map[string]struct
 		return nil, err
 	}
 	if info.IsDir() {
-		return resolveIncludeDir(abs, rootDir, visited)
+		return resolveIncludeDir(ctx, abs, rootDir, visited)
 	}
 	return collectIncludeFile(abs, rootDir, visited)
 }
 
-// collectAllAssets gathers directive assets from every walked workflow plus each
-// --include path, deduplicating via st.visited, then sorts by bundle path for
-// determinism (WalkDir and map iteration order are not guaranteed).
-func collectAllAssets(st *packWalkState, includes []string) ([]packedFile, error) {
-	entryDir := filepath.Dir(st.entryAbs)
+// collectWorkflowAssets gathers directive assets from every walked workflow,
+// honoring ctx cancellation between workflows.
+func collectWorkflowAssets(ctx context.Context, st *packWalkState) ([]packedFile, error) {
 	var assets []packedFile
 	for absPath, wf := range st.wfMap {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		pfs, err := collectDirectiveAssets(wf, absPath, st.rootDir, st.visited)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, pfs...)
 	}
+	return assets, nil
+}
+
+// collectIncludeAssets resolves every --include path, honoring ctx cancellation
+// between includes.
+func collectIncludeAssets(ctx context.Context, st *packWalkState, includes []string) ([]packedFile, error) {
+	entryDir := filepath.Dir(st.entryAbs)
+	var assets []packedFile
 	for _, inc := range includes {
-		pfs, err := resolveIncludePath(inc, entryDir, st.rootDir, st.visited)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		pfs, err := resolveIncludePath(ctx, inc, entryDir, st.rootDir, st.visited)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, pfs...)
 	}
+	return assets, nil
+}
+
+// collectAllAssets gathers directive assets from every walked workflow plus each
+// --include path, deduplicating via st.visited, then sorts by bundle path for
+// determinism (WalkDir and map iteration order are not guaranteed).
+func collectAllAssets(ctx context.Context, st *packWalkState, includes []string) ([]packedFile, error) {
+	assets, err := collectWorkflowAssets(ctx, st)
+	if err != nil {
+		return nil, err
+	}
+	inc, err := collectIncludeAssets(ctx, st, includes)
+	if err != nil {
+		return nil, err
+	}
+	assets = append(assets, inc...)
 	sort.Slice(assets, func(i, j int) bool { return assets[i].bundlePath < assets[j].bundlePath })
 	return assets, nil
 }

--- a/dipx/helpers.go
+++ b/dipx/helpers.go
@@ -585,6 +585,9 @@ func ensureAssetUnderRoot(abs, rootDir string) error {
 // path. Callers MUST run ensureAssetUnderRoot first (ReadNoFollowSymlinks
 // assumes containment).
 func readAssetFile(abs, rootDir string) (packedFile, error) {
+	if strings.HasSuffix(abs, ".dip") {
+		return packedFile{}, newError(ErrPathUnsafe, abs, "assets may not end in .dip", nil)
+	}
 	raw, err := ReadNoFollowSymlinks(abs, rootDir)
 	if err != nil {
 		return packedFile{}, err
@@ -676,12 +679,9 @@ func collectDirectiveAssets(wf *ir.Workflow, wfAbsPath, rootDir string, visited 
 	return results, nil
 }
 
-// collectIncludeFile reads one --include leaf file as an asset, rejecting .dip
-// targets and skipping already-visited paths.
+// collectIncludeFile reads one --include leaf file as an asset (readAssetFile
+// rejects .dip targets) and skips already-visited paths.
 func collectIncludeFile(abs, rootDir string, visited map[string]struct{}) ([]packedFile, error) {
-	if strings.HasSuffix(abs, ".dip") {
-		return nil, newError(ErrPathUnsafe, abs, "assets may not end in .dip", nil)
-	}
 	if _, ok := visited[abs]; ok {
 		return nil, nil
 	}

--- a/dipx/manifest.go
+++ b/dipx/manifest.go
@@ -307,7 +307,7 @@ func verifyFiles(m Manifest) (map[string]struct{}, error) {
 	seenByte := make(map[string]struct{}, len(m.Files))
 	seenFold := make(map[string]struct{}, len(m.Files))
 	for _, e := range m.Files {
-		if err := verifyOneFile(e, seenByte, seenFold); err != nil {
+		if err := verifyOneFile(e, m.FormatVersion, seenByte, seenFold); err != nil {
 			return nil, err
 		}
 	}
@@ -316,8 +316,8 @@ func verifyFiles(m Manifest) (map[string]struct{}, error) {
 
 // verifyOneFile validates a single ManifestEntry and records it in the seen
 // sets. Mutates seenByte and seenFold on success.
-func verifyOneFile(e ManifestEntry, seenByte, seenFold map[string]struct{}) error {
-	if err := verifyEntryFields(e); err != nil {
+func verifyOneFile(e ManifestEntry, version int, seenByte, seenFold map[string]struct{}) error {
+	if err := verifyEntryFields(e, version); err != nil {
 		return err
 	}
 	return checkAndRecordPath(e.Path, seenByte, seenFold)
@@ -325,12 +325,16 @@ func verifyOneFile(e ManifestEntry, seenByte, seenFold map[string]struct{}) erro
 
 // verifyEntryFields enforces presence and shape of an entry's path and sha256
 // fields. Missing path is classified as ErrManifestInvalid (schema rule 3),
-// not as ErrPathUnsafe.
-func verifyEntryFields(e ManifestEntry) error {
+// not as ErrPathUnsafe. Path safety is checked by Canonicalize; the
+// version-aware prefix/suffix POLICY is checked by checkPathPolicy.
+func verifyEntryFields(e ManifestEntry, version int) error {
 	if e.Path == "" {
 		return newError(ErrManifestInvalid, "", "files[] entry missing required key: path", nil)
 	}
 	if _, err := Canonicalize(e.Path); err != nil {
+		return err
+	}
+	if err := checkPathPolicy(e.Path, version); err != nil {
 		return err
 	}
 	if !isValidHash(e.SHA256) {
@@ -358,6 +362,11 @@ func checkAndRecordPath(path string, seenByte, seenFold map[string]struct{}) err
 // the previously-seen files[].path values.
 func verifyEntryInFiles(m Manifest, seenByte map[string]struct{}) error {
 	if _, err := Canonicalize(m.Entry); err != nil {
+		return err
+	}
+	// entry is always a workflow; v1 policy (workflows/ prefix + .dip suffix)
+	// applies regardless of bundle format version.
+	if err := checkPathPolicy(m.Entry, 1); err != nil {
 		return err
 	}
 	if _, ok := seenByte[m.Entry]; !ok {
@@ -397,4 +406,4 @@ func isLowerHexRune(r rune) bool {
 
 // SupportedFormatVersions returns the format_version values this build accepts.
 // Returns a fresh slice on every call to prevent mutation by callers.
-func SupportedFormatVersions() []int { return []int{1} }
+func SupportedFormatVersions() []int { return []int{1, 2} }

--- a/dipx/manifest_test.go
+++ b/dipx/manifest_test.go
@@ -177,6 +177,72 @@ func TestVerifyManifestShape_MissingPath(t *testing.T) {
 	}
 }
 
+// TestVerifyManifestShape_V2_Happy proves format_version 2 accepts a manifest
+// mixing a .dip workflow and a non-.dip asset under workflows/.
+func TestVerifyManifestShape_V2_Happy(t *testing.T) {
+	hash := strings.Repeat("a", 64)
+	m := Manifest{
+		FormatVersion: 2,
+		Entry:         "workflows/entry.dip",
+		Files: []ManifestEntry{
+			{Path: "workflows/entry.dip", SHA256: hash},
+			{Path: "workflows/scripts/boot.sh", SHA256: hash},
+		},
+	}
+	if err := verifyManifestShape(m); err != nil {
+		t.Fatalf("verifyManifestShape(v2 mixed) = %v, want nil", err)
+	}
+}
+
+// TestVerifyManifestShape_V2_EntryMustBeDIP proves the entry is held to v1
+// policy (.dip suffix) even in a v2 bundle.
+func TestVerifyManifestShape_V2_EntryMustBeDIP(t *testing.T) {
+	hash := strings.Repeat("a", 64)
+	m := Manifest{
+		FormatVersion: 2,
+		Entry:         "workflows/boot.sh",
+		Files: []ManifestEntry{
+			{Path: "workflows/boot.sh", SHA256: hash},
+		},
+	}
+	if err := verifyManifestShape(m); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("verifyManifestShape(v2 non-.dip entry) = %v, want ErrPathUnsafe", err)
+	}
+}
+
+// TestVerifyManifestShape_V1_RejectsAssetEntry proves v1 policy is unchanged:
+// a non-.dip path in files[] is rejected.
+func TestVerifyManifestShape_V1_RejectsAssetEntry(t *testing.T) {
+	hash := strings.Repeat("a", 64)
+	m := Manifest{
+		FormatVersion: 1,
+		Entry:         "workflows/entry.dip",
+		Files: []ManifestEntry{
+			{Path: "workflows/entry.dip", SHA256: hash},
+			{Path: "workflows/scripts/boot.sh", SHA256: hash},
+		},
+	}
+	if err := verifyManifestShape(m); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("verifyManifestShape(v1 asset entry) = %v, want ErrPathUnsafe", err)
+	}
+}
+
+// TestSupportedFormatVersions_IncludesV2 confirms the gate accepts v2.
+func TestSupportedFormatVersions_IncludesV2(t *testing.T) {
+	var has1, has2 bool
+	for _, v := range SupportedFormatVersions() {
+		if v == 1 {
+			has1 = true
+		}
+		if v == 2 {
+			has2 = true
+		}
+	}
+	if !has1 || !has2 {
+		t.Fatalf("SupportedFormatVersions() = %v, want to contain 1 and 2", SupportedFormatVersions())
+	}
+}
+
 // TestDecodeManifest_DepthAtCap is the positive boundary partner to
 // TestDecodeManifest_DepthCap. The depth cap is 32. The source builds the
 // top-level object (depth 1) plus 31 nested unknown-key objects = depth 32,

--- a/dipx/pack_noinline_test.go
+++ b/dipx/pack_noinline_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
 )
 
 // dipWithCommandFile is a minimal workflow referencing a script via
@@ -414,6 +416,33 @@ func TestPack_IncludeWithoutNoInlineErrors(t *testing.T) {
 	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{Include: []string{"loose"}})
 	if !errors.Is(err, ErrPathUnsafe) {
 		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+// TestCollectAllAssets_ContextCancelled guards that no-inline asset collection
+// honors ctx cancellation in both the per-workflow and per-include loops, so a
+// cancel after the workflow BFS still short-circuits before walking/reading.
+func TestCollectAllAssets_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stWf := &packWalkState{
+		rootDir:  "/x",
+		visited:  map[string]struct{}{},
+		trackWfs: true,
+		wfMap:    map[string]*ir.Workflow{"/x/a.dip": {}},
+	}
+	if _, err := collectAllAssets(ctx, stWf, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("workflow loop: err = %v, want context.Canceled", err)
+	}
+	stInc := &packWalkState{
+		entryAbs: "/x/a.dip",
+		rootDir:  "/x",
+		visited:  map[string]struct{}{},
+		trackWfs: true,
+		wfMap:    map[string]*ir.Workflow{},
+	}
+	if _, err := collectAllAssets(ctx, stInc, []string{"lib"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("include loop: err = %v, want context.Canceled", err)
 	}
 }
 

--- a/dipx/pack_noinline_test.go
+++ b/dipx/pack_noinline_test.go
@@ -498,12 +498,9 @@ func TestPack_NoInlineExtractRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read extracted %s: %v", rel, err)
 		}
-		if rel == "dev_loop.dip" {
-			if !strings.Contains(string(got), "command_file:") {
-				t.Errorf("extracted entry lost command_file: directive")
-			}
-			continue // .dip is reformatted; assets are byte-identical
-		}
+		// No-inline pack ships raw .dip bytes (dipx never reformats — it can't
+		// import the formatter), so every file, including the entry .dip, must
+		// extract byte-identical to source under workflows/<rel>.
 		if string(got) != want {
 			t.Errorf("extracted %s not byte-identical:\n got %q\nwant %q", rel, got, want)
 		}

--- a/dipx/pack_noinline_test.go
+++ b/dipx/pack_noinline_test.go
@@ -1,0 +1,375 @@
+package dipx
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// dipWithCommandFile is a minimal workflow referencing a script via
+// command_file:, used across the no-inline pack tests.
+const dipWithCommandFile = `workflow A
+  goal: "no-inline test"
+  start: Run
+  exit: Done
+
+  tool Run
+    timeout: 30s
+    command_file: scripts/run.sh
+
+  agent Done
+    prompt:
+      Done.
+
+  edges
+    Run -> Done
+`
+
+// writeTree writes files (path->contents) under dir, creating parent dirs.
+func writeTree(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for rel, body := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// packBytes packs entryPath with opts and returns the raw bundle bytes.
+func packBytes(t *testing.T, entryPath string, opts PackOptions) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if _, err := Pack(context.Background(), entryPath, &buf, opts); err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// manifestPaths returns the set of files[] paths in a packed bundle.
+func manifestPaths(m Manifest) map[string]struct{} {
+	out := make(map[string]struct{}, len(m.Files))
+	for _, e := range m.Files {
+		out[e.Path] = struct{}{}
+	}
+	return out
+}
+
+// openBundle opens raw bundle bytes via the internal reader path.
+func openBundle(t *testing.T, raw []byte) *Bundle {
+	t.Helper()
+	b, err := openFromReader(context.Background(), bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("openFromReader: %v", err)
+	}
+	return b
+}
+
+func TestPack_NoInlineRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip":          dipWithCommandFile,
+		"scripts/run.sh": "#!/bin/sh\necho hello-from-script\n",
+	})
+	raw := packBytes(t, filepath.Join(dir, "a.dip"), PackOptions{NoInline: true})
+
+	b := openBundle(t, raw)
+	m := b.Manifest()
+	if m.FormatVersion != 2 {
+		t.Fatalf("FormatVersion = %d, want 2", m.FormatVersion)
+	}
+	paths := manifestPaths(m)
+	if _, ok := paths["workflows/a.dip"]; !ok {
+		t.Errorf("manifest missing workflows/a.dip; files=%v", m.Files)
+	}
+	if _, ok := paths["workflows/scripts/run.sh"]; !ok {
+		t.Errorf("manifest missing workflows/scripts/run.sh; files=%v", m.Files)
+	}
+	if len(m.Files) != 2 {
+		t.Errorf("len(Files) = %d, want 2: %v", len(m.Files), m.Files)
+	}
+	// The bundled .dip must RETAIN the command_file: directive (not inlined).
+	dipText := string(b.fileBytes["workflows/a.dip"])
+	if !strings.Contains(dipText, "command_file:") {
+		t.Errorf("bundled .dip lost command_file: directive:\n%s", dipText)
+	}
+	if strings.Contains(dipText, "hello-from-script") {
+		t.Errorf("bundled .dip unexpectedly inlined script body:\n%s", dipText)
+	}
+	// Asset bytes are present and hash-verified (open succeeded).
+	if got := string(b.fileBytes["workflows/scripts/run.sh"]); !strings.Contains(got, "hello-from-script") {
+		t.Errorf("asset bytes wrong: %q", got)
+	}
+}
+
+func TestPack_V1DefaultUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{"a.dip": minimalStandaloneDip()})
+	entry := filepath.Join(dir, "a.dip")
+	first := packBytes(t, entry, PackOptions{})
+	second := packBytes(t, entry, PackOptions{})
+	if !bytes.Equal(first, second) {
+		t.Fatal("zero-opts Pack is not byte-deterministic")
+	}
+	b := openBundle(t, first)
+	if b.Manifest().FormatVersion != 1 {
+		t.Fatalf("FormatVersion = %d, want 1", b.Manifest().FormatVersion)
+	}
+}
+
+func TestPack_NoInlinePromptFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip": `workflow A
+  goal: "prompt-file no-inline"
+  start: R
+  exit: R
+
+  agent R
+    model: claude-sonnet-4-6
+    system_prompt_file: prompts/persona.md
+    prompt_file: prompts/task.md
+`,
+		"prompts/persona.md": "PERSONA\n",
+		"prompts/task.md":    "TASK\n",
+	})
+	raw := packBytes(t, filepath.Join(dir, "a.dip"), PackOptions{NoInline: true})
+	m := openBundle(t, raw).Manifest()
+	paths := manifestPaths(m)
+	for _, want := range []string{"workflows/prompts/persona.md", "workflows/prompts/task.md"} {
+		if _, ok := paths[want]; !ok {
+			t.Errorf("manifest missing %s; files=%v", want, m.Files)
+		}
+	}
+}
+
+func TestPack_IncludeDir(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip":                 minimalStandaloneDip(),
+		"scripts/lib/boot.sh":   "boot\n",
+		"scripts/lib/helper.sh": "help\n",
+	})
+	raw := packBytes(t, filepath.Join(dir, "a.dip"), PackOptions{NoInline: true, Include: []string{"scripts/lib"}})
+	paths := manifestPaths(openBundle(t, raw).Manifest())
+	for _, want := range []string{"workflows/scripts/lib/boot.sh", "workflows/scripts/lib/helper.sh"} {
+		if _, ok := paths[want]; !ok {
+			t.Errorf("manifest missing %s; paths=%v", want, paths)
+		}
+	}
+}
+
+func TestPack_IncludeFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip":        minimalStandaloneDip(),
+		"scripts/x.sh": "x\n",
+	})
+	raw := packBytes(t, filepath.Join(dir, "a.dip"), PackOptions{NoInline: true, Include: []string{"scripts/x.sh"}})
+	m := openBundle(t, raw).Manifest()
+	if m.FormatVersion != 2 {
+		t.Fatalf("FormatVersion = %d, want 2", m.FormatVersion)
+	}
+	if len(m.Files) != 2 {
+		t.Fatalf("len(Files) = %d, want 2: %v", len(m.Files), m.Files)
+	}
+}
+
+func TestPack_Dedup(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip":          dipWithCommandFile,
+		"scripts/run.sh": "run\n",
+	})
+	// scripts/run.sh referenced both by command_file: and --include.
+	raw := packBytes(t, filepath.Join(dir, "a.dip"), PackOptions{NoInline: true, Include: []string{"scripts/run.sh"}})
+	m := openBundle(t, raw).Manifest()
+	count := 0
+	for _, e := range m.Files {
+		if e.Path == "workflows/scripts/run.sh" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("scripts/run.sh appears %d times, want 1: %v", count, m.Files)
+	}
+}
+
+func TestPack_NoInlineReproducible(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip":          dipWithCommandFile,
+		"scripts/run.sh": "run\n",
+		"lib/b.sh":       "b\n",
+		"lib/a.sh":       "a\n",
+	})
+	entry := filepath.Join(dir, "a.dip")
+	opts := PackOptions{NoInline: true, Include: []string{"lib"}}
+	if !bytes.Equal(packBytes(t, entry, opts), packBytes(t, entry, opts)) {
+		t.Fatal("no-inline Pack is not byte-deterministic")
+	}
+}
+
+func TestPack_IncludeDipFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip":      minimalStandaloneDip(),
+		"helper.dip": minimalStandaloneDip(),
+	})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{NoInline: true, Include: []string{"helper.dip"}})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+func TestPack_IncludeEscapeRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{"sub/a.dip": minimalStandaloneDip()})
+	writeTree(t, dir, map[string]string{"outside.sh": "x\n"})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "sub", "a.dip"), &buf, PackOptions{NoInline: true, Include: []string{"../outside.sh"}})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+func TestPack_IncludeEmptyRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{"a.dip": minimalStandaloneDip()})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{NoInline: true, Include: []string{""}})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+func TestPack_IncludeSymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip":       minimalStandaloneDip(),
+		"real/tgt.sh": "x\n",
+	})
+	link := filepath.Join(dir, "link.sh")
+	if err := os.Symlink(filepath.Join(dir, "real", "tgt.sh"), link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{NoInline: true, Include: []string{"link.sh"}})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+func TestPack_IncludeDirWithDipRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip":            minimalStandaloneDip(),
+		"tools/helper.dip": minimalStandaloneDip(),
+	})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{NoInline: true, Include: []string{"tools"}})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+func TestCheckPackCaps_FileCount(t *testing.T) {
+	all := make([]packedFile, maxFiles+1)
+	if err := checkPackCaps(all); !errors.Is(err, ErrCapExceeded) {
+		t.Fatalf("err = %v, want ErrCapExceeded", err)
+	}
+}
+
+func TestCheckPackCaps_TotalBytes(t *testing.T) {
+	big := make([]byte, maxPerFileBytes)
+	all := make([]packedFile, 0, 3)
+	for i := 0; i < 3; i++ { // 3 * 50MB = 150MB > 100MB total cap
+		all = append(all, packedFile{bytes: big})
+	}
+	if err := checkPackCaps(all); !errors.Is(err, ErrCapExceeded) {
+		t.Fatalf("err = %v, want ErrCapExceeded", err)
+	}
+}
+
+func TestBundleAssetPathFor(t *testing.T) {
+	root := t.TempDir()
+	got, err := bundlePathFor(filepath.Join(root, "scripts", "run.sh"), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "workflows/scripts/run.sh" {
+		t.Fatalf("got %q, want workflows/scripts/run.sh", got)
+	}
+}
+
+func TestEnsureAssetUnderRoot_EscapeRejected(t *testing.T) {
+	root := t.TempDir()
+	if err := ensureAssetUnderRoot(filepath.Dir(root)+"/evil", root); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+func TestParseAllWorkflows_SkipsAssets(t *testing.T) {
+	verified := map[string]verifiedBytes{
+		"workflows/entry.dip":      newVerifiedBytes([]byte(minimalStandaloneDip())),
+		"workflows/scripts/run.sh": newVerifiedBytes([]byte("#!/bin/sh\nnot a workflow\n")),
+	}
+	out, err := parseAllWorkflows(verified, "workflows/entry.dip")
+	if err != nil {
+		t.Fatalf("parseAllWorkflows: %v", err)
+	}
+	if _, ok := out["workflows/entry.dip"]; !ok {
+		t.Error("missing workflow entry")
+	}
+	if _, ok := out["workflows/scripts/run.sh"]; ok {
+		t.Error("asset was parsed as a workflow")
+	}
+}
+
+// TestPack_NoInlineExtractRoundTrip is the structural acceptance test: a source
+// tree whose command_file: script sources a sibling via --include, packed with
+// --no-inline, extracted, must be byte-identical under extracted/workflows/<rel>
+// with directives preserved.
+func TestPack_NoInlineExtractRoundTrip(t *testing.T) {
+	src := t.TempDir()
+	tree := map[string]string{
+		"dev_loop.dip":             dipWithCommandFile,
+		"scripts/run.sh":           "#!/bin/sh\n. \"${graph.workflow_dir}/scripts/lib/bootstrap.sh\"\n",
+		"scripts/lib/bootstrap.sh": "#!/bin/sh\necho bootstrapped\n",
+	}
+	writeTree(t, src, tree)
+	// Point command_file: at scripts/run.sh (dipWithCommandFile already does).
+	raw := packBytes(t, filepath.Join(src, "dev_loop.dip"), PackOptions{NoInline: true, Include: []string{"scripts/lib"}})
+
+	bundleFile := filepath.Join(t.TempDir(), "out.dipx")
+	if err := os.WriteFile(bundleFile, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(t.TempDir(), "extracted")
+	if err := Extract(context.Background(), bundleFile, dest, false); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	for rel, want := range tree {
+		got, err := os.ReadFile(filepath.Join(dest, "workflows", filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read extracted %s: %v", rel, err)
+		}
+		if rel == "dev_loop.dip" {
+			if !strings.Contains(string(got), "command_file:") {
+				t.Errorf("extracted entry lost command_file: directive")
+			}
+			continue // .dip is reformatted; assets are byte-identical
+		}
+		if string(got) != want {
+			t.Errorf("extracted %s not byte-identical:\n got %q\nwant %q", rel, got, want)
+		}
+	}
+}

--- a/dipx/pack_noinline_test.go
+++ b/dipx/pack_noinline_test.go
@@ -301,6 +301,122 @@ func TestPack_IncludeDirWithDipRejected(t *testing.T) {
 	}
 }
 
+// TestPack_DirectiveAbsoluteRejected: an absolute file-directive path is
+// rejected, matching parser.ResolveFileDirectives (which never accepts
+// absolute paths). Without this, --no-inline would diverge from source/inline.
+func TestPack_DirectiveAbsoluteRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip": strings.Replace(dipWithCommandFile,
+			"command_file: scripts/run.sh",
+			"command_file: /etc/run.sh", 1),
+	})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{NoInline: true})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+// TestPack_SubgraphDirectiveEscapeRejected: a subgraph whose command_file:
+// escapes its OWN directory (../run.sh) is rejected even though the target
+// stays under the entry root. parser.ResolveFileDirectives rejects it relative
+// to the declaring .dip's dir, so --no-inline must too — otherwise it ships a
+// file the source run rejects and preserves a directive later resolution fails.
+func TestPack_SubgraphDirectiveEscapeRejected(t *testing.T) {
+	dir := t.TempDir()
+	parent := `workflow P
+  goal: x
+  start: S
+  exit: E
+  subgraph S
+    ref: sub/child.dip
+  agent E
+    prompt: end
+  edges
+    S -> E
+`
+	child := `workflow C
+  goal: y
+  start: Run
+  exit: Done
+  tool Run
+    timeout: 30s
+    command_file: ../run.sh
+  agent Done
+    prompt: done
+  edges
+    Run -> Done
+`
+	writeTree(t, dir, map[string]string{
+		"parent.dip":    parent,
+		"sub/child.dip": child,
+		"run.sh":        "x\n", // exists, under entry root, but escapes sub/
+	})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "parent.dip"), &buf, PackOptions{NoInline: true})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+// TestPack_IncludeReachableDipRejected: --include of a .dip that is ALSO a
+// reachable subgraph must still error, not silently succeed via the visited
+// dedup fast-path (the .dip check must precede dedup).
+func TestPack_IncludeReachableDipRejected(t *testing.T) {
+	dir := t.TempDir()
+	parent := `workflow P
+  goal: x
+  start: S
+  exit: E
+  subgraph S
+    ref: child.dip
+  agent E
+    prompt: end
+  edges
+    S -> E
+`
+	writeTree(t, dir, map[string]string{
+		"parent.dip": parent,
+		"child.dip":  minimalStandaloneDip(),
+	})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "parent.dip"), &buf, PackOptions{NoInline: true, Include: []string{"child.dip"}})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+// TestPack_IncludeEmptyDirRejected: --include of an existing but empty
+// directory is an error (catches typos rather than silently shipping nothing).
+func TestPack_IncludeEmptyDirRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{"a.dip": minimalStandaloneDip()})
+	if err := os.MkdirAll(filepath.Join(dir, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{NoInline: true, Include: []string{"empty"}})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+// TestPack_IncludeWithoutNoInlineErrors: the dipx.Pack library API rejects
+// Include when NoInline is false, rather than silently dropping the assets.
+func TestPack_IncludeWithoutNoInlineErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip": minimalStandaloneDip(),
+		"loose": "x\n",
+	})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{Include: []string{"loose"}})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
 func TestCheckPackCaps_FileCount(t *testing.T) {
 	all := make([]packedFile, maxFiles+1)
 	if err := checkPackCaps(all); !errors.Is(err, ErrCapExceeded) {

--- a/dipx/pack_noinline_test.go
+++ b/dipx/pack_noinline_test.go
@@ -230,6 +230,26 @@ func TestPack_IncludeDipFileRejected(t *testing.T) {
 	}
 }
 
+// TestPack_DirectiveDipTargetRejected guards the discriminator invariant: a
+// file-directive (here command_file:) whose target ends in .dip must be
+// rejected at pack time, not shipped as an asset. Shipping it would produce a
+// bundle whose Open re-parses the asset as a workflow (spec: assets may not end
+// in .dip).
+func TestPack_DirectiveDipTargetRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"a.dip": strings.Replace(dipWithCommandFile,
+			"command_file: scripts/run.sh",
+			"command_file: scripts/helper.dip", 1),
+		"scripts/helper.dip": "#!/bin/sh\necho hi\n",
+	})
+	var buf bytes.Buffer
+	_, err := Pack(context.Background(), filepath.Join(dir, "a.dip"), &buf, PackOptions{NoInline: true})
+	if !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
 func TestPack_IncludeEscapeRejected(t *testing.T) {
 	dir := t.TempDir()
 	writeTree(t, dir, map[string]string{"sub/a.dip": minimalStandaloneDip()})

--- a/dipx/resolve.go
+++ b/dipx/resolve.go
@@ -14,16 +14,19 @@ const (
 	maxPathComponents = 16
 )
 
-// Canonicalize returns the canonical form of a bundle-relative path or an
-// error if the path violates any rule in the spec's "Path canonicalization"
-// section. All call sites in dipx and its consumers MUST use this function;
-// no other code in dipx is permitted to call path.Clean / filepath.Clean.
+// Canonicalize applies the version-independent SAFETY rules (NFC, reject
+// absolute paths, .. segments, backslash, NUL/control chars, component-count
+// cap, Windows-reserved names) and returns the canonical form of a
+// bundle-relative path or an error if any safety rule is violated. It does
+// NOT enforce the workflows/ prefix or the .dip suffix — those are
+// version-aware POLICY; call checkPathPolicy for them. All call sites in dipx
+// and its consumers MUST use this function; no other code in dipx is permitted
+// to call path.Clean / filepath.Clean.
 func Canonicalize(p string) (string, error) {
 	checks := []func(string) error{
 		checkPathBasics,
 		checkPathStructure,
 		checkPathComponents,
-		checkPathSuffix,
 		checkPathIdempotent,
 	}
 	for _, fn := range checks {
@@ -90,12 +93,26 @@ func checkPathComponents(p string) error {
 	return nil
 }
 
-// checkPathSuffix enforces workflows/ prefix and .dip suffix.
-func checkPathSuffix(p string) error {
+// isReservedBundleName reports whether p collides with a root-level reserved
+// bundle entry. Because assets live under workflows/ they can never collide,
+// but checkPathPolicy asserts it anyway as defense in depth (spec § Security 4).
+func isReservedBundleName(p string) bool {
+	return p == "manifest.json" || p == "manifest.sig"
+}
+
+// checkPathPolicy enforces the version-aware path POLICY that Canonicalize no
+// longer applies. Both versions require the workflows/ prefix and reject the
+// reserved bundle names; format_version 1 additionally requires the .dip
+// suffix (every listed path is a workflow). format_version 2 allows any
+// canonical path under workflows/ that does not end in .dip to be an asset.
+func checkPathPolicy(p string, version int) error {
+	if isReservedBundleName(p) {
+		return newError(ErrPathUnsafe, p, "reserved bundle name", nil)
+	}
 	if !strings.HasPrefix(p, "workflows/") {
 		return newError(ErrPathUnsafe, p, "must start with workflows/", nil)
 	}
-	if !strings.HasSuffix(p, ".dip") {
+	if version == 1 && !strings.HasSuffix(p, ".dip") {
 		return newError(ErrPathUnsafe, p, "must end with .dip", nil)
 	}
 	return nil
@@ -292,8 +309,15 @@ func resolveLexically(refPath, relativeTo string) (string, error) {
 	}
 	joined := path.Join(dir, refPath)
 	cleaned := path.Clean(joined)
-	// Run through Canonicalize for safety checks. Note: refPath may have
-	// originally contained "..", which path.Clean resolves; the resulting
-	// cleaned path must itself be canonical.
-	return Canonicalize(cleaned)
+	// Run through Canonicalize for safety checks, then apply v1 path policy:
+	// subgraph refs are always workflows (workflows/ prefix + .dip suffix),
+	// which holds for both format_version 1 and 2 bundles. Note: refPath may
+	// have originally contained "..", which path.Clean resolves; the resulting
+	// cleaned path must itself be canonical. The future CI grep (Task 26) must
+	// allowlist both the Canonicalize and checkPathPolicy calls here.
+	canon, err := Canonicalize(cleaned)
+	if err != nil {
+		return "", err
+	}
+	return canon, checkPathPolicy(canon, 1)
 }

--- a/dipx/resolve.go
+++ b/dipx/resolve.go
@@ -20,9 +20,11 @@ const (
 // bundle-relative path or an error if any safety rule is violated. It does
 // NOT enforce the workflows/ prefix or the .dip suffix — those are
 // version-aware POLICY, enforced separately inside dipx by checkPathPolicy;
-// external callers of Canonicalize get safety canonicalization only. Within
-// dipx, all bundle-path handling MUST go through this function; no other code
-// in dipx is permitted to call path.Clean / filepath.Clean.
+// external callers of Canonicalize get safety canonicalization only. Every
+// bundle-relative path admitted to a manifest or bundle MUST pass through this
+// function to count as validated. Other path.Clean / filepath.Clean uses in
+// dipx only prepare or lexically join filesystem paths (e.g. resolveLexically,
+// the pack/include helpers) and are never a substitute for this validation.
 func Canonicalize(p string) (string, error) {
 	checks := []func(string) error{
 		checkPathBasics,

--- a/dipx/resolve.go
+++ b/dipx/resolve.go
@@ -19,9 +19,10 @@ const (
 // cap, Windows-reserved names) and returns the canonical form of a
 // bundle-relative path or an error if any safety rule is violated. It does
 // NOT enforce the workflows/ prefix or the .dip suffix — those are
-// version-aware POLICY; call checkPathPolicy for them. All call sites in dipx
-// and its consumers MUST use this function; no other code in dipx is permitted
-// to call path.Clean / filepath.Clean.
+// version-aware POLICY, enforced separately inside dipx by checkPathPolicy;
+// external callers of Canonicalize get safety canonicalization only. Within
+// dipx, all bundle-path handling MUST go through this function; no other code
+// in dipx is permitted to call path.Clean / filepath.Clean.
 func Canonicalize(p string) (string, error) {
 	checks := []func(string) error{
 		checkPathBasics,

--- a/dipx/resolve_test.go
+++ b/dipx/resolve_test.go
@@ -45,12 +45,8 @@ func TestCanonicalize_Rejects(t *testing.T) {
 		{"win-reserved-con-multi-ext", "workflows/CON.tar.dip"},
 		{"win-reserved-com1-multi-ext", "workflows/COM1.foo.dip"},
 		{"win-reserved-aux-with-prefix", "workflows/AUX.something.dip"},
-		{"missing-extension", "workflows/foo"},
-		{"wrong-extension", "workflows/foo.txt"},
-		{"uppercase-extension", "workflows/foo.DIP"},
 		{"too-many-components", "workflows/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p.dip"}, // 17
 		{"too-long", "workflows/" + strings.Repeat("a", 1020) + ".dip"},
-		{"not-under-workflows", "other/foo.dip"},
 		{"empty", ""},
 	}
 	for _, c := range cases {
@@ -92,6 +88,79 @@ func TestCanonicalize_RejectsNFD(t *testing.T) {
 	}
 	if !errors.Is(err, ErrPathUnsafe) {
 		t.Fatalf("err = %v, want ErrPathUnsafe", err)
+	}
+}
+
+// TestCanonicalize_AcceptsNonDIPSuffix proves the safety-only contract: after
+// the policy split, Canonicalize accepts a non-.dip path under workflows/.
+func TestCanonicalize_AcceptsNonDIPSuffix(t *testing.T) {
+	if _, err := Canonicalize("workflows/boot.sh"); err != nil {
+		t.Fatalf("Canonicalize(workflows/boot.sh) = %v, want nil", err)
+	}
+}
+
+// TestCanonicalize_AcceptsNonWorkflowsPrefix proves the workflows/ prefix is
+// policy, not safety: Canonicalize no longer requires it.
+func TestCanonicalize_AcceptsNonWorkflowsPrefix(t *testing.T) {
+	if _, err := Canonicalize("other/foo.dip"); err != nil {
+		t.Fatalf("Canonicalize(other/foo.dip) = %v, want nil", err)
+	}
+}
+
+func TestCheckPathPolicy_V1_Valid(t *testing.T) {
+	if err := checkPathPolicy("workflows/foo.dip", 1); err != nil {
+		t.Fatalf("checkPathPolicy(workflows/foo.dip, 1) = %v, want nil", err)
+	}
+}
+
+func TestCheckPathPolicy_V1_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"missing-extension", "workflows/foo"},
+		{"wrong-extension", "workflows/foo.txt"},
+		{"uppercase-extension", "workflows/foo.DIP"},
+		{"not-under-workflows", "other/foo.dip"},
+		{"reserved-manifest-json", "manifest.json"},
+		{"reserved-manifest-sig", "manifest.sig"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := checkPathPolicy(c.in, 1)
+			if !errors.Is(err, ErrPathUnsafe) {
+				t.Fatalf("checkPathPolicy(%q, 1) = %v, want ErrPathUnsafe", c.in, err)
+			}
+		})
+	}
+}
+
+func TestCheckPathPolicy_V2_Valid(t *testing.T) {
+	cases := []string{
+		"workflows/foo.dip",
+		"workflows/scripts/boot.sh",
+		"workflows/scripts/lib/bootstrap.sh",
+	}
+	for _, in := range cases {
+		if err := checkPathPolicy(in, 2); err != nil {
+			t.Errorf("checkPathPolicy(%q, 2) = %v, want nil", in, err)
+		}
+	}
+}
+
+func TestCheckPathPolicy_V2_RejectsNoWorkflowsPrefix(t *testing.T) {
+	if err := checkPathPolicy("scripts/boot.sh", 2); !errors.Is(err, ErrPathUnsafe) {
+		t.Fatalf("checkPathPolicy(scripts/boot.sh, 2) = %v, want ErrPathUnsafe", err)
+	}
+}
+
+func TestCheckPathPolicy_RejectsReservedNames(t *testing.T) {
+	for _, version := range []int{1, 2} {
+		for _, in := range []string{"manifest.json", "manifest.sig"} {
+			if err := checkPathPolicy(in, version); !errors.Is(err, ErrPathUnsafe) {
+				t.Errorf("checkPathPolicy(%q, %d) = %v, want ErrPathUnsafe", in, version, err)
+			}
+		}
 	}
 }
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -157,7 +157,9 @@ child, err := src.Workflow("phases/review.dip", entry.SourceLocation.File)
 - `Manifest()` — the parsed manifest (format version, entry path, files[])
 - `Identity()` — 32-byte SHA-256 over the manifest bytes-as-stored (a stable content-addressed id)
 
-`dipx.Pack(ctx, entry, w)` writes a deterministic ZIP from a `.dip` entry; `dipx.Extract(ctx, src, dest, allowOverwrite)` atomically unpacks one. Both refuse symlinks anywhere in the source tree (Pack) or staging tree (Extract) and enforce the spec's per-file (50 MB) and total-bundle (100 MB) caps.
+`dipx.Pack(ctx, entry, w, opts)` writes a deterministic ZIP from a `.dip` entry; `dipx.Extract(ctx, src, dest, allowOverwrite)` atomically unpacks one. Both refuse symlinks anywhere in the source tree (Pack) or staging tree (Extract) and enforce the spec's per-file (50 MB) and total-bundle (100 MB) caps.
+
+`PackOptions{}` (the zero value) is the default: every `command_file:` / `prompt_file:` / `system_prompt_file:` body is inlined into the bundled `.dip`, producing a self-contained `format_version 1` bundle. `PackOptions{NoInline: true, Include: []string{...}}` instead ships those directive targets — plus any extra sibling files or directories listed in `Include` (relative to the entry's directory) — as separate entries under `workflows/`, keeps the `*_file:` directives, and produces `format_version 2`. `Include` requires `NoInline`.
 
 **Note:** `dipx` does not run `validate`/`lint`/`cost` on the bundled workflow — call `validator.Validate(src.Entry())` from your code if needed. `dippin pack` does this at the CLI layer because `dipx` is bound by the loader-tier rule and cannot import `validator`.
 

--- a/docs/superpowers/specs/2026-07-01-issue-73-file-shipping-pack-design.md
+++ b/docs/superpowers/specs/2026-07-01-issue-73-file-shipping-pack-design.md
@@ -1,0 +1,307 @@
+# Issue #73 — File-shipping pack mode (`--no-inline` / `--include`)
+
+**Date:** 2026-07-01
+**Status:** Design approved (via multi-reviewer squad debate)
+**Issue:** dippin-lang#73 (paired with tracker#430; motivating case pipelines#49)
+
+## Problem
+
+`dippin pack` today inlines every `command_file:` / `prompt_file:` /
+`system_prompt_file:` body into the packed `.dip` text (see
+`cmd/dippin/pack_shadow.go`). The resulting `.dipx` contains only inline
+`command:` / `prompt:` / `system_prompt:` blocks — no external files.
+
+That breaks any script that sources a sibling helper by relative path, e.g.
+
+```sh
+. "${graph.workflow_dir}/scripts/lib/bootstrap.sh"
+```
+
+Under a packed run the file isn't on disk, so under `set -eu` the run aborts.
+The concrete motivation (pipelines#49) is collapsing 22 byte-identical inlined
+bootstrap preambles into one *sourced* helper — impossible today without
+breaking the packed distribution path.
+
+Two distinct categories of files must reach the bundle:
+
+- **(a) Directive-referenced files** — the targets of `command_file:` /
+  `prompt_file:` / `system_prompt_file:`. dippin discovers these statically.
+- **(b) Sibling / asset files** — like `bootstrap.sh`, referenced only from
+  *inside shell bodies* via runtime interpolation. dippin's parser **cannot**
+  discover these (it doesn't parse shell). They must be declared explicitly.
+
+## Goal / acceptance (dippin half)
+
+dippin's deliverable is **structural and tracker-free**: for every file in the
+entry's reachable closure (`.dip` workflows + shipped assets),
+
+```
+extract(pack(S, --no-inline --include …))/workflows/<rel>  ==  S/<rel>   (byte-for-byte)
+```
+
+with the entry `.dip` present, directives **preserved (not inlined)**, and each
+declared asset present at its mirrored path. This is verifiable in dippin's own
+test suite with no shell and no tracker.
+
+The end-to-end shell-parity check (`tracker run dev_loop.dip` vs
+`dippin pack … && tracker out.dipx` behaving identically under `set -eu`) is
+**tracker#430's** acceptance test, not dippin's. dippin must never gate its own
+"done" on the tracker runtime (project rule: never-gate-dippin-on-tracker).
+
+## Non-goals
+
+- Glob patterns in `--include` (e.g. `scripts/**`). Deferred; directory
+  includes cover the motivating case. Go's stdlib `filepath.Glob` doesn't even
+  implement recursive `**` and follows symlinks — not worth the surface now.
+- Preserving file mode / executable bit (assets are *sourced*, not executed;
+  see Security).
+- A `Kind` discriminator field in the manifest (the `.dip` suffix already
+  serves this role — see Format).
+- Auto-detecting shell `source`/`.` references (a lint warning for the literal
+  `${graph.workflow_dir}/<path>` case is a possible later enhancement, out of
+  scope here).
+- tracker#430 (seeding `graph.workflow_dir` in packed runs) — tracked
+  separately; dippin ships nothing gated on it.
+
+## CLI surface
+
+```
+dippin pack --no-inline [--include <path> ...] -o out.dipx entry.dip
+```
+
+- **`--no-inline`** — mode switch. Instead of inlining directive bodies, ship
+  the directive-referenced files as bundle entries and keep the `*_file:`
+  directives in the `.dip` text. Default (flag absent) = today's inline
+  behavior, byte-for-byte unchanged.
+- **`--include <path>`** (repeatable) — declare a sibling asset that dippin
+  can't discover statically. `<path>` is a **file or a directory**, resolved
+  relative to the entry `.dip`'s directory:
+  - a **file** ships that one file;
+  - a **directory** ships its entire subtree (recursive), via a safe
+    `WalkDir` that refuses to descend symlinked directories.
+- **`--include` requires `--no-inline`** — using `--include` without
+  `--no-inline` is a usage error (an incoherent hybrid: inlined bodies plus
+  loose assets).
+- A `--include` path that **doesn't exist / is empty / escapes the root /
+  is (or traverses) a symlink** is an error (fail fast; catches typos and
+  path-safety violations).
+- A `--include` that would ship a **`.dip` file** (directly, or found inside an
+  included directory) is an error: `.dip` files reach the bundle as workflows
+  via subgraph refs, not as opaque assets (assets may not end in `.dip`).
+
+## Bundle format v2
+
+Only `--no-inline` produces `format_version: 2`. Inline mode still emits
+`format_version: 1`; existing bundles and readers are untouched.
+
+### Layout — keep the `workflows/` prefix
+
+Assets ship under `workflows/` as **siblings of the `.dip` that references
+them**, reusing the existing `bundlePathFor` mapping (`"workflows/" + rel`,
+`dipx/helpers.go:441-448`) unchanged.
+
+```
+out.dipx (format_version: 2)
+  manifest.json
+  workflows/dev_loop.dip              # workflow (entry)
+  workflows/sub/child.dip             # workflow
+  workflows/scripts/dev_loop.sh       # asset (command_file target)
+  workflows/scripts/lib/bootstrap.sh  # asset (via --include scripts/lib/)
+```
+
+**Why keep `workflows/` (rejected mirror-root):** `command_file:` and shell
+`${graph.workflow_dir}/…` paths are all *relative*, so the absolute prefix is
+invisible to resolution — a packed run resolves identically whether or not the
+prefix is present, as long as the tree structure is mirrored. tracker#430 seeds
+`graph.workflow_dir = <extract>/workflows/` (a one-line `filepath.Join`).
+Keeping the prefix:
+
+- leaves the escape-critical `Canonicalize` / `resolveLexically` path and
+  ~162 existing test expectations untouched;
+- **structurally prevents** an asset named `manifest.json` / `manifest.sig`
+  from colliding with the reserved root entries (mirror-root would have needed
+  an explicit collision guard).
+
+### Discriminator — the `.dip` suffix, no new field
+
+No `Kind` field is added to `ManifestEntry` (avoids the manifest-`Identity`
+determinism risk of a new struct field).
+
+- Manifest entries **ending in `.dip`** are workflows: parsed and cycle-checked
+  by `Open` exactly as today (preserves the "cycle-check every listed
+  workflow, even unreachable ones" hardening in `dipx/helpers.go:107-133`).
+- Entries **not ending in `.dip`** are assets: hash-verified and shipped
+  opaque, never parsed.
+- **An asset path may not end in `.dip`** (enforced at pack time; removes all
+  ambiguity).
+
+### Path validation — version-aware policy
+
+`Canonicalize` (`dipx/resolve.go:21`) currently bundles path *safety* (NFC,
+reject `..` / absolute / `//` / backslash / NUL / control chars / component
+caps / Windows-reserved) with path *policy* (`checkPathSuffix`: require
+`workflows/` prefix **and** `.dip` suffix, `resolve.go:93-102`).
+
+Refactor: pull the suffix/policy check out of `Canonicalize` into a
+version-aware `checkPathPolicy(path, version)`:
+
+- **v1:** every path must be `workflows/…​.dip` (unchanged).
+- **v2:** every path must be under `workflows/`; workflow entries end in
+  `.dip`; asset entries are any canonical relative path under `workflows/`
+  that does **not** end in `.dip`.
+
+All the version-independent safety checks stay in `Canonicalize` and apply to
+both. `SupportedFormatVersions()` → `{1, 2}` (`dipx/manifest.go:400`).
+
+## Pack pipeline changes
+
+### cmd layer (`cmd/dippin/cmd_pack.go`)
+
+- `parsePackArgs` gains `--no-inline` (bool) and repeatable `--include`
+  (`flag.Var` collecting a `[]string`). Validate `--include` ⇒ `--no-inline`.
+- `runPack`: in `--no-inline` mode, **skip** `prepShadowSourceTree` entirely
+  (no inlining) and pass the real entry to `dipx.Pack` with options. Structural
+  validation (`validateEntryPrePack`) runs first, unchanged.
+
+### dipx layer (`dipx/dipx.go`, `dipx/helpers.go`)
+
+Add options to the existing `Pack` (one walk, one entry point — preferred over
+a parallel `PackFiles` that would fork the shared skeleton):
+
+```go
+type PackOptions struct {
+    NoInline bool     // ship directive targets as asset entries, keep directives
+    Include  []string // extra sibling files/dirs (relative to entry dir) to ship
+}
+
+func Pack(ctx context.Context, entryPath string, w io.Writer, opts PackOptions) (Manifest, error)
+```
+
+`PackOptions{}` reproduces today's behavior. The three existing call sites
+(all in `cmd_pack.go`) pass the zero value except in `--no-inline` mode.
+
+`walkSourceTree` (or a helper it calls) additionally, when `NoInline`:
+
+1. **Directive assets** — for each walked workflow, collect its
+   `CommandFile` / `PromptFile` / `SystemPromptFile` targets, resolved relative
+   to *that* workflow's own directory. (dipx may import `parser`; it already
+   parses every workflow.)
+2. **Include assets** — resolve each `--include` path relative to the entry
+   dir; a directory is expanded via safe `WalkDir`.
+3. Each candidate is read via the existing `ReadNoFollowSymlinks`
+   (`dipx/helpers.go:396` — refuses symlink leaf/ancestor and non-regular
+   files) after an `ensureUnderRoot` containment check, hashed (SHA-256), and
+   recorded as an asset `packedFile` at `bundlePathFor(...)`.
+4. **Dedup** — a file referenced by two nodes, or referenced *and* `--include`d,
+   is packed once (reuse the `visited`-map pattern).
+
+Assets join the existing `all []packedFile` slice, which is already sorted by
+path in `buildManifestForPack` (`helpers.go:463`) → deterministic bytes. Add a
+v2 manifest builder emitting `FormatVersion: 2` (do **not** mutate the v1
+builder).
+
+### Open / Extract (`dipx/dipx.go`, `dipx/helpers.go`)
+
+`Open` must **skip non-`.dip` entries** in its parse / ref-listed / cycle-check
+passes (`parseAllWorkflows`, `verifyRefsListed`, `detectCyclesAll`) — otherwise
+`Extract` of a v2 bundle dies parsing `bootstrap.sh` as a workflow. Assets are
+still hash-verified. `Extract`/`writeOneFile` already mirror each entry's
+`bundlePath` onto disk (`dipx.go:342-351`) — no change needed there beyond the
+policy relaxation.
+
+**No new runtime *resolution* logic:** because the extracted tree mirrors the
+source tree under `workflows/`, `parser.ResolveFileDirectives` resolves
+`command_file:` against the extracted disk exactly as in a source run. The only
+new load-path behavior is the parse-skip above.
+
+## Security (MUST-FIX items from review)
+
+1. **Never trust traversal output.** Every `--include` candidate (glob/readdir/
+   WalkDir result) is re-validated: absolutize → `ensureUnderRoot` →
+   `ReadNoFollowSymlinks`. Prefer `WalkDir` (won't descend symlinked dirs) over
+   pattern matching. A naive `os.ReadFile(match)` that follows symlinks is
+   forbidden.
+2. **Pack-time caps.** Today the 100 MB-total and 10 000-file caps are enforced
+   only at Open. A directory include could sweep past them and emit a bundle
+   that fails its *own* Open. Mirror both caps at pack time (across `.dip` +
+   assets combined) so the producer gets a clean error instead of a
+   self-invalid bundle.
+3. **Keep `0644`; do not carry file mode / exec bit.** Assets are *sourced*
+   (read), not executed — no exec bit needed. Carrying mode would widen the
+   surface (setuid/setgid/sticky/world-writable). Matches the existing
+   hardcoded `0644` in `writeZipEntry`/`writeOneFile`.
+4. **Reserved-name safety is automatic.** Because assets live under
+   `workflows/`, they cannot collide with the root-level reserved
+   `manifest.json` / `manifest.sig`. (Assert it anyway for defense in depth.)
+5. **Threat model is net-equivalent for code execution** (the runtime already
+   executes inlined command bodies); the only net-new surface is files landing
+   on the consumer's disk at mirrored paths, fully contained by items 1 & 4 and
+   the existing zip-slip defenses. Opaque non-`.dip` assets bypass DIP lint but
+   stay within the existing producer/consumer trust boundary (opening a `.dipx`
+   was already "run their code").
+
+## Determinism guards
+
+- Sort included/asset candidates before hashing/writing (WalkDir order isn't
+  guaranteed) — they flow through the existing path-sort, so ensure they're
+  added before it runs.
+- Separate v1/v2 manifest builders; the v1 path stays byte-identical, so
+  existing v1 goldens and `Identity()` values are unaffected.
+- No `ManifestEntry` struct change → no per-file wire-order / `Identity` shift.
+
+## Complexity-cap plan (≤5 cyclomatic / ≤7 cognitive)
+
+Pre-plan helper extraction to avoid blowing the caps:
+
+- `collectDirectiveAssets(wf, srcDir, root) ([]packedFile, error)` — split out
+  of `readAndRecord`/`walkSourceTree` (mirror the per-config split already in
+  `pack_shadow.go`).
+- `resolveIncludePath(path, root) ([]packedFile, error)` — file-vs-dir +
+  WalkDir + containment + symlink-refuse + read/hash.
+- `checkPathPolicy(path, version)` — the version-aware suffix/prefix check
+  pulled out of `Canonicalize`.
+- Asset dedup via the existing `visited`-map pattern, not inline.
+
+## Testing
+
+**dipx unit:**
+- `Pack` with `PackOptions{NoInline:true}` round-trip: bundle carries asset
+  entries at `workflows/<rel>` paths; the `.dip` **retains** its `command_file:`
+  directive (proves no inlining); `Open` skips parsing assets; hashes verify.
+- `--include` of a directory ships the whole subtree; of a file ships one file;
+  dedup when a file is both directive-referenced and included.
+- Manifest v2 decode/`checkPathPolicy` accepts non-`.dip` under `workflows/`,
+  rejects asset paths ending in `.dip`, rejects escapes; v1 policy unchanged.
+- Pack-time cap enforcement (file-count + total-size) triggers a clean error.
+- Symlink/`..`/absolute `--include` rejected.
+
+**CLI:**
+- `--no-inline --include` produces a v2 bundle; default pack still yields
+  deterministic v1 bytes (regression guard).
+- `--include` without `--no-inline` is a usage error.
+- Missing/empty/escaping `--include` path errors.
+
+**Structural acceptance (tracker-free):** build a source tree with an entry
+`.dip` whose `command_file:` script sources a sibling via
+`${graph.workflow_dir}/scripts/lib/bootstrap.sh`; pack with
+`--no-inline --include scripts/lib/`; extract; assert every `.dip` and asset in
+the reachable closure is byte-identical to its source counterpart under
+`workflows/<rel>`, entry present, directive preserved.
+
+## Backward compatibility
+
+- Default (inline) pack is byte-for-byte unchanged and still `format_version 1`.
+- Existing v1 bundles open identically (v1 policy path untouched).
+- No `ManifestEntry` wire change → existing v1 `Identity()` / goldens stable.
+- An old dippin binary opening a v2 bundle fails closed loudly with
+  `ErrUnsupportedFormatVersion` (integrity exit 2) — the honest tripwire.
+
+## Out of scope / follow-ups
+
+- **tracker#430** — seed `graph.workflow_dir = <extract>/workflows/` in packed
+  runs. Separate repo/issue. dippin ships independently.
+- **`--include` glob patterns** — later PR if requested.
+- **Source-reference lint** — optional warning when a packed command body
+  literally contains `${graph.workflow_dir}/<relpath>` or `source`/`.` of a
+  relative literal not present in the bundle. Cheap, catches the exact footgun;
+  deferred to keep PR1 tight.

--- a/validator/lint_examples_test.go
+++ b/validator/lint_examples_test.go
@@ -76,7 +76,7 @@ func TestPackExamples(t *testing.T) {
 		path := path
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			var buf bytes.Buffer
-			if _, err := dipx.Pack(context.Background(), path, &buf); err != nil {
+			if _, err := dipx.Pack(context.Background(), path, &buf, dipx.PackOptions{}); err != nil {
 				t.Fatalf("Pack failed: %v", err)
 			}
 			bundlePath := filepath.Join(t.TempDir(), "bundle.dipx")


### PR DESCRIPTION
Closes #73. Paired with tracker#430 (seed `graph.workflow_dir` in packed runs) — dippin ships independently and is **not** gated on the tracker.

## Problem
`dippin pack` inlines every `command_file:` / `prompt_file:` / `system_prompt_file:` body, so a script that sources a sibling by relative path (`. "${graph.workflow_dir}/scripts/lib/bootstrap.sh"`) can't run in a packed bundle — the file isn't on disk. Motivating case: pipelines#49 (collapse 22 byte-identical inlined bootstrap preambles into one sourced helper).

## What this adds
Opt-in file-shipping pack mode:
```
dippin pack --no-inline [--include <file-or-dir> ...] -o out.dipx entry.dip
```
- `--no-inline` — ship directive-referenced files as bundle entries and **keep** the directives (instead of inlining), so `ResolveFileDirectives` resolves against the extracted tree exactly as in a source run. Emits `format_version: 2`.
- `--include <path>` (repeatable, requires `--no-inline`) — declare sibling assets dippin can't discover statically (referenced only from shell bodies). A directory ships its whole subtree via a safe `WalkDir`. An `--include` that resolves to a `.dip` errors.
- Default (inline) pack is **byte-for-byte unchanged** and still `format_version 1`.

## Layout — keep the `workflows/` prefix
Assets ship under `workflows/` as siblings of their referencing `.dip`. Relative paths make the prefix invisible to resolution, so a packed run resolves identically to a source run once tracker seeds `workflow_dir = <extract>/workflows/`. Discriminator is the `.dip` suffix (no new manifest field). `format_version 2` gates a version-aware `checkPathPolicy` that relaxes only the `.dip`-suffix rule for assets; all path-safety checks are unchanged.

## Design & review
Design approved via a multi-reviewer squad debate (spec: `docs/superpowers/specs/2026-07-01-issue-73-file-shipping-pack-design.md`). Implemented via a 4-lens adversarial review workflow; one high-severity finding (a `command_file:` target ending in `.dip` shipped as an asset → self-invalid bundle) was caught and fixed in `760fb56`.

Security MUST-FIXes verified (escapes constructed and rejected): every `--include`/`WalkDir` candidate re-validated via `ensureAssetUnderRoot` + `ReadNoFollowSymlinks` (symlink leaf/ancestor, `..`, absolute, case-fold all rejected); `WalkDir` won't descend symlinked dirs; assets write `0644` (no mode carried); reserved `manifest.json`/`manifest.sig` can't be assets; pack-time count+size caps mirror Open.

## Verification
`go build ./...`, `go test ./dipx/... ./cmd/dippin/... ./validator/... -race`, `just complexity`, `just validate-examples` all green.

> ⚠️ Note: the pre-commit hook flags pre-existing `staticcheck SA5011` warnings in `lsp/*_test.go` (untouched by this branch — `git diff main..HEAD -- lsp/ ir/` is empty; local golangci-lint version drift). Please confirm CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785522594&installation_id=131176874&pr_number=176&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F176&signature=723b492037a20926bef242e723acd26d70bb3e299adfec67e152f5b2072a2de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `dippin pack --no-inline` to preserve `*_file:` directives and package referenced targets as separate entries.
  * Added repeatable `--include` for adding extra files/directories to no-inline packs (with `--no-inline` required).
* **Bug Fixes**
  * Enforced case-sensitive `.dip` inputs; improved format v1/v2 manifest and path safety validation.
* **Documentation**
  * Updated integration docs for the `dipx.Pack(..., opts)` API and `PackOptions`.
* **Tests**
  * Added coverage for v1/v2 bundles, include deduplication, determinism, and round-trip extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->