### PR TITLE
docs: fix brew install command to use dippin-lang formula name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ go install github.com/2389-research/dippin-lang/cmd/dippin@latest
 Or via Homebrew:
 
 ```sh
-brew install 2389-research/tap/dippin
+brew install 2389-research/tap/dippin-lang
 ```
 
 Verify:

--- a/docs/superpowers/plans/2026-05-21-issue-40-coverage-redirection.md
+++ b/docs/superpowers/plans/2026-05-21-issue-40-coverage-redirection.md
@@ -499,7 +499,7 @@ Run: `gh run watch` (or `gh run list --workflow=release.yml --limit=1`) and wait
 ### Step 6.3: Verify the release
 
 Run: `gh release view v0.30.0`
-Expected: release page exists with cross-platform binaries listed. The Homebrew tap should also have updated (`brew info 2389-research/tap/dippin` or the tap repo's commit log).
+Expected: release page exists with cross-platform binaries listed. The Homebrew tap should also have updated (`brew info 2389-research/tap/dippin-lang` or the tap repo's commit log).
 
 ### Step 6.4: Exit the worktree
 

--- a/site/content/blog/getting-started.md
+++ b/site/content/blog/getting-started.md
@@ -45,7 +45,7 @@ Dippin is a single [Go](https://go.dev/) binary. Install it with `go install`:
 Or via Homebrew (macOS and Linux):
 
 <pre>
-<span class="hl-dim">$</span> <span class="hl-shcmd">brew install 2389-research/tap/dippin</span>
+<span class="hl-dim">$</span> <span class="hl-shcmd">brew install 2389-research/tap/dippin-lang</span>
 </pre>
 
 Verify it works:

--- a/site/content/blog/multi-line-prompts.md
+++ b/site/content/blog/multi-line-prompts.md
@@ -138,7 +138,7 @@ Ready to use Dippin on your own pipelines? Install the binary:
 Or via Homebrew (macOS and Linux):
 
 <pre>
-<span class="hl-dim">$</span> <span class="hl-shcmd">brew install 2389-research/tap/dippin</span>
+<span class="hl-dim">$</span> <span class="hl-shcmd">brew install 2389-research/tap/dippin-lang</span>
 </pre>
 
 If you're new to Dippin, [Getting Started](getting-started.html) walks

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -229,7 +229,7 @@
     <div class="install-or">or</div>
     <h3>Homebrew</h3>
     <div class="install-cmd">
-      <span class="prompt">$</span> brew install 2389-research/tap/dippin
+      <span class="prompt">$</span> brew install 2389-research/tap/dippin-lang
     </div>
     <div class="install-or">then</div>
     <h3>Verify</h3>


### PR DESCRIPTION
The install instructions on https://dippin.org/#install (and in the blog posts, AGENTS.md, and one plan doc) say:

```
brew install 2389-research/tap/dippin
```

but the tap ships the formula as `dippin-lang`, so this fails with:

```
Warning: No available formula or cask with the name "2389-research/tap/dippin". Did you mean 2389-research/tap/dippin-lang, ...?
```

This updates all five occurrences to `brew install 2389-research/tap/dippin-lang`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786032734&installation_id=131176874&pr_number=179&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F179&signature=0e1b343945be8b6392d82899a43ce1c36cd982cfd7def8abdeefa64eff0b35ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Homebrew installation instructions across the site and docs to use the correct `dippin-lang` package.
  * Corrected release verification guidance to point to the proper Homebrew tap/package path.
  * Ensured the homepage and blog onboarding content show the right install command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->