### PR TITLE
fix: resolve dotted Anthropic model IDs in cost + lint (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.51.1] — 2026-08-07
 
 ### Fixed
 - **Dotted Anthropic model IDs now price and lint correctly** ([#188](https://github.com/2389-research/dippin-lang/issues/188)). The pricing table and model catalog key Anthropic models with dashed versions (`claude-haiku-4-5`), but a Vercel AI Gateway–routed runtime documents the dotted spelling (`anthropic/claude-haiku-4.5`) — which a `.dip` must carry, since the first-party API rejects dotted IDs. The exact-match lookup missed the dotted form, so `dippin cost` silently reported **$0** and `dippin lint` fired a spurious **DIP108** "unknown model". Both `cost.lookupPrice` and the validator's `modelKnown` now fall back to a version-separator-insensitive match (`.` and `-` fold together) after the exact match, so a dotted ID resolves to its dashed catalog key and vice versa. Exact matches are unchanged — the legitimately dotted OpenAI/Gemini keys (`gpt-5.5`, `gemini-3.1-flash-lite`) still resolve as before, and no two keys in any provider collide under the fold, so the fallback can only turn a miss into the intended hit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Dotted Anthropic model IDs now price and lint correctly** ([#188](https://github.com/2389-research/dippin-lang/issues/188)). The pricing table and model catalog key Anthropic models with dashed versions (`claude-haiku-4-5`), but a Vercel AI Gateway–routed runtime documents the dotted spelling (`anthropic/claude-haiku-4.5`) — which a `.dip` must carry, since the first-party API rejects dotted IDs. The exact-match lookup missed the dotted form, so `dippin cost` silently reported **$0** and `dippin lint` fired a spurious **DIP108** "unknown model". Both `cost.lookupPrice` and the validator's `modelKnown` now fall back to a version-separator-insensitive match (`.` and `-` fold together) after the exact match, so a dotted ID resolves to its dashed catalog key and vice versa. Exact matches are unchanged — the legitimately dotted OpenAI/Gemini keys (`gpt-5.5`, `gemini-3.1-flash-lite`) still resolve as before, and no two keys in any provider collide under the fold, so the fallback can only turn a miss into the intended hit.
+
 ## [v0.51.0] — 2026-08-07
 
 **Native `inputs` declaration — typed, introspectable input schema** ([#190](https://github.com/2389-research/dippin-lang/issues/190)). Phase 1 of pipeline inputs. A workflow-level `inputs` block is the callee-side signature declaring what a caller must supply — a human at the entry point, or a parent workflow via a subgraph's `params:`. One-line form (`name: type`) or an indented attribute block; six types (text, number, bool, enum, file, secret) and ten attributes (required, default, prompt, description, options, pattern, min, max, max_length, multiline). `${inputs.x}` is the first **closed** namespace in the language: unlike the open `ctx` namespace, a reference to an undeclared input is a lint error, not a maybe-valid pass-through — values are untrusted by construction. Fully additive to dip 1: a `.dip` with no `inputs` block is unchanged, and the parser accepts an unknown input type verbatim (only the lint complains), so a `.dip` using a future type still parses, formats, and packs on an older dippin.

--- a/cost/cost.go
+++ b/cost/cost.go
@@ -220,13 +220,33 @@ func outputTokensForModel(model string) int {
 }
 
 // lookupPrice finds pricing for a provider/model pair.
+//
+// An exact key match wins. On a miss it retries with a version-separator-
+// insensitive comparison so a dotted ID (claude-haiku-4.5, the Vercel AI
+// Gateway spelling) resolves to a dashed catalog key (claude-haiku-4-5), and
+// vice versa (issue #188). No two keys in any provider collide under this
+// normalization, so the fallback can only turn a miss into the intended hit.
 func lookupPrice(provider, model string, pricing PricingTable) (ModelPrice, bool) {
 	models, ok := pricing[provider]
 	if !ok {
 		return ModelPrice{}, false
 	}
-	p, ok := models[model]
-	return p, ok
+	if p, ok := models[model]; ok {
+		return p, true
+	}
+	want := canonicalModelID(model)
+	for k, p := range models {
+		if canonicalModelID(k) == want {
+			return p, true
+		}
+	}
+	return ModelPrice{}, false
+}
+
+// canonicalModelID folds the model version separator so dotted and dashed
+// spellings compare equal (claude-haiku-4.5 == claude-haiku-4-5). See #188.
+func canonicalModelID(model string) string {
+	return strings.ReplaceAll(model, ".", "-")
 }
 
 // computeCostRange calculates cost for each turn scenario.

--- a/cost/cost_test.go
+++ b/cost/cost_test.go
@@ -495,3 +495,33 @@ func TestTopCostsSorting(t *testing.T) {
 		t.Errorf("expected top cost to be 'expensive', got %q", r.TopCosts[0].NodeID)
 	}
 }
+
+// TestLookupPriceDottedDashedEquivalence covers #188: the Anthropic pricing
+// keys are dashed (claude-haiku-4-5) but the Vercel-gateway-documented ID a
+// .dip must carry is dotted (claude-haiku-4.5). Both spellings must resolve to
+// the same price; a genuinely unknown model must still miss.
+func TestLookupPriceDottedDashedEquivalence(t *testing.T) {
+	pricing := DefaultPricing()
+
+	dashed, ok := lookupPrice("anthropic", "claude-haiku-4-5", pricing)
+	if !ok {
+		t.Fatal("dashed claude-haiku-4-5 should be known")
+	}
+	dotted, ok := lookupPrice("anthropic", "claude-haiku-4.5", pricing)
+	if !ok {
+		t.Fatal("dotted claude-haiku-4.5 must resolve (issue #188)")
+	}
+	if dotted != dashed {
+		t.Errorf("dotted price %+v != dashed price %+v", dotted, dashed)
+	}
+
+	// Exact dotted keys (OpenAI/Gemini) must still resolve unchanged.
+	if _, ok := lookupPrice("openai", "gpt-5.5", pricing); !ok {
+		t.Error("exact dotted OpenAI key gpt-5.5 regressed")
+	}
+
+	// A genuinely unknown model must still miss (no false positive from normalization).
+	if _, ok := lookupPrice("anthropic", "claude-nonexistent-9-9", pricing); ok {
+		t.Error("unknown model must not resolve")
+	}
+}

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -406,6 +406,13 @@ warning[DIP108]: unknown model/provider combination
 
 **How to fix**: Check for typos. Use recognized model/provider combinations.
 
+**Version-separator spelling**: the model catalog and cost table treat `.` and
+`-` in the version portion as equivalent, so a dotted ID and its dashed form are
+the same model — `anthropic/claude-haiku-4.5` (the
+Vercel AI Gateway spelling) resolves to the dashed catalog key
+`claude-haiku-4-5`, and both price identically under `dippin cost`. Carry
+whichever spelling your executing runtime requires.
+
 ---
 
 ### DIP109: Duplicate Subgraph Reference

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.51.1] — 2026-08-07
+
+### Fixed
+- **Dotted Anthropic model IDs now price and lint correctly** ([#188](https://github.com/2389-research/dippin-lang/issues/188)). The pricing table and model catalog key Anthropic models with dashed versions (`claude-haiku-4-5`), but a Vercel AI Gateway–routed runtime documents the dotted spelling (`anthropic/claude-haiku-4.5`) — which a `.dip` must carry, since the first-party API rejects dotted IDs. The exact-match lookup missed the dotted form, so `dippin cost` silently reported **$0** and `dippin lint` fired a spurious **DIP108** "unknown model". Both `cost.lookupPrice` and the validator's `modelKnown` now fall back to a version-separator-insensitive match (`.` and `-` fold together) after the exact match, so a dotted ID resolves to its dashed catalog key and vice versa. Exact matches are unchanged — the legitimately dotted OpenAI/Gemini keys (`gpt-5.5`, `gemini-3.1-flash-lite`) still resolve as before, and no two keys in any provider collide under the fold, so the fallback can only turn a miss into the intended hit.
+
 ## [v0.51.0] — 2026-08-07
 
 **Native `inputs` declaration — typed, introspectable input schema** ([#190](https://github.com/2389-research/dippin-lang/issues/190)). Phase 1 of pipeline inputs. A workflow-level `inputs` block is the callee-side signature declaring what a caller must supply — a human at the entry point, or a parent workflow via a subgraph's `params:`. One-line form (`name: type`) or an indented attribute block; six types (text, number, bool, enum, file, secret) and ten attributes (required, default, prompt, description, options, pattern, min, max, max_length, multiline). `${inputs.x}` is the first **closed** namespace in the language: unlike the open `ctx` namespace, a reference to an undeclared input is a lint error, not a maybe-valid pass-through — values are untrusted by construction. Fully additive to dip 1: a `.dip` with no `inputs` block is unchanged, and the parser accepts an unknown input type verbatim (only the lint complains), so a `.dip` using a future type still parses, formats, and packs on an older dippin.

--- a/validator/lint_model.go
+++ b/validator/lint_model.go
@@ -292,7 +292,32 @@ func providerKnown(provider string, extra ExtraModels) bool {
 // modelKnown reports whether the model is registered for the provider in either
 // the base catalog or the scoped extra catalog.
 func modelKnown(provider, model string, extra ExtraModels) bool {
-	return knownModelProviders[provider][model] || extra[provider][model]
+	if knownModelProviders[provider][model] || extra[provider][model] {
+		return true
+	}
+	// Fall back to a version-separator-insensitive match so a dotted ID
+	// (claude-haiku-4.5, the Vercel AI Gateway spelling) is recognized as the
+	// dashed catalog key (claude-haiku-4-5), and vice versa (issue #188).
+	return modelKnownNormalized(knownModelProviders[provider], model) ||
+		modelKnownNormalized(extra[provider], model)
+}
+
+// modelKnownNormalized reports whether any key in catalog matches model once
+// their version separators are folded (dots to dashes). See #188.
+func modelKnownNormalized(catalog map[string]bool, model string) bool {
+	want := canonicalModelID(model)
+	for k := range catalog {
+		if canonicalModelID(k) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// canonicalModelID folds the model version separator so dotted and dashed
+// spellings compare equal (claude-haiku-4.5 == claude-haiku-4-5). See #188.
+func canonicalModelID(model string) string {
+	return strings.ReplaceAll(model, ".", "-")
 }
 
 // knownProviderList returns a sorted comma-separated list of known providers,

--- a/validator/lint_model_test.go
+++ b/validator/lint_model_test.go
@@ -34,3 +34,41 @@ func TestLintDIP108NewAnthropicModels(t *testing.T) {
 		}
 	}
 }
+
+// TestLintDIP108DottedAnthropicID covers #188: a dotted Anthropic model ID
+// (claude-haiku-4.5, the Vercel-gateway-documented spelling) must be recognized
+// as the same model as the dashed catalog key (claude-haiku-4-5), so it does not
+// trip DIP108. A genuinely unknown model must still be flagged.
+func TestLintDIP108DottedAnthropicID(t *testing.T) {
+	known := fmt.Sprintf(`workflow w
+  start: A
+  exit: A
+
+  agent A
+    provider: anthropic
+    model: %s
+    prompt: go
+
+  edges
+    A -> A
+`, "claude-haiku-4.5")
+	if diags := lintSrc(t, known); hasCode(diags, DIP108) {
+		t.Errorf("dotted claude-haiku-4.5 tripped DIP108 (issue #188): %v", codes(diags))
+	}
+
+	unknown := fmt.Sprintf(`workflow w
+  start: A
+  exit: A
+
+  agent A
+    provider: anthropic
+    model: %s
+    prompt: go
+
+  edges
+    A -> A
+`, "claude-nonexistent-9.9")
+	if diags := lintSrc(t, unknown); !hasCode(diags, DIP108) {
+		t.Errorf("genuinely unknown dotted model must still trip DIP108: %v", codes(diags))
+	}
+}


### PR DESCRIPTION
Fixes #188.

## The bug

The pricing table (`cost/pricing.go`) and model catalog (`validator/lint_model.go`) key Anthropic models with **dashed** versions (`claude-haiku-4-5`). But a Vercel AI Gateway–routed runtime documents — and requires — the **dotted** spelling (`anthropic/claude-haiku-4.5`); the first-party Anthropic API rejects dotted IDs (404), so a `.dip` targeting the gateway has to carry the dotted form.

Both lookups were exact-match, so the dotted ID missed:
- `dippin cost` silently reported **$0** for the node (`unknown model` assumption).
- `dippin lint` fired a spurious **DIP108** "unknown model".

Reproduced on `claude-haiku-4.5`: dashed priced at $0.04 max, dotted at $0.00.

## The fix

`cost.lookupPrice` and `validator.modelKnown` keep exact-match first, then fall back to a **version-separator-insensitive** comparison (`.` and `-` fold together via a small `canonicalModelID` helper). A dotted ID resolves to its dashed catalog key and vice versa.

**Why it's safe:**
- Exact match runs first, so every currently-working lookup is unchanged — the legitimately dotted OpenAI/Gemini keys (`gpt-5.5`, `gemini-3.1-flash-lite`) still resolve on the exact path.
- Verified no two keys in any provider collide under the fold (checked all 73/74 model-ish keys in both files), so the fallback can only turn a miss into the intended hit — never a wrong match.
- The fallback is O(n) only on a miss, n ≈ a dozen per provider.

## Scope

Fixed in **both** surfaces because it's one root cause — a cost-only fix would leave `dippin lint` still flagging the dotted ID as unknown. Adds a focused test in each package (dotted resolves == dashed; exact dotted keys still resolve; a genuinely unknown model still misses / still trips DIP108) and a docs note in `docs/validation.md` under DIP108.

Not in scope: adding *new* pricing rows (that's #189, which needs pricing verified against provider docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788709145&installation_model_id=21126&pr_number=192&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F192&signature=6bb4eb08e018cce1d64657f3644ed5187696f2853879710ed7a4ee0c926de15a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Model IDs using dots or dashes interchangeably are now recognized consistently.
  - Pricing lookup and model validation correctly support dotted Anthropic model versions, such as `claude-haiku-4.5`.
  - Exact model matches remain supported, while unknown models continue to be rejected.

- **Documentation**
  - Added guidance on accepted model version-separator formats and runtime-specific spelling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->