### PR TITLE
fix(parser): preserve quoted edge conditions (#182)

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -1,3 +1,5 @@
+// ABOUTME: Tokenizes .dip source while retaining source locations and literal details.
+// ABOUTME: Decodes field values and preserves syntax metadata needed by the parser.
 package parser
 
 import (
@@ -30,9 +32,11 @@ const (
 )
 
 type Token struct {
-	Type     TokenType
-	Value    string
-	Location ir.SourceLocation
+	Type        TokenType
+	Value       string
+	rawLexeme   string
+	quoteClosed bool
+	Location    ir.SourceLocation
 }
 
 type Lexer struct {
@@ -101,7 +105,8 @@ func isBlankOrComment(line string) bool {
 }
 
 // findUnquotedHash scans a token-stream line for a # that starts a trailing
-// comment — one not inside a quoted string. Double quotes toggle on every `"`.
+// comment — one not inside a quoted string. Escaped bytes inside double quotes
+// do not close the string.
 // A single quote is a string delimiter only at a token-start boundary (see
 // opensSingleQuote); a `'` mid-word is a prose apostrophe and is ignored, so a
 // value like `goal: it's great # note` still strips its comment. Inside a
@@ -148,8 +153,12 @@ func advanceInQuote(s string, i int, quote byte) (int, byte) {
 	return advanceInSingleQuote(s, i)
 }
 
-// advanceInDoubleQuote closes a `"`-string on a `"`, otherwise stays inside.
+// advanceInDoubleQuote skips escaped bytes, closes on an unescaped `"`, and
+// otherwise stays inside the string.
 func advanceInDoubleQuote(s string, i int) (int, byte) {
+	if s[i] == '\\' && i+1 < len(s) {
+		return i + 1, '"'
+	}
 	if s[i] == '"' {
 		return i, 0
 	}
@@ -499,8 +508,11 @@ func (l *Lexer) tryLexOperator(line string, i int, loc ir.SourceLocation) (int, 
 func (l *Lexer) tryLexQuotedString(line string, i int, loc ir.SourceLocation) (int, bool) {
 	switch line[i] {
 	case '"':
-		content, newI := readQuotedContent(line, i+1)
-		l.tokens = append(l.tokens, Token{Type: TokenLiteral, Value: content, Location: loc})
+		content, newI, closed := readQuotedContent(line, i+1)
+		l.tokens = append(l.tokens, Token{
+			Type: TokenLiteral, Value: content, rawLexeme: line[i:newI],
+			quoteClosed: closed, Location: loc,
+		})
 		return newI, true
 	case '\'':
 		content, newI := readSingleQuotedContent(line, i+1)
@@ -512,8 +524,8 @@ func (l *Lexer) tryLexQuotedString(line string, i int, loc ir.SourceLocation) (i
 }
 
 // readQuotedContent reads characters from line[start:] until an unescaped closing quote.
-// Returns the content string and the position after the closing quote.
-func readQuotedContent(line string, start int) (string, int) {
+// Returns the content string, the next position, and whether a closing quote was found.
+func readQuotedContent(line string, start int) (string, int, bool) {
 	var content strings.Builder
 	i := start
 	for i < len(line) && line[i] != '"' {
@@ -521,8 +533,9 @@ func readQuotedContent(line string, start int) (string, int) {
 	}
 	if i < len(line) {
 		i++ // skip closing quote
+		return content.String(), i, true
 	}
-	return content.String(), i
+	return content.String(), i, false
 }
 
 // readSingleQuotedContent reads characters from line[start:] until the closing

--- a/parser/parse_edges.go
+++ b/parser/parse_edges.go
@@ -4,7 +4,6 @@ package parser
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
@@ -345,7 +344,15 @@ func formatConditionToken(t Token) string {
 		return t.rawLexeme
 	}
 	if t.Type == TokenLiteral {
-		return strconv.Quote(t.Value)
+		return encodeConditionLiteral(t.Value)
 	}
 	return t.Value
+}
+
+var conditionLiteralEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+
+// encodeConditionLiteral wraps decoded content in the condition grammar's
+// double quotes, escaping only the two bytes that grammar treats specially.
+func encodeConditionLiteral(value string) string {
+	return `"` + conditionLiteralEscaper.Replace(value) + `"`
 }

--- a/parser/parse_edges.go
+++ b/parser/parse_edges.go
@@ -1,3 +1,5 @@
+// ABOUTME: Parses workflow edge declarations, routing conditions, and edge attributes.
+// ABOUTME: Preserves condition syntax while populating the workflow edge IR.
 package parser
 
 import (
@@ -308,9 +310,21 @@ func (p *Parser) readConditionRaw() string {
 			break
 		}
 		t := p.lexer.NextToken()
+		p.diagnoseUnclosedConditionLiteral(t)
 		parts = append(parts, formatConditionToken(t))
 	}
 	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+// diagnoseUnclosedConditionLiteral reports a double-quoted condition token that
+// reached the end of its source line without a closing quote.
+func (p *Parser) diagnoseUnclosedConditionLiteral(t Token) {
+	if t.rawLexeme == "" || t.quoteClosed {
+		return
+	}
+	p.diagnostics = append(p.diagnostics, fmt.Sprintf(
+		"unterminated double-quoted literal at %d:%d", t.Location.Line, t.Location.Column,
+	))
 }
 
 // conditionTerminates reports whether the upcoming token ends the current
@@ -326,6 +340,9 @@ func (p *Parser) conditionTerminates(pk Token) bool {
 
 // formatConditionToken formats a single token for raw condition text.
 func formatConditionToken(t Token) string {
+	if t.rawLexeme != "" {
+		return t.rawLexeme
+	}
 	if t.Type == TokenLiteral {
 		return "\"" + t.Value + "\""
 	}

--- a/parser/parse_edges.go
+++ b/parser/parse_edges.go
@@ -4,6 +4,7 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/2389-research/dippin-lang/ir"
@@ -344,7 +345,7 @@ func formatConditionToken(t Token) string {
 		return t.rawLexeme
 	}
 	if t.Type == TokenLiteral {
-		return "\"" + t.Value + "\""
+		return strconv.Quote(t.Value)
 	}
 	return t.Value
 }

--- a/parser/parse_edges_test.go
+++ b/parser/parse_edges_test.go
@@ -79,6 +79,17 @@ func TestParseConditionKeepsSingleQuoteNormalization(t *testing.T) {
 	}
 }
 
+func TestParseConditionEscapesNormalizedSingleQuoteValue(t *testing.T) {
+	p := NewParser(buildEdgeDip(`A -> B when ctx.x = 'it''s \d+ here'`), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if got := w.Edges[0].Condition.Raw; got != `ctx.x = "it's \\d+ here"` {
+		t.Fatalf("Condition.Raw = %q, want escaped double-quoted normalization", got)
+	}
+}
+
 // buildOnDip produces a workflow whose first edge originates from a node of the
 // given kind, so `on` desugaring can be exercised per source-node channel.
 // kindBlock is the node declaration for A (e.g. an agent, tool, or parallel).

--- a/parser/parse_edges_test.go
+++ b/parser/parse_edges_test.go
@@ -53,18 +53,54 @@ func TestParseConditionPreservesHashInsideEscapedQuotes(t *testing.T) {
 	}
 }
 
+func TestParseConditionStripsCommentAfterEscapedQuoteLiteral(t *testing.T) {
+	p := NewParser(buildEdgeDip(`A -> B when ctx.x = "say \"alpha\"" # trailing`), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if got, want := w.Edges[0].Condition.Raw, `ctx.x = "say \"alpha\""`; got != want {
+		t.Fatalf("Condition.Raw = %q, want comment-free %q", got, want)
+	}
+}
+
+func TestParseConditionBackslashParityControlsQuoteClosure(t *testing.T) {
+	tests := []struct {
+		name, edgeLine, want string
+	}{
+		{"even run closes quote", `A -> B when ctx.x = "path\\" # trailing`, `ctx.x = "path\\"`},
+		{"odd run escapes quote", `A -> B when ctx.x = "path\\\"quoted" # trailing`, `ctx.x = "path\\\"quoted"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(buildEdgeDip(tt.edgeLine), "test.dip")
+			w, err := p.Parse()
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v (%v)", err, p.Diagnostics())
+			}
+			if got := w.Edges[0].Condition.Raw; got != tt.want {
+				t.Fatalf("Condition.Raw = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseConditionRejectsUnterminatedDoubleQuote(t *testing.T) {
 	p := NewParser(buildEdgeDip(`A -> B when ctx.tool_stdout = "say alpha`), "test.dip")
 	_, err := p.Parse()
 	if err == nil {
 		t.Fatal("expected parse error for unterminated double quote")
 	}
-	diagnostic := strings.Join(p.Diagnostics(), "\n")
+	diagnostics := p.Diagnostics()
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %v, want exactly one unterminated-quote diagnostic", diagnostics)
+	}
+	diagnostic := diagnostics[0]
 	if !strings.Contains(diagnostic, "unterminated double-quoted literal") {
 		t.Fatalf("diagnostic = %q, want unterminated quote explanation", diagnostic)
 	}
-	if !strings.Contains(diagnostic, "16:") {
-		t.Fatalf("diagnostic = %q, want source line and column", diagnostic)
+	if want := "unterminated double-quoted literal at 16:35"; diagnostic != want {
+		t.Fatalf("diagnostic = %q, want exact quote-start location %q", diagnostic, want)
 	}
 }
 

--- a/parser/parse_edges_test.go
+++ b/parser/parse_edges_test.go
@@ -90,6 +90,17 @@ func TestParseConditionEscapesNormalizedSingleQuoteValue(t *testing.T) {
 	}
 }
 
+func TestParseConditionPreservesLiteralTabWhenNormalizing(t *testing.T) {
+	p := NewParser(buildEdgeDip("A -> B when ctx.x = 'a\tcafé'"), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if got, want := w.Edges[0].Condition.Raw, "ctx.x = \"a\tcafé\""; got != want {
+		t.Fatalf("Condition.Raw = %q, want literal tab and non-ASCII content %q", got, want)
+	}
+}
+
 // buildOnDip produces a workflow whose first edge originates from a node of the
 // given kind, so `on` desugaring can be exercised per source-node channel.
 // kindBlock is the node declaration for A (e.g. an agent, tool, or parallel).

--- a/parser/parse_edges_test.go
+++ b/parser/parse_edges_test.go
@@ -1,3 +1,5 @@
+// ABOUTME: Exercises edge parsing, attributes, conditions, and related diagnostics.
+// ABOUTME: Uses complete .dip workflows to verify parser behavior at the public boundary.
 package parser
 
 import (
@@ -27,6 +29,54 @@ func buildEdgeDip(edgeLine string) string {
 		"  edges\n" +
 		"    " + edgeLine + "\n" +
 		"    B -> C\n"
+}
+
+func TestParseConditionPreservesDoubleQuotedLexeme(t *testing.T) {
+	p := NewParser(buildEdgeDip(`A -> B when ctx.tool_stdout = "say \"alpha||beta\""`), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if got := w.Edges[0].Condition.Raw; got != `ctx.tool_stdout = "say \"alpha||beta\""` {
+		t.Fatalf("Condition.Raw = %q, want %q", got, `ctx.tool_stdout = "say \"alpha||beta\""`)
+	}
+}
+
+func TestParseConditionPreservesHashInsideEscapedQuotes(t *testing.T) {
+	p := NewParser(buildEdgeDip(`A -> B when ctx.tool_stdout = "say \"alpha # beta\""`), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if got := w.Edges[0].Condition.Raw; got != `ctx.tool_stdout = "say \"alpha # beta\""` {
+		t.Fatalf("Condition.Raw = %q, want escaped-quote content including hash", got)
+	}
+}
+
+func TestParseConditionRejectsUnterminatedDoubleQuote(t *testing.T) {
+	p := NewParser(buildEdgeDip(`A -> B when ctx.tool_stdout = "say alpha`), "test.dip")
+	_, err := p.Parse()
+	if err == nil {
+		t.Fatal("expected parse error for unterminated double quote")
+	}
+	diagnostic := strings.Join(p.Diagnostics(), "\n")
+	if !strings.Contains(diagnostic, "unterminated double-quoted literal") {
+		t.Fatalf("diagnostic = %q, want unterminated quote explanation", diagnostic)
+	}
+	if !strings.Contains(diagnostic, "16:") {
+		t.Fatalf("diagnostic = %q, want source line and column", diagnostic)
+	}
+}
+
+func TestParseConditionKeepsSingleQuoteNormalization(t *testing.T) {
+	p := NewParser(buildEdgeDip(`A -> B when ctx.tool_stdout = 'say alpha||beta'`), "test.dip")
+	w, err := p.Parse()
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v (%v)", err, p.Diagnostics())
+	}
+	if got := w.Edges[0].Condition.Raw; got != `ctx.tool_stdout = "say alpha||beta"` {
+		t.Fatalf("Condition.Raw = %q, want normalized single-quoted literal", got)
+	}
 }
 
 // buildOnDip produces a workflow whose first edge originates from a node of the

--- a/simulate/condition.go
+++ b/simulate/condition.go
@@ -1,3 +1,5 @@
+// ABOUTME: Parses raw routing conditions and populates their executable condition ASTs.
+// ABOUTME: Tokenizes operators, words, and quoted values for simulation and linting.
 package simulate
 
 import (
@@ -206,16 +208,37 @@ func tryTokenizeQuotedCond(raw string, i int) (token string, consumed int) {
 	}
 
 	quote := raw[i]
-	i++
-	start := i
+	token, end := readQuotedCond(raw, i+1, quote)
+	return token, end - i
+}
+
+// readQuotedCond returns decoded quoted content and the position after its
+// closing quote. Double-quoted backslash escapes match the .dip lexer.
+func readQuotedCond(raw string, i int, quote byte) (string, int) {
+	var token strings.Builder
 	for i < len(raw) && raw[i] != quote {
+		if isQuotedCondEscape(raw, i, quote) {
+			i += appendQuotedCondEscape(&token, raw, i)
+			continue
+		}
+		token.WriteByte(raw[i])
 		i++
 	}
-	token = raw[start:i]
 	if i < len(raw) {
-		i++ // skip closing quote
+		i++
 	}
-	return token, i - (start - 1)
+	return token.String(), i
+}
+
+// isQuotedCondEscape reports whether i starts a complete double-quoted escape.
+func isQuotedCondEscape(raw string, i int, quote byte) bool {
+	return quote == '"' && raw[i] == '\\' && i+1 < len(raw)
+}
+
+// appendQuotedCondEscape decodes one lexer-compatible backslash escape.
+func appendQuotedCondEscape(token *strings.Builder, raw string, i int) int {
+	token.WriteByte(raw[i+1])
+	return 2
 }
 
 // operatorChars is the set of characters that form operators.

--- a/simulate/condition_parser_test.go
+++ b/simulate/condition_parser_test.go
@@ -1,0 +1,42 @@
+// ABOUTME: Verifies simulator conditions against Raw text produced by the real .dip parser.
+// ABOUTME: Covers quoting compatibility that crosses the parser and simulator boundary.
+package simulate_test
+
+import (
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/parser"
+	"github.com/2389-research/dippin-lang/simulate"
+)
+
+func TestParseConditionPreservesNormalizedLiteralTab(t *testing.T) {
+	source := "workflow X\n" +
+		"  goal: \"Test\"\n" +
+		"  start: A\n" +
+		"  exit: B\n" +
+		"\n" +
+		"  agent A\n" +
+		"    prompt: \"Do A.\"\n" +
+		"\n" +
+		"  agent B\n" +
+		"    prompt: \"Do B.\"\n" +
+		"\n" +
+		"  edges\n" +
+		"    A -> B when ctx.x = 'a\tcafé'\n"
+	w, err := parser.NewParser(source, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+	expr, err := simulate.ParseCondition(w.Edges[0].Condition.Raw)
+	if err != nil {
+		t.Fatalf("ParseCondition error: %v", err)
+	}
+	cmp, ok := expr.(ir.CondCompare)
+	if !ok {
+		t.Fatalf("expected CondCompare, got %T", expr)
+	}
+	if got, want := cmp.Value, "a\tcafé"; got != want {
+		t.Fatalf("Value = %q, want literal tab and non-ASCII content %q", got, want)
+	}
+}

--- a/simulate/condition_test.go
+++ b/simulate/condition_test.go
@@ -44,6 +44,20 @@ func TestParseCondition_DecodesEscapedDoubleQuotedValue(t *testing.T) {
 	}
 }
 
+func TestParseCondition_DecodesNormalizedSingleQuoteBackslash(t *testing.T) {
+	expr, err := ParseCondition(`ctx.x = "it's \\d+ here"`)
+	if err != nil {
+		t.Fatalf("ParseCondition error: %v", err)
+	}
+	cmp, ok := expr.(ir.CondCompare)
+	if !ok {
+		t.Fatalf("expected CondCompare, got %T", expr)
+	}
+	if cmp.Value != `it's \d+ here` {
+		t.Fatalf("Value = %q, want literal backslash preserved", cmp.Value)
+	}
+}
+
 func TestParseCondition_NotEqual(t *testing.T) {
 	expr, err := ParseCondition("ctx.x != empty")
 	if err != nil {

--- a/simulate/condition_test.go
+++ b/simulate/condition_test.go
@@ -1,3 +1,5 @@
+// ABOUTME: Verifies condition tokenization, parsing, and workflow AST population.
+// ABOUTME: Covers comparison operators, boolean composition, quoting, and errors.
 package simulate
 
 import (
@@ -25,6 +27,20 @@ func TestParseCondition_SimpleCompare(t *testing.T) {
 	}
 	if cmp.Value != "success" {
 		t.Errorf("Value = %q, want success", cmp.Value)
+	}
+}
+
+func TestParseCondition_DecodesEscapedDoubleQuotedValue(t *testing.T) {
+	expr, err := ParseCondition(`ctx.tool_stdout = "say \"alpha\\beta\""`)
+	if err != nil {
+		t.Fatalf("ParseCondition error: %v", err)
+	}
+	cmp, ok := expr.(ir.CondCompare)
+	if !ok {
+		t.Fatalf("expected CondCompare, got %T", expr)
+	}
+	if cmp.Value != `say "alpha\beta"` {
+		t.Fatalf("Value = %q, want decoded quote and backslash", cmp.Value)
 	}
 }
 

--- a/validator/validate_conditions_test.go
+++ b/validator/validate_conditions_test.go
@@ -1,8 +1,11 @@
+// ABOUTME: Verifies structural validation of edge conditions parsed from real .dip source.
+// ABOUTME: Covers DIP010 diagnostics and lazy population of condition ASTs.
 package validator
 
 import (
 	"testing"
 
+	"github.com/2389-research/dippin-lang/ir"
 	"github.com/2389-research/dippin-lang/parser"
 )
 
@@ -125,6 +128,36 @@ func TestDIP010_ValidConditionsClean(t *testing.T) {
 	diags := validateSrc(t, src)
 	if hasCode(diags, "DIP010") {
 		t.Fatalf("unexpected DIP010 on valid conditions: %v", codes(diags))
+	}
+}
+
+func TestDIP010_EscapedQuoteConditionParsesFromSource(t *testing.T) {
+	src := `workflow W
+  goal: "escaped quote"
+  start: A
+  exit: B
+
+  agent A
+    prompt: "a"
+  agent B
+    prompt: "b"
+
+  edges
+    A -> B when ctx.tool_stdout = "say \"alpha||beta\""
+`
+	w, err := parser.NewParser(src, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if diags := Validate(w).Diagnostics; len(diags) != 0 {
+		t.Fatalf("unexpected validation diagnostics: %v", diags)
+	}
+	cmp, ok := w.Edges[0].Condition.Parsed.(ir.CondCompare)
+	if !ok {
+		t.Fatalf("Condition.Parsed = %T, want ir.CondCompare", w.Edges[0].Condition.Parsed)
+	}
+	if want := `say "alpha||beta"`; cmp.Value != want {
+		t.Fatalf("comparison Value = %q, want %q", cmp.Value, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve exact double-quoted condition lexemes through parsing, including escaped quotes and embedded delimiters
- reject unterminated double-quoted condition literals with an exact source location
- align simulator escape decoding with parser output while retaining single-quote normalization semantics

## Test plan
- [x] `just check`
- [x] parser-to-validator escaped-quote regression coverage
- [x] comment-boundary, backslash-parity, tabs, UTF-8, and unmatched-quote coverage

Closes #182

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786511052&installation_id=131176874&pr_number=183&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F183&signature=4df61eed8b76b293803bff987d0ec0afa57c9d3d744b6299e3dd7d14eeecae54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of escaped quotes, backslashes, comments, and embedded `#` characters in condition strings.
  * Unterminated double-quoted literals now produce a clear, location-specific diagnostic.
  * Preserved literal content more accurately, including tabs, non-ASCII characters, and normalized single-quoted values.
  * Fixed condition parsing and validation for escaped quote content.

* **Tests**
  * Added coverage for quoted-string parsing, escape handling, comment boundaries, diagnostics, and literal preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->