### PR TITLE
release: v0.45.0 — DIP152 marker-coverage lint + simulate else routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.45.0] — 2026-07-08
+
+### Added
+- **`DIP152` — coverage-aware `marker_grep` lint** ([#156](https://github.com/2389-research/dippin-lang/issues/156), [#180](https://github.com/2389-research/dippin-lang/pull/180)). Warns when a tool node's `marker_grep` enumerates a literal marker that no outgoing edge routes and that no section `else ->` default or unconditional fallback covers — that marker would be emitted at runtime with nowhere to go, previously a silent hole (any `marker_grep` blanket-exempted the source node from DIP101/DIP102). DIP152 catches it precisely, naming the uncovered markers. **Additive**: DIP101/DIP102 keep their marker exemption, so a gap gets exactly one warning. **Ultra-conservative — no false positives**: only recognizable finite literal alternations (`^(a|b|c)$` or a bare literal) are coverage-checked; any regex with a metacharacter, an empty branch, or a non-full-span group stays blanket-exempt, and any compound (`or`), negated (`!=` / `not`), other-variable, or unconditional edge makes the node safe. The exit node and edge-less dead-ends are handled correctly (the simulator dead-ends an edge-less node before any `else` routing, so `else` cannot cover it). Reuses `ir.ExtractEqualityCondition`; a `TestLintExamples` guard keeps the example suite covered. Brings the catalog to 62 codes (DIP101–DIP152).
+
+### Changed
+- **`dippin simulate` + the all-paths enumerator now honor the section `else ->` default** ([#158](https://github.com/2389-research/dippin-lang/issues/158), [#178](https://github.com/2389-research/dippin-lang/pull/178)). `ir.Workflow.ElseTarget` lives outside `Edges` and `EdgesFrom` doesn't expose it, so the built-in simulator and enumerator never traversed the `else` funnel default (they fell back to `edges[0]`, the happy-path heuristic). Now the simulator routes an unmatched node — including a concrete `--scenario` value no guard covers — to `ElseTarget`, mirroring the engine; the enumerator emits the `else` branch as a distinct path, gated on non-exhaustive guards (a declared-exhaustive success/fail set or complete partition does not enumerate an unreachable `else`). The static analyses (DIP003/004/101/102/105) were already `else`-aware since #157; this finishes the two execution-simulation consumers. Enabled by moving the edge-condition exhaustiveness helper to the shared `ir` tier as `ir.EdgesExhaustive` (validator and simulate share one source of truth — no import cycle, no drift).
+
+### Fixed
+- **Spec self-contradiction on block-form `parallel`** ([#174](https://github.com/2389-research/dippin-lang/issues/174)) — the `parallel`/`fan_in` section said "Inline syntax only", contradicting the supported block form (`parallel P` / `branch:` lines with per-branch `model`/`provider`/`fidelity`/`tool_access`/`writable_paths`/`last_response_truncate` overrides). Reworded to document both forms; the `fan_in`/DIP007 pairing applies to both.
+- **`brew install` formula name** in the site + docs install instructions ([#179](https://github.com/2389-research/dippin-lang/pull/179), thanks [@lra](https://github.com/lra)) — the tap ships the formula as `dippin-lang`, so `brew install 2389-research/tap/dippin` failed; corrected all five occurrences.
+
 ## [v0.44.0] — 2026-07-01
 
 ### Added

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,18 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.45.0] — 2026-07-08
+
+### Added
+- **`DIP152` — coverage-aware `marker_grep` lint** ([#156](https://github.com/2389-research/dippin-lang/issues/156), [#180](https://github.com/2389-research/dippin-lang/pull/180)). Warns when a tool node's `marker_grep` enumerates a literal marker that no outgoing edge routes and that no section `else ->` default or unconditional fallback covers — that marker would be emitted at runtime with nowhere to go, previously a silent hole (any `marker_grep` blanket-exempted the source node from DIP101/DIP102). DIP152 catches it precisely, naming the uncovered markers. **Additive**: DIP101/DIP102 keep their marker exemption, so a gap gets exactly one warning. **Ultra-conservative — no false positives**: only recognizable finite literal alternations (`^(a|b|c)$` or a bare literal) are coverage-checked; any regex with a metacharacter, an empty branch, or a non-full-span group stays blanket-exempt, and any compound (`or`), negated (`!=` / `not`), other-variable, or unconditional edge makes the node safe. The exit node and edge-less dead-ends are handled correctly (the simulator dead-ends an edge-less node before any `else` routing, so `else` cannot cover it). Reuses `ir.ExtractEqualityCondition`; a `TestLintExamples` guard keeps the example suite covered. Brings the catalog to 62 codes (DIP101–DIP152).
+
+### Changed
+- **`dippin simulate` + the all-paths enumerator now honor the section `else ->` default** ([#158](https://github.com/2389-research/dippin-lang/issues/158), [#178](https://github.com/2389-research/dippin-lang/pull/178)). `ir.Workflow.ElseTarget` lives outside `Edges` and `EdgesFrom` doesn't expose it, so the built-in simulator and enumerator never traversed the `else` funnel default (they fell back to `edges[0]`, the happy-path heuristic). Now the simulator routes an unmatched node — including a concrete `--scenario` value no guard covers — to `ElseTarget`, mirroring the engine; the enumerator emits the `else` branch as a distinct path, gated on non-exhaustive guards (a declared-exhaustive success/fail set or complete partition does not enumerate an unreachable `else`). The static analyses (DIP003/004/101/102/105) were already `else`-aware since #157; this finishes the two execution-simulation consumers. Enabled by moving the edge-condition exhaustiveness helper to the shared `ir` tier as `ir.EdgesExhaustive` (validator and simulate share one source of truth — no import cycle, no drift).
+
+### Fixed
+- **Spec self-contradiction on block-form `parallel`** ([#174](https://github.com/2389-research/dippin-lang/issues/174)) — the `parallel`/`fan_in` section said "Inline syntax only", contradicting the supported block form (`parallel P` / `branch:` lines with per-branch `model`/`provider`/`fidelity`/`tool_access`/`writable_paths`/`last_response_truncate` overrides). Reworded to document both forms; the `fan_in`/DIP007 pairing applies to both.
+- **`brew install` formula name** in the site + docs install instructions ([#179](https://github.com/2389-research/dippin-lang/pull/179), thanks [@lra](https://github.com/lra)) — the tap ships the formula as `dippin-lang`, so `brew install 2389-research/tap/dippin` failed; corrected all five occurrences.
+
 ## [v0.44.0] — 2026-07-01
 
 ### Added


### PR DESCRIPTION
Cuts **v0.45.0**, delivering the two features merged since v0.44.0 to consumers.

- **DIP152 — coverage-aware `marker_grep` lint** (#156, #180). Catches an enumerated marker that no edge routes and no `else`/unconditional fallback covers — previously a silent hole. Additive, ultra-conservative (no false positives). Catalog → 62 codes (DIP101–DIP152).
- **`dippin simulate` + all-paths enumerator honor the `else ->` default** (#158, #178), via the shared `ir.EdgesExhaustive` helper.
- Fixes: block-form `parallel` spec self-contradiction (#174); `brew install` formula name in install docs (#179, thanks @lra).

After merge: tag `v0.45.0` → GoReleaser publishes cross-platform binaries + Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786129861&installation_id=131176874&pr_number=181&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F181&signature=6882636c2c77c41a989998aa503ff599f7ee1a706ac691557d8cbdcf4ff39553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lint warning for coverage-aware marker reachability gaps.

* **Changed**
  * Simulation and all-paths results now honor section-level default paths when no specific route matches.
  * Clarified the supported wording for block-style `parallel` and `fan_in` syntax.

* **Bug Fixes**
  * Corrected install instructions to use the proper Homebrew formula name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->