### PR TITLE
release: v0.49.0 — quoted edge conditions (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.49.0] — 2026-07-13
+
+**Lossless quoted edge conditions** ([#182](https://github.com/2389-research/dippin-lang/issues/182)). Double-quoted edge-condition values containing escaped quotes or backslashes were corrupted while the parser reconstructed `Condition.Raw`; embedded operator-like text could then be reinterpreted, and valid workflows failed validation with DIP010. This release makes the double-quoted path escape-aware end to end, from source parsing through `Condition.Raw` to the condition parser used by simulation and validation.
+
+### Fixed
+- **Escaped double-quoted condition values now round-trip losslessly.** Interior `\"` and `\\` survive parse → `Condition.Raw` → simulate/validate with their literal values intact. Operator- and comment-like text inside the quoted value — including `||` and `#` — remains literal, while a real trailing `#` comment is still stripped. Additional boundary coverage contributed in [PR #183](https://github.com/2389-research/dippin-lang/pull/183) (thanks [@harperreed](https://github.com/harperreed)) caught the comment-boundary/backslash-parity gap and covers even/odd backslash runs, escaped quotes, literal tabs, and UTF-8.
+- **Unterminated double-quoted literals are rejected.** The lexer now reports an unterminated string literal at the opening quote's source line and column instead of fabricating a closing quote and allowing validation to pass. Existing single-quoted condition behavior is unchanged, including YAML-style normalization and literal backslashes.
+
+### Runtime pairing (requires an enforcing runtime)
+- None. This is parser/validator correctness with no new runtime field or behavior to interpret. This `v0.49.0` tag is the release [tracker#444](https://github.com/2389-research/tracker/issues/444) can consume.
+
 ## [v0.48.0] — 2026-07-10
 
 **Shared prompt fragments** ([#175](https://github.com/2389-research/dippin-lang/issues/175)). `prompt_file:` / `system_prompt_file:` load an *entire* prompt from a file — all or nothing — so control-protocol boilerplate that must be byte-identical across many agents (e.g. a STATUS / FINAL-LINE contract) gets hand-pasted and drifts (downstream: pipelines#111, the same block duplicated 65× across 11 files). This release lets a shared fragment be declared once and applied to many agents. Fully additive and non-breaking: every existing `.dip` parses, validates, formats, and packs unchanged, in v1 and `dip 2` alike.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,17 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.49.0] — 2026-07-13
+
+**Lossless quoted edge conditions** ([#182](https://github.com/2389-research/dippin-lang/issues/182)). Double-quoted edge-condition values containing escaped quotes or backslashes were corrupted while the parser reconstructed `Condition.Raw`; embedded operator-like text could then be reinterpreted, and valid workflows failed validation with DIP010. This release makes the double-quoted path escape-aware end to end, from source parsing through `Condition.Raw` to the condition parser used by simulation and validation.
+
+### Fixed
+- **Escaped double-quoted condition values now round-trip losslessly.** Interior `\"` and `\\` survive parse → `Condition.Raw` → simulate/validate with their literal values intact. Operator- and comment-like text inside the quoted value — including `||` and `#` — remains literal, while a real trailing `#` comment is still stripped. Additional boundary coverage contributed in [PR #183](https://github.com/2389-research/dippin-lang/pull/183) (thanks [@harperreed](https://github.com/harperreed)) caught the comment-boundary/backslash-parity gap and covers even/odd backslash runs, escaped quotes, literal tabs, and UTF-8.
+- **Unterminated double-quoted literals are rejected.** The lexer now reports an unterminated string literal at the opening quote's source line and column instead of fabricating a closing quote and allowing validation to pass. Existing single-quoted condition behavior is unchanged, including YAML-style normalization and literal backslashes.
+
+### Runtime pairing (requires an enforcing runtime)
+- None. This is parser/validator correctness with no new runtime field or behavior to interpret. This `v0.49.0` tag is the release [tracker#444](https://github.com/2389-research/tracker/issues/444) can consume.
+
 ## [v0.48.0] — 2026-07-10
 
 **Shared prompt fragments** ([#175](https://github.com/2389-research/dippin-lang/issues/175)). `prompt_file:` / `system_prompt_file:` load an *entire* prompt from a file — all or nothing — so control-protocol boilerplate that must be byte-identical across many agents (e.g. a STATUS / FINAL-LINE contract) gets hand-pasted and drifts (downstream: pipelines#111, the same block duplicated 65× across 11 files). This release lets a shared fragment be declared once and applied to many agents. Fully additive and non-breaking: every existing `.dip` parses, validates, formats, and packs unchanged, in v1 and `dip 2` alike.


### PR DESCRIPTION
## Summary
- document lossless escaped-quote and backslash handling for edge conditions
- document source-located rejection of unterminated double-quoted literals and unchanged single-quote behavior
- regenerate the Hugo changelog mirror for the v0.49.0 release

## Test plan
- [x] `just check`
- [x] generated changelog parity
- [x] spec-compliance and quality reviews
- [x] fresh-eyes review

## Release
After merge, tag the merge commit with `just release v0.49.0 "v0.49.0 — edge-condition quoted literal correctness (#182)"` and verify the GoReleaser workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786577806&installation_id=131176874&pr_number=184&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F184&signature=e0044f26cdb02a30e3b7abde634ea9845dd2014ac48b78ef2f9e4832021bc5f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of escaped quotes and backslashes in double-quoted condition values, preserving their content during parsing and validation.
  * Improved comment handling within quoted values while continuing to remove genuine trailing comments.
  * Unterminated double-quoted values are now rejected with an accurate error location.

* **Documentation**
  * Added release notes for version 0.49.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->