### PR TITLE
feat: frontier model pricing + catalog refresh; docs/site sync (#189)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Editor / agent integrations:
 ```sh
 dippin parse pipeline.dip          # JSON IR
 dippin validate pipeline.dip       # structural errors (DIP001-DIP010)
-dippin lint pipeline.dip           # validation + semantic warnings (DIP101-DIP152)
+dippin lint pipeline.dip           # validation + semantic warnings (DIP101-DIP157)
 dippin format pipeline.dip         # canonical formatting
 dippin doctor pipeline.dip         # A-F health report
 dippin cost pipeline.dip           # per-run cost estimate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Frontier model pricing + catalog refresh** ([#189](https://github.com/2389-research/dippin-lang/issues/189)). `dippin cost` reported **$0** and `dippin lint` fired spurious **DIP108** for a raft of current frontier models simply absent from the tables. Added, each verified against official provider docs on 2026-08-07 (source URLs recorded in `cost/pricing.go`): **Anthropic** `claude-opus-5` ($5/$25), `claude-sonnet-5` ($3/$15 durable; intro $2/$10 through 2026-08-31); **OpenAI** `gpt-5.6-sol` ($5/$30), `gpt-5.6-terra` ($2/$12), `gpt-5.6-luna` ($0.20/$1.20); **Gemini** `gemini-3.6-flash` ($1.50/$7.50), `gemini-3.5-flash` ($1.50/$9), `gemini-3.5-flash-lite` ($0.30/$2.50); **xAI** `grok-4.5` ($2/$6 base), `grok-build-0.1` ($1/$2). Plus three **new providers**: **Z.AI / GLM** (`zai` — glm-5.2/5.1/5/5-turbo/4.7/4.6/4.5 family), **Moonshot / Kimi** (`moonshot`+`kimi` — `kimi-k3` $3/$15), and **MiniMax** (`minimax` — MiniMax-M3/M2.7/M2.5/M2.1/M2). All base-tier list prices (large-prompt and cache tiers are out of dippin's schema).
+- **Qwen recognized by the linter** (`qwen` — qwen3.7-max/plus, qwen3.6-flash). Its international per-token USD pricing is console-gated and could not be verified from an official page, so Qwen is in the model catalog (no more DIP108) but has **no cost-table row yet** — a follow-up.
+
+### Docs
+- Swept the living docs and website to current code: diagnostic-code counts and ranges corrected to **67 codes (DIP001–DIP010, DIP101–DIP157)** across `CLAUDE.md`, `AGENTS.md`, `README.md`, `docs/`, and `site/content/`; the `inputs` block and `${inputs.*}` namespace added to `docs/llm-reference.md` (feeds the embedded spec) with DIP155–DIP157; corrected the `skill.md` canonical section order (**inputs → defaults → vars**, not defaults → inputs); updated the supported-provider list.
+
 ## [v0.51.1] — 2026-08-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,13 +76,13 @@ GoReleaser is configured (`.goreleaser.yml`) — pushing a tag triggers GitHub A
 
 Model names and pricing in `validator/lint_model.go` and `cost/pricing.go` must be verified against official provider documentation before committing. Source URLs and "Last verified" dates are maintained as code comments. Never use training data for pricing — it goes stale.
 
-Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistral, Cohere.
+Supported providers: Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistral, Cohere, Z.AI/GLM, Moonshot/Kimi, MiniMax, Qwen (Qwen is recognized by the linter but has no cost-table pricing yet — its international USD rates weren't verifiable from an official page; see the follow-up).
 
 `TestLintExamples` in `validator/lint_examples_test.go` parses all example .dip files through the real parser and asserts zero DIP108 warnings — this catches model catalog staleness and invalid model IDs.
 
 ## Lint Rules
 
-62 diagnostic codes: DIP001-DIP010 (structural errors), DIP101-DIP152 (semantic warnings). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
+67 diagnostic codes: DIP001-DIP010 (structural errors), DIP101-DIP157 (semantic lint — mostly warnings; DIP155-DIP157 are error-severity and fail `lint`/`check`). DIP101/DIP102 suppress automatically when source node conditions are exhaustive (success/fail pairs, contains/not-contains complementary pairs). DIP121/DIP122 only fire when source nodes declare writes/outputs (advisory metadata).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ graph LR
 | Shell scripts | `tool_command="#!/bin/sh\nset -eu\nif..."` | Real multiline, real syntax |
 | Model config | Untyped `llm_model="..."` attribute | Typed `model:` field with validation |
 | Branching | `condition="context.x!=y && context.a==b"` | `when ctx.x != "y" and ctx.a == "b"` |
-| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP152) |
+| Validation | Silent — typos in attrs are ignored | Diagnostic codes (DIP001–DIP010, DIP101–DIP157) |
 | Node types | Shape overloading (`box`=agent, `hexagon`=human) | Explicit `agent`, `tool`, `human` keywords |
 | Composition | No import/include system | `subgraph` with ref (v2) |
 
@@ -131,7 +131,7 @@ Every analysis command (`validate`, `lint`, `doctor`, `parse`, `cost`, `coverage
 |---------|-------------|
 | `dippin parse <file>` | Parse and output IR as JSON |
 | `dippin validate <file>` | Structural validation (DIP001–DIP010) |
-| `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP152) |
+| `dippin lint <file>` | Validation + semantic warnings (DIP101–DIP157) |
 | `dippin check [--format json\|text] <file>` | Parse+validate+lint in one shot (JSON default, for LLM tooling) |
 | `dippin fmt [--check] [--write] <file>` | Format to canonical style |
 | `dippin new [--name N] [--write F] <template>` | Generate a starter .dip from a template |
@@ -390,7 +390,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 | DIP008 | Duplicate node ID |
 | DIP009 | Duplicate edge |
 
-### Warnings (DIP101–DIP152 — selected; see [docs/validation.md](docs/validation.md) for the full catalog)
+### Warnings (DIP101–DIP157 — selected; see [docs/validation.md](docs/validation.md) for the full catalog)
 
 | Code | What it catches |
 |------|----------------|

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -15,6 +15,12 @@ workflow <Name>
   start: <NodeID>
   exit: <NodeID>
 
+  [inputs
+    <name>: <text|number|bool|enum|file|secret>
+      [required: true] [default: <value>] [prompt: "<text>"] [description: "<text>"]
+      [options: <a>, <b>] [pattern: "<regex>"] [min: <n>] [max: <n>] [max_length: <int>] [multiline: true]
+    ...]
+
   [defaults
     model: <string>
     provider: <string>
@@ -77,7 +83,7 @@ on <token>                       # sugar: equality vs the source node's outcome 
 
 **`on <token>` shorthand:** desugars to `when <channel> = <token>`, where the channel is the source node's natural outcome channel — `ctx.outcome` for agent nodes, `ctx.tool_marker` for tool nodes with `marker_grep`. IR-identical to the equivalent `when`; `dippin fmt` rewrites eligible `when` edges to `on`. The value must be a single bare identifier (`[A-Za-z0-9][A-Za-z0-9_-]*`); quoted, multi-token, or any other values require an explicit `when <channel> = ...`. Source nodes with no outcome channel must use `when`: human gates (which route on the choice/label, not `ctx.outcome`), `conditional` nodes, and tools without `marker_grep`.
 
-**Variables:** Always namespace-qualified: `ctx.outcome`, `ctx.status`, `graph.goal`
+**Variables:** Always namespace-qualified: `ctx.outcome`, `ctx.status`, `graph.goal`, `params.*` (subgraph params), `inputs.*` (declared workflow inputs — a closed namespace; an undeclared reference is DIP156)
 
 ---
 
@@ -157,7 +163,7 @@ workflow ReviewPipeline
 
 **Identifiers:** `[a-zA-Z0-9][a-zA-Z0-9_\-./]*` — letters, digits, underscore, dash, dot, slash.
 
-**Contextual keywords** (not reserved — usable as node IDs): `workflow`, `agent`, `human`, `tool`, `subgraph`, `parallel`, `fan_in`, `edges`, `defaults`, `when`, `on`, `and`, `or`, `not`, `true`, `false`, `restart`, `loop`, `override`, `label`, `weight`.
+**Contextual keywords** (not reserved — usable as node IDs): `workflow`, `agent`, `human`, `tool`, `subgraph`, `parallel`, `fan_in`, `edges`, `defaults`, `inputs`, `vars`, `when`, `on`, `and`, `or`, `not`, `true`, `false`, `restart`, `loop`, `override`, `label`, `weight`.
 
 **Position-reserved keyword:** `else` is the one exception — it is reserved *only* as the first token of an `edges`-block line (where it introduces the section default), so it cannot be an edge *source* node ID there. Everywhere else `else` is an ordinary identifier and may be used as a node ID.
 
@@ -197,10 +203,10 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-64 diagnostic codes across two categories:
+67 diagnostic codes across two categories:
 
 - **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
-- **DIP101–DIP154** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges), human-gate choice key (label routes without explicit choice), edge weight (unused by routing), marker coverage (marker_grep enumerates a marker no edge routes), redundant parallel/fan_in edge (edges-block re-declaration of an inline fork; the inline list is authoritative), prompt-cascade opt-out no-op (prompt_prefix/suffix: none with no defaults cascade)
+- **DIP101–DIP157** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges), human-gate choice key (label routes without explicit choice), edge weight (unused by routing), marker coverage (marker_grep enumerates a marker no edge routes), redundant parallel/fan_in edge (edges-block re-declaration of an inline fork; the inline list is authoritative), prompt-cascade opt-out no-op (prompt_prefix/suffix: none with no defaults cascade), unknown input type (DIP155), reference to an undeclared input in a prompt or edge condition (DIP156), `${inputs.x}` inside a tool `command:` which never interpolates (DIP157). DIP155–DIP157 are error-severity — they cause `dippin lint` and `dippin check` to exit non-zero.
 
 ---
 
@@ -228,7 +234,7 @@ workflow <Name>
     <edge declarations>
 ```
 
-Five sections in order: **header** (workflow name, goal, optional `requires`, start, exit) → **defaults** (optional) → **inputs** (optional) → **nodes** (any order) → **edges** (optional). `defaults`, `inputs`, and `edges` are bare keywords — no colon after them. `requires:` is a comma-separated list of environmental dependencies (e.g. `git, docker, jq`); semantics live in downstream consumers and unknown entries are accepted without a parser diagnostic.
+Sections in canonical order: **header** (workflow name, goal, optional `requires`, start, exit) → **inputs** (optional) → **defaults** (optional) → **vars** (optional) → **nodes** (any order) → **stylesheet** (optional) → **edges** (optional). `inputs`, `defaults`, `vars`, and `edges` are bare keywords — no colon after them. `requires:` is a comma-separated list of environmental dependencies (e.g. `git, docker, jq`); semantics live in downstream consumers and unknown entries are accepted without a parser diagnostic.
 
 `inputs` declares the workflow's callee-side signature: entries are `name: type` (types: `text`, `number`, `bool`, `enum`, `file`, `secret`) with an optional indented block of attributes (`required`, `prompt`, `description`, `default`, `options`, `pattern`, `min`, `max`, `max_length`, `multiline`). Declaration order is significant and never reordered by the formatter. Reference a declared input as `${inputs.name}` in a prompt — never inside a tool `command:`, which never interpolates it (DIP157); an undeclared reference is DIP156, and an unrecognized type is DIP155.
 

--- a/cost/cost_test.go
+++ b/cost/cost_test.go
@@ -525,3 +525,33 @@ func TestLookupPriceDottedDashedEquivalence(t *testing.T) {
 		t.Error("unknown model must not resolve")
 	}
 }
+
+// TestNewFrontierProvidersPriced covers #189: current frontier models across
+// all providers — including the new zai/moonshot/minimax providers — must
+// resolve to a non-zero price. Guards against the "unknown model → $0" gap.
+func TestNewFrontierProvidersPriced(t *testing.T) {
+	p := DefaultPricing()
+	cases := []struct{ provider, model string }{
+		{"anthropic", "claude-opus-5"},
+		{"anthropic", "claude-sonnet-5"},
+		{"openai", "gpt-5.6-sol"},
+		{"openai", "gpt-5.6-terra"},
+		{"gemini", "gemini-3.6-flash"},
+		{"xai", "grok-4.5"},
+		{"grok", "grok-4.5"},
+		{"zai", "glm-5.2"},
+		{"moonshot", "kimi-k3"},
+		{"kimi", "kimi-k3"},
+		{"minimax", "MiniMax-M3"},
+	}
+	for _, c := range cases {
+		price, ok := lookupPrice(c.provider, c.model, p)
+		if !ok {
+			t.Errorf("%s/%s not in pricing table", c.provider, c.model)
+			continue
+		}
+		if price.InputPer1M <= 0 || price.OutputPer1M <= 0 {
+			t.Errorf("%s/%s priced at %+v, want non-zero", c.provider, c.model, price)
+		}
+	}
+}

--- a/cost/pricing.go
+++ b/cost/pricing.go
@@ -2,18 +2,24 @@ package cost
 
 // DefaultPricing returns a PricingTable with current model prices (USD per 1M tokens).
 //
-// Last verified: 2026-06-10
+// Last verified: 2026-06-10 for the original providers; the rows dated
+// "verified 2026-08-07" in inline comments (Claude 5, GPT-5.6, Gemini 3.5/3.6,
+// grok-4.5/grok-build, and the zai/moonshot/minimax providers) were confirmed
+// against official docs on that date. DeepSeek, Mistral, and Cohere were NOT
+// re-verified on 2026-08-07 — their 2026-06-10 values stand.
 //
 // Sources:
 //
-//	Anthropic:  https://platform.claude.com/docs/en/docs/about-claude/pricing
+//	Anthropic:  https://platform.claude.com/docs/en/about-claude/models/overview
 //	Google:     https://ai.google.dev/gemini-api/docs/pricing
-//	OpenAI:     https://developers.openai.com/api/docs/models/all
+//	OpenAI:     https://developers.openai.com/api/docs/pricing
 //	DeepSeek:   https://api-docs.deepseek.com/quick_start/pricing
-//	xAI (Grok): https://docs.x.ai/developers/models
-//	            https://docs.x.ai/developers/migration/may-15-retirement
+//	xAI (Grok): https://docs.x.ai/docs/models
 //	Mistral:    https://docs.mistral.ai/getting-started/models/models_overview/
 //	Cohere:     https://docs.cohere.com/docs/models
+//	Z.AI (GLM): https://docs.z.ai/guides/overview/pricing
+//	Moonshot:   https://platform.kimi.ai/docs/pricing/chat-k3
+//	MiniMax:    https://platform.minimax.io/docs/guides/pricing-paygo
 //
 // Notes on uncertainty (carried across this verification pass):
 //   - Mistral nemo and mistral-small-2603: Mistral's official pricing tab is
@@ -33,7 +39,16 @@ func DefaultPricing() PricingTable {
 	gemini := geminiPricing()
 	grok := grokPricing()
 	return PricingTable{
+		"zai":      zaiPricing(),
+		"moonshot": moonshotPricing(),
+		"kimi":     moonshotPricing(),
+		"minimax":  minimaxPricing(),
 		"anthropic": {
+			// Claude 5 line (verified 2026-08-07, platform.claude.com models
+			// overview). sonnet-5 durable list price is $3/$15; an introductory
+			// $2/$10 rate applies through 2026-08-31 — the durable rate is modeled.
+			"claude-opus-5":     {InputPer1M: 5.00, OutputPer1M: 25.00},
+			"claude-sonnet-5":   {InputPer1M: 3.00, OutputPer1M: 15.00},
 			"claude-opus-4-8":   {InputPer1M: 5.00, OutputPer1M: 25.00},
 			"claude-opus-4-7":   {InputPer1M: 5.00, OutputPer1M: 25.00},
 			"claude-opus-4-6":   {InputPer1M: 5.00, OutputPer1M: 25.00},
@@ -54,6 +69,10 @@ func DefaultPricing() PricingTable {
 			"claude-haiku-3-5": {InputPer1M: 0.80, OutputPer1M: 4.00},
 		},
 		"openai": {
+			// GPT-5.6 line (verified 2026-08-07, developers.openai.com/api/docs/pricing).
+			"gpt-5.6-sol":   {InputPer1M: 5.00, OutputPer1M: 30.00},
+			"gpt-5.6-terra": {InputPer1M: 2.00, OutputPer1M: 12.00},
+			"gpt-5.6-luna":  {InputPer1M: 0.20, OutputPer1M: 1.20},
 			// Current frontier.
 			"gpt-5.5":      {InputPer1M: 5.00, OutputPer1M: 30.00},
 			"gpt-5.5-pro":  {InputPer1M: 30.00, OutputPer1M: 180.00},
@@ -132,6 +151,10 @@ func DefaultPricing() PricingTable {
 // runtime actually bills for workflows that still reference them.
 func grokPricing() map[string]ModelPrice {
 	return map[string]ModelPrice{
+		// Verified 2026-08-07 (docs.x.ai/docs/models); base tier only —
+		// grok-4.5 is $4/$12 for prompts ≥200k tokens.
+		"grok-4.5":                     {InputPer1M: 2.00, OutputPer1M: 6.00},
+		"grok-build-0.1":               {InputPer1M: 1.00, OutputPer1M: 2.00},
 		"grok-4.3":                     {InputPer1M: 1.25, OutputPer1M: 2.50},
 		"grok-4.20-0309-reasoning":     {InputPer1M: 1.25, OutputPer1M: 2.50},
 		"grok-4.20-0309-non-reasoning": {InputPer1M: 1.25, OutputPer1M: 2.50},
@@ -148,6 +171,10 @@ func grokPricing() map[string]ModelPrice {
 // >200K tokens; this table reflects the base tier only.
 func geminiPricing() map[string]ModelPrice {
 	return map[string]ModelPrice{
+		// Gemini 3.5/3.6 flash line (verified 2026-08-07, ai.google.dev/gemini-api/docs/pricing).
+		"gemini-3.6-flash":                   {InputPer1M: 1.50, OutputPer1M: 7.50},
+		"gemini-3.5-flash":                   {InputPer1M: 1.50, OutputPer1M: 9.00},
+		"gemini-3.5-flash-lite":              {InputPer1M: 0.30, OutputPer1M: 2.50},
 		"gemini-3.1-pro-preview":             {InputPer1M: 2.00, OutputPer1M: 12.00},
 		"gemini-3.1-pro-preview-customtools": {InputPer1M: 2.00, OutputPer1M: 12.00},
 		"gemini-3-flash-preview":             {InputPer1M: 0.50, OutputPer1M: 3.00},
@@ -158,5 +185,54 @@ func geminiPricing() map[string]ModelPrice {
 		"gemini-2.5-flash-lite":              {InputPer1M: 0.10, OutputPer1M: 0.40},
 		// Deprecated, shuts down 2026-06-01.
 		"gemini-2.0-flash": {InputPer1M: 0.10, OutputPer1M: 0.40},
+	}
+}
+
+// zaiPricing returns pricing for Z.AI GLM models.
+//
+// Verified 2026-08-07 against https://docs.z.ai/guides/overview/pricing.
+// Base list prices only (cached-input tiers are out of dippin's schema).
+// glm-4.7-flash / glm-4.5-flash are free tiers and are omitted (a $0 row is
+// indistinguishable from an unknown-model miss in cost output).
+func zaiPricing() map[string]ModelPrice {
+	return map[string]ModelPrice{
+		"glm-5.2":        {InputPer1M: 1.40, OutputPer1M: 4.40},
+		"glm-5.1":        {InputPer1M: 1.40, OutputPer1M: 4.40},
+		"glm-5":          {InputPer1M: 1.00, OutputPer1M: 3.20},
+		"glm-5-turbo":    {InputPer1M: 1.20, OutputPer1M: 4.00},
+		"glm-4.7":        {InputPer1M: 0.60, OutputPer1M: 2.20},
+		"glm-4.7-flashx": {InputPer1M: 0.07, OutputPer1M: 0.40},
+		"glm-4.6":        {InputPer1M: 0.60, OutputPer1M: 2.20},
+		"glm-4.5":        {InputPer1M: 0.60, OutputPer1M: 2.20},
+		"glm-4.5-x":      {InputPer1M: 2.20, OutputPer1M: 8.90},
+		"glm-4.5-air":    {InputPer1M: 0.20, OutputPer1M: 1.10},
+		"glm-4.5-airx":   {InputPer1M: 1.10, OutputPer1M: 4.50},
+	}
+}
+
+// moonshotPricing returns pricing for Moonshot AI (Kimi) models. Aliased under
+// both the "moonshot" and "kimi" provider keys.
+//
+// Verified 2026-08-07 against https://platform.kimi.ai/docs/pricing/chat-k3.
+// Input is the cache-miss rate (cache-hit tiers are out of dippin's schema).
+func moonshotPricing() map[string]ModelPrice {
+	return map[string]ModelPrice{
+		"kimi-k3": {InputPer1M: 3.00, OutputPer1M: 15.00},
+	}
+}
+
+// minimaxPricing returns pricing for MiniMax models.
+//
+// Verified 2026-08-07 against https://platform.minimax.io/docs/guides/pricing-paygo.
+// Base tier only — MiniMax-M3 is $0.60/$2.40 for prompts >512k tokens. The
+// published rates already reflect MiniMax's standing "permanent 50% off".
+func minimaxPricing() map[string]ModelPrice {
+	return map[string]ModelPrice{
+		"MiniMax-M3":             {InputPer1M: 0.30, OutputPer1M: 1.20},
+		"MiniMax-M2.7":           {InputPer1M: 0.30, OutputPer1M: 1.20},
+		"MiniMax-M2.7-highspeed": {InputPer1M: 0.60, OutputPer1M: 2.40},
+		"MiniMax-M2.5":           {InputPer1M: 0.30, OutputPer1M: 1.20},
+		"MiniMax-M2.1":           {InputPer1M: 0.30, OutputPer1M: 1.20},
+		"MiniMax-M2":             {InputPer1M: 0.30, OutputPer1M: 1.20},
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ dippin-lang/
 │
 ├── validator/          # Graph validation + semantic linting
 │   ├── codes.go        # Error code constants (DIP001–DIP010)
-│   ├── lint_codes.go   # Warning code constants (DIP101–DIP154)
+│   ├── lint_codes.go   # Warning code constants (DIP101–DIP157)
 │   ├── diagnostic.go   # Diagnostic type, Result, Severity
 │   ├── validate.go     # 10 structural checks
 │   ├── lint.go         # Lint orchestration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,7 +124,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 
 ### lint
 
-Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP154).
+Run both structural validation and semantic linting (DIP001–DIP010 + DIP101–DIP157).
 
 ```bash
 dippin lint [--extra-models <spec>] <file>
@@ -132,7 +132,7 @@ dippin lint [--extra-models <spec>] <file>
 
 **Input**: `.dip` or `.dot` file
 
-**Checks**: All 64 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP154) are reported but don't affect the exit code.
+**Checks**: All 67 diagnostic rules. Errors (DIP001–DIP010) cause exit code 1. Warnings (DIP101–DIP157) are reported but don't affect the exit code.
 
 **Output**: All diagnostics (errors and warnings) to stderr.
 

--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -18,7 +18,7 @@ This starts the server on stdio (stdin/stdout), speaking JSON-RPC 2.0 per the LS
 
 | Feature | Description |
 |---------|-------------|
-| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP154 semantic) |
+| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001–DIP010 structural, DIP101–DIP157 semantic) |
 | **Hover** | Tooltip showing node kind, model, provider, prompt preview, and field summary |
 | **Go-to-definition** | Jump from a node reference in an edge to the node's declaration |
 | **Autocomplete** | Node IDs in edges, field names within node blocks, keywords |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -111,7 +111,7 @@ if result.HasErrors() {
     }
 }
 
-// Semantic lint (DIP101–DIP154; DIP146 is CLI/cross-file only) — warnings
+// Semantic lint (DIP101–DIP157; DIP146 is CLI/cross-file only) — warnings
 lintResult := validator.Lint(workflow)
 for _, d := range lintResult.Diagnostics {
     fmt.Println(d.String())

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -13,6 +13,12 @@ workflow <Name>
   start: <NodeID>
   exit: <NodeID>
 
+  [inputs
+    <name>: <text|number|bool|enum|file|secret>
+      [required: true] [default: <value>] [prompt: "<text>"] [description: "<text>"]
+      [options: <a>, <b>] [pattern: "<regex>"] [min: <n>] [max: <n>] [max_length: <int>] [multiline: true]
+    ...]
+
   [defaults
     model: <string>
     provider: <string>
@@ -75,7 +81,7 @@ on <token>                       # sugar: equality vs the source node's outcome 
 
 **`on <token>` shorthand:** desugars to `when <channel> = <token>`, where the channel is the source node's natural outcome channel — `ctx.outcome` for agent nodes, `ctx.tool_marker` for tool nodes with `marker_grep`. IR-identical to the equivalent `when`; `dippin fmt` rewrites eligible `when` edges to `on`. The value must be a single bare identifier (`[A-Za-z0-9][A-Za-z0-9_-]*`); quoted, multi-token, or any other values require an explicit `when <channel> = ...`. Source nodes with no outcome channel must use `when`: human gates (which route on the choice/label, not `ctx.outcome`), `conditional` nodes, and tools without `marker_grep`.
 
-**Variables:** Always namespace-qualified: `ctx.outcome`, `ctx.status`, `graph.goal`
+**Variables:** Always namespace-qualified: `ctx.outcome`, `ctx.status`, `graph.goal`, `params.*` (subgraph params), `inputs.*` (declared workflow inputs — a closed namespace; an undeclared reference is DIP156)
 
 ---
 
@@ -155,7 +161,7 @@ workflow ReviewPipeline
 
 **Identifiers:** `[a-zA-Z0-9][a-zA-Z0-9_\-./]*` — letters, digits, underscore, dash, dot, slash.
 
-**Contextual keywords** (not reserved — usable as node IDs): `workflow`, `agent`, `human`, `tool`, `subgraph`, `parallel`, `fan_in`, `edges`, `defaults`, `when`, `on`, `and`, `or`, `not`, `true`, `false`, `restart`, `loop`, `override`, `label`, `weight`.
+**Contextual keywords** (not reserved — usable as node IDs): `workflow`, `agent`, `human`, `tool`, `subgraph`, `parallel`, `fan_in`, `edges`, `defaults`, `inputs`, `vars`, `when`, `on`, `and`, `or`, `not`, `true`, `false`, `restart`, `loop`, `override`, `label`, `weight`.
 
 **Position-reserved keyword:** `else` is the one exception — it is reserved *only* as the first token of an `edges`-block line (where it introduces the section default), so it cannot be an edge *source* node ID there. Everywhere else `else` is an ordinary identifier and may be used as a node ID.
 
@@ -195,7 +201,7 @@ Workflow: author and lint as `.dip`; package with `dippin pack` for distribution
 
 ## Diagnostic Code Summary
 
-64 diagnostic codes across two categories:
+67 diagnostic codes across two categories:
 
 - **DIP001–DIP010** (errors): start/exit missing, unknown refs, unreachable nodes, cycles, duplicates, parallel/fan_in mismatch, unparseable edge conditions
-- **DIP101–DIP154** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges), human-gate choice key (label routes without explicit choice), edge weight (unused by routing), marker coverage (marker_grep enumerates a marker no edge routes), redundant parallel/fan_in edge (edges-block re-declaration of an inline fork; the inline list is authoritative), prompt-cascade opt-out no-op (prompt_prefix/suffix: none with no defaults cascade)
+- **DIP101–DIP157** (warnings): conditional reachability, missing defaults, overlapping conditions, unbounded retries, undefined variables, unknown models, empty prompts, missing timeouts, invalid policy/fidelity/reasoning_effort, stylesheet refs, namespace prefixes, condition type checking, structured output validation, manager_loop checks, tool-access safety, writable-paths safety, subgraph tool_access boundary, agent failure route, negative budget defaults, cross-file subgraph tool_access, restricted→tool-bearing info-flow (chain-attack), negative last_response_truncate, ambiguous routing (multiple unconditional edges), human-gate choice key (label routes without explicit choice), edge weight (unused by routing), marker coverage (marker_grep enumerates a marker no edge routes), redundant parallel/fan_in edge (edges-block re-declaration of an inline fork; the inline list is authoritative), prompt-cascade opt-out no-op (prompt_prefix/suffix: none with no defaults cascade), unknown input type (DIP155), reference to an undeclared input in a prompt or edge condition (DIP156), `${inputs.x}` inside a tool `command:` which never interpolates (DIP157). DIP155–DIP157 are error-severity — they cause `dippin lint` and `dippin check` to exit non-zero.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,9 +1,9 @@
 # Validation and Linting Reference
 
-Dippin registers 64 diagnostic codes split into two categories; this page gives a dedicated section to every code except `DIP138`, which is reserved and has no firing logic (63 documented sections):
+Dippin registers 67 diagnostic codes split into two categories; this page gives a dedicated section to every code except `DIP138`, which is reserved and has no firing logic (66 documented sections):
 
 - **Structural validation** (DIP001–DIP010): Errors that **must** be fixed. A workflow with any of these cannot execute.
-- **Semantic linting** (DIP101–DIP154): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
+- **Semantic linting** (DIP101–DIP157): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed.
 
 Run `dippin validate <file>` for structural checks only, or `dippin lint <file>` for both.
 
@@ -12,7 +12,7 @@ graph LR
     SRC[".dip file"] --> PARSE["Parser"]
     PARSE --> IR["IR"]
     IR --> VAL["Structural Validation<br>DIP001–DIP010<br>(errors)"]
-    IR --> LINT["Semantic Linting<br>DIP101–DIP154<br>(warnings)"]
+    IR --> LINT["Semantic Linting<br>DIP101–DIP157<br>(warnings)"]
     VAL --> DIAG["Diagnostics"]
     LINT --> DIAG
 ```
@@ -248,7 +248,7 @@ lints (DIP103/DIP120/DIP121/DIP122), so one bad condition no longer masks the re
 
 ---
 
-## Semantic Lint Warnings (DIP101–DIP154)
+## Semantic Lint Warnings (DIP101–DIP157)
 
 ### DIP101: Node Only Reachable via Conditional Edges
 
@@ -1512,7 +1512,7 @@ Runs DIP001–DIP010. Exit code 0 if all pass, 1 if any errors.
 dippin lint pipeline.dip
 ```
 
-Runs all DIP001–DIP010 errors and DIP101–DIP154 warnings. Exit code 1 only for errors; warnings alone exit 0.
+Runs all DIP001–DIP010 errors and DIP101–DIP157 warnings. Exit code 1 only for errors; warnings alone exit 0.
 
 ### JSON output for CI
 

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -68,7 +68,7 @@ dippin-lang/
 │
 ├── validator/          # Graph validation + semantic linting
 │   ├── validate.go     # 10 structural checks (DIP001-DIP010)
-│   ├── lint.go         # Lint orchestration (DIP101-DIP154)
+│   ├── lint.go         # Lint orchestration (DIP101-DIP157)
 │   └── diagnostic.go   # Diagnostic type, Result, Severity
 │
 ├── formatter/          # Canonical .dip source formatter
@@ -103,7 +103,7 @@ dippin-lang/
   </div>
   <div class="decision-card">
     <h4>No short-circuiting validation</h4>
-    <p>All 10 structural checks and all 54 semantic checks run unconditionally. A single call reports every issue, not just the first. This enables batch fixing.</p>
+    <p>All 10 structural checks and all 57 semantic checks run unconditionally. A single call reports every issue, not just the first. This enables batch fixing.</p>
   </div>
   <div class="decision-card">
     <h4>Zero external dependencies</h4>

--- a/site/content/blog/editor-setup.md
+++ b/site/content/blog/editor-setup.md
@@ -39,7 +39,7 @@ Any editor with LSP support can connect.<sup>1</sup>
 <div class="feature-grid">
   <div class="feature-item">
     <h4>Diagnostics</h4>
-    <p>Parse errors and every lint diagnostic on every keystroke — DIP001-DIP010 structural, DIP101-DIP152 semantic (62 codes). Same checks as <code>dippin lint</code>.</p>
+    <p>Parse errors and every lint diagnostic on every keystroke — DIP001-DIP010 structural, DIP101-DIP157 semantic (67 codes). Same checks as <code>dippin lint</code>.</p>
   </div>
   <div class="feature-item">
     <h4>Hover</h4>

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -56,7 +56,7 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 <div class="cmd-card">
   <h3>lint</h3>
   <div class="cmd-usage">dippin lint [--extra-models &lt;spec&gt;] &lt;file&gt;</div>
-  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP154). All 64 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
+  <p>Run both structural validation and semantic linting (DIP001-DIP010 + DIP101-DIP157). All 67 diagnostic rules. Errors cause exit code 1; warnings alone exit 0.</p>
   <dl>
     <dt><code>--extra-models "provider:model1,model2;provider2:model3"</code></dt>
     <dd>Extend the DIP108 model catalog at runtime for private or newly-released models.</dd>

--- a/site/content/editors.md
+++ b/site/content/editors.md
@@ -11,7 +11,7 @@ The built-in LSP server (`dippin lsp`) provides rich editing features for any LS
 
 | Feature | Description |
 |---------|-------------|
-| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001-DIP010 structural, DIP101-DIP154 semantic) |
+| **Diagnostics** | Parse errors and lint warnings published on every change (DIP001-DIP010 structural, DIP101-DIP157 semantic) |
 | **Hover** | Tooltip showing node kind and a per-kind field summary — model/provider for agents, command for tools, mode for human gates |
 | **Go-to-definition** | Jump from a node reference in an edge to the node's declaration |
 | **Autocomplete** | Node IDs in edges and field names within node blocks |

--- a/site/content/glossary.md
+++ b/site/content/glossary.md
@@ -61,7 +61,7 @@ subtitle: "Terms you'll encounter authoring .dip files and using the dippin tool
 
 ## Diagnostics
 
-**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP010 are structural errors (parse / shape failures). DIP101–DIP154 are semantic warnings (style, correctness hints, model catalog issues).
+**DIP code** — A diagnostic identifier emitted by `dippin lint` and `dippin validate`. DIP001–DIP010 are structural errors (parse / shape failures). DIP101–DIP157 are semantic warnings (style, correctness hints, model catalog issues).
 
 **Exhaustive conditions** — A pair of edge conditions detected as covering all outcomes (e.g., `when ctx.status = success` + `when ctx.status = fail`). Suppresses DIP101 / DIP102 warnings.
 

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -1,8 +1,8 @@
 ---
 title: "Validation & Linting"
-description: "64 diagnostic codes for AI pipeline workflows. 10 structural errors and 54 semantic warnings catch bugs before runtime."
+description: "67 diagnostic codes for AI pipeline workflows. 10 structural errors and 57 semantic checks catch bugs before runtime."
 section_label: "Diagnostics"
-subtitle: "64 diagnostic codes — 10 structural errors and 54 semantic warnings — to catch problems before runtime."
+subtitle: "67 diagnostic codes — 10 structural errors and 57 semantic checks — to catch problems before runtime."
 ---
 
 ## Overview
@@ -11,7 +11,7 @@ Dippin provides two levels of analysis:
 
 **Structural validation** (DIP001-DIP010): Errors that must be fixed. A workflow with any of these cannot execute. Run with `dippin validate`.
 
-**Semantic linting** (DIP101-DIP154): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
+**Semantic linting** (DIP101-DIP157): Warnings that flag likely bugs or questionable patterns. They don't block execution but should be reviewed. Run with `dippin lint` for both levels.
 
 ### Diagnostic Format
 
@@ -107,7 +107,7 @@ These must be fixed for a workflow to be valid. Each causes exit code 1.
   = help: valid operators: = == != contains startswith endswith in</pre>
 </div>
 
-## Semantic Warnings (DIP101-DIP154)
+## Semantic Warnings (DIP101-DIP157)
 
 These flag likely bugs or questionable patterns. Warnings alone exit 0.
 
@@ -378,4 +378,4 @@ An agent sets `prompt_prefix: none` or `prompt_suffix: none` to opt out of the d
 hint[DIP154]: agent "A" sets prompt_suffix: none but no defaults prompt_suffix cascade is declared — the opt-out is a no-op
 ```
 
-> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP154) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.
+> **Full catalog:** This page highlights the most common diagnostics. For every code (DIP001–DIP010, DIP101–DIP157) with full descriptions, run `dippin explain <code>` or see the [generated language spec](https://github.com/2389-research/dippin-lang/blob/main/cmd/dippin/generated-spec.md). Codes DIP135–DIP142 are documented there.

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -41,7 +41,7 @@ workflow <Name>
     <edge declarations>
 ```
 
-Five sections in order: **header** (workflow name, goal, optional `requires`, start, exit) → **defaults** (optional) → **inputs** (optional) → **nodes** (any order) → **edges** (optional). `defaults`, `inputs`, and `edges` are bare keywords — no colon after them. `requires:` is a comma-separated list of environmental dependencies (e.g. `git, docker, jq`); semantics live in downstream consumers and unknown entries are accepted without a parser diagnostic.
+Sections in canonical order: **header** (workflow name, goal, optional `requires`, start, exit) → **inputs** (optional) → **defaults** (optional) → **vars** (optional) → **nodes** (any order) → **stylesheet** (optional) → **edges** (optional). `inputs`, `defaults`, `vars`, and `edges` are bare keywords — no colon after them. `requires:` is a comma-separated list of environmental dependencies (e.g. `git, docker, jq`); semantics live in downstream consumers and unknown entries are accepted without a parser diagnostic.
 
 `inputs` declares the workflow's callee-side signature: entries are `name: type` (types: `text`, `number`, `bool`, `enum`, `file`, `secret`) with an optional indented block of attributes (`required`, `prompt`, `description`, `default`, `options`, `pattern`, `min`, `max`, `max_length`, `multiline`). Declaration order is significant and never reordered by the formatter. Reference a declared input as `${inputs.name}` in a prompt — never inside a tool `command:`, which never interpolates it (DIP157); an undeclared reference is DIP156, and an unrecognized type is DIP155.
 

--- a/validator/lint_model.go
+++ b/validator/lint_model.go
@@ -26,6 +26,9 @@ import (
 //	Cohere:     https://docs.cohere.com/docs/models
 var knownModelProviders = map[string]map[string]bool{
 	"anthropic": {
+		// Claude 5 line (verified 2026-08-07, platform.claude.com models overview).
+		"claude-opus-5":     true,
+		"claude-sonnet-5":   true,
 		"claude-opus-4-8":   true,
 		"claude-opus-4-7":   true,
 		"claude-opus-4-6":   true,
@@ -52,6 +55,10 @@ var knownModelProviders = map[string]map[string]bool{
 	"google": geminiModels(),
 	"gemini": geminiModels(),
 	"openai": {
+		// GPT-5.6 line (verified 2026-08-07, developers.openai.com/api/docs/pricing).
+		"gpt-5.6-sol":   true,
+		"gpt-5.6-terra": true,
+		"gpt-5.6-luna":  true,
 		// Current frontier (May 2026).
 		"gpt-5.5":      true,
 		"gpt-5.5-pro":  true,
@@ -92,6 +99,20 @@ var knownModelProviders = map[string]map[string]bool{
 	},
 	"xai":  grokModels(),
 	"grok": grokModels(),
+	"zai":  zaiModels(),
+	// Moonshot AI (Kimi) — aliased under both provider keys.
+	"moonshot": moonshotModels(),
+	"kimi":     moonshotModels(),
+	"minimax":  minimaxModels(),
+	// Alibaba Qwen — recognized so DIP108 doesn't fire (IDs verified 2026-08-07,
+	// alibabacloud.com/help/en/model-studio/models). Not in the cost table: the
+	// international per-token USD pricing is console-gated and could not be
+	// verified from an official page (tracked in a follow-up).
+	"qwen": {
+		"qwen3.7-max":   true,
+		"qwen3.7-plus":  true,
+		"qwen3.6-flash": true,
+	},
 	"mistral": {
 		"mistral-large-3":         true,
 		"mistral-medium-3":        true,
@@ -123,6 +144,10 @@ var knownModelProviders = map[string]map[string]bool{
 // geminiModels returns the set of known Gemini model IDs.
 func geminiModels() map[string]bool {
 	return map[string]bool{
+		// Gemini 3.5/3.6 flash line (verified 2026-08-07, ai.google.dev/gemini-api/docs/pricing).
+		"gemini-3.6-flash":      true,
+		"gemini-3.5-flash":      true,
+		"gemini-3.5-flash-lite": true,
 		// Gemini 3.x
 		"gemini-3.1-pro-preview":             true,
 		"gemini-3.1-pro-preview-customtools": true,
@@ -138,6 +163,48 @@ func geminiModels() map[string]bool {
 	}
 }
 
+// zaiModels returns the set of known Z.AI GLM model IDs (verified 2026-08-07,
+// docs.z.ai/guides/overview/pricing). Includes the free-tier flash models, which
+// are recognized here even though they carry no cost-table row.
+func zaiModels() map[string]bool {
+	return map[string]bool{
+		"glm-5.2":        true,
+		"glm-5.1":        true,
+		"glm-5":          true,
+		"glm-5-turbo":    true,
+		"glm-4.7":        true,
+		"glm-4.7-flashx": true,
+		"glm-4.7-flash":  true,
+		"glm-4.6":        true,
+		"glm-4.5":        true,
+		"glm-4.5-x":      true,
+		"glm-4.5-air":    true,
+		"glm-4.5-airx":   true,
+		"glm-4.5-flash":  true,
+	}
+}
+
+// moonshotModels returns the set of known Moonshot AI (Kimi) model IDs (verified
+// 2026-08-07, platform.kimi.ai/docs/pricing).
+func moonshotModels() map[string]bool {
+	return map[string]bool{
+		"kimi-k3": true,
+	}
+}
+
+// minimaxModels returns the set of known MiniMax model IDs (verified 2026-08-07,
+// platform.minimax.io/docs/guides/pricing-paygo).
+func minimaxModels() map[string]bool {
+	return map[string]bool{
+		"MiniMax-M3":             true,
+		"MiniMax-M2.7":           true,
+		"MiniMax-M2.7-highspeed": true,
+		"MiniMax-M2.5":           true,
+		"MiniMax-M2.1":           true,
+		"MiniMax-M2":             true,
+	}
+}
+
 // grokModels returns the set of known xAI Grok model IDs.
 //
 // grok-4-1-fast-reasoning and grok-4-1-fast-non-reasoning were retired
@@ -148,6 +215,9 @@ func geminiModels() map[string]bool {
 // "deprecated alias" diagnostic can replace this comment.
 func grokModels() map[string]bool {
 	return map[string]bool{
+		// Verified 2026-08-07 (docs.x.ai/docs/models).
+		"grok-4.5":                     true,
+		"grok-build-0.1":               true,
 		"grok-4.3":                     true, // Current flagship (Apr 2026).
 		"grok-4.20-0309-reasoning":     true,
 		"grok-4.20-0309-non-reasoning": true,

--- a/validator/lint_model_test.go
+++ b/validator/lint_model_test.go
@@ -72,3 +72,37 @@ func TestLintDIP108DottedAnthropicID(t *testing.T) {
 		t.Errorf("genuinely unknown dotted model must still trip DIP108: %v", codes(diags))
 	}
 }
+
+// TestDIP108FrontierCatalog covers #189: current frontier models across every
+// provider (incl. the new zai/moonshot/minimax/qwen providers) must be
+// recognized so they don't trip a spurious DIP108.
+func TestDIP108FrontierCatalog(t *testing.T) {
+	cases := []struct{ provider, model string }{
+		{"anthropic", "claude-opus-5"},
+		{"anthropic", "claude-sonnet-5"},
+		{"openai", "gpt-5.6-sol"},
+		{"gemini", "gemini-3.6-flash"},
+		{"xai", "grok-4.5"},
+		{"zai", "glm-5.2"},
+		{"moonshot", "kimi-k3"},
+		{"minimax", "MiniMax-M3"},
+		{"qwen", "qwen3.7-max"},
+	}
+	for _, c := range cases {
+		src := fmt.Sprintf(`workflow w
+  start: A
+  exit: A
+
+  agent A
+    provider: %s
+    model: %s
+    prompt: go
+
+  edges
+    A -> A
+`, c.provider, c.model)
+		if diags := lintSrc(t, src); hasCode(diags, DIP108) {
+			t.Errorf("%s/%s tripped DIP108 (should be known): %v", c.provider, c.model, codes(diags))
+		}
+	}
+}


### PR DESCRIPTION
Fixes #189 (expanded).

## Frontier pricing + catalog refresh

Current frontier models were absent from the tables, so `dippin cost` reported **$0** and `dippin lint` fired spurious **DIP108**. Added, each **verified against official provider docs on 2026-08-07** (source URLs recorded inline in `cost/pricing.go`):

| Provider | Added | in/out $ per MTok |
|---|---|---|
| Anthropic | `claude-opus-5`, `claude-sonnet-5` | 5/25, 3/15 (durable; intro 2/10 to 2026-08-31) |
| OpenAI | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | 5/30, 2/12, 0.20/1.20 |
| Gemini | `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite` | 1.50/7.50, 1.50/9, 0.30/2.50 |
| xAI | `grok-4.5`, `grok-build-0.1` | 2/6 (base), 1/2 |
| **Z.AI/GLM** (new) | glm-5.2/5.1/5/5-turbo/4.7/4.7-flashx/4.6/4.5/4.5-x/4.5-air/4.5-airx | e.g. glm-5.2 1.40/4.40 |
| **Moonshot/Kimi** (new) | `kimi-k3` | 3/15 (cache-miss) |
| **MiniMax** (new) | MiniMax-M3/M2.7/M2.7-highspeed/M2.5/M2.1/M2 | 0.30/1.20 base |

Base-tier list prices only (large-prompt and cache tiers are out of dippin's schema). Each new provider is mirrored into both the cost table and the validator known-models catalog.

**Qwen** (`qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-flash`) is added to the **linter catalog only** — its international per-token USD pricing is console-gated and I could not verify it from an official page, so it no longer trips DIP108 but has no cost row yet. Follow-up needed.

**Honesty note on provenance:** DeepSeek, Mistral, and Cohere were **not** re-verified today — their 2026-06-10 values stand, and the header comment says so explicitly rather than falsely bumping the global "Last verified" date.

## Docs / website sync to current code

Per the "keep docs current" rule, swept the living docs + site:
- Diagnostic counts/ranges → **67 codes (DIP001–DIP010, DIP101–DIP157)** across `CLAUDE.md`, `AGENTS.md`, `README.md`, `docs/`, and `site/content/` (they variously said 62/64 codes, DIP101–DIP152/154).
- Added the `inputs` block + `${inputs.*}` closed namespace + DIP155–157 to `docs/llm-reference.md` (which feeds the embedded `generated-spec.md`) — it had been missed in the v0.51.0 inputs sweep.
- Corrected `skill.md`'s canonical section order (**inputs → defaults → vars**; it wrongly said defaults → inputs, contradicting the formatter).
- Updated the supported-provider list.

Historical spec/plan/changelog docs and dated blog posts were left untouched (they're point-in-time records).

## Follow-up (separate PR, per design discussion)
Deterministic pricing tooling: a declarative manifest as the single source of truth that **generates** both the cost table and the known-models catalog (killing the two-file drift this PR had to maintain by hand), with provenance + a staleness checker.

## Verification
- New regression tests: every added frontier model prices non-zero and is DIP108-clean (incl. the new providers + Qwen recognition).
- `just test`, `just complexity`, `just validate-examples`, `just lint-examples` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788711960&installation_model_id=21126&pr_number=193&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F193&signature=72fb4d669741f114934a93c6dcf091830271086e68e8503ddf1fb6f9bf72a6c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workflow `inputs` syntax, namespaces, attributes, and validation.
  - Added recognition for Z.AI, Moonshot/Kimi, MiniMax, Qwen, and expanded frontier model catalogs.
  - Added pricing coverage for newly supported frontier models and providers.

- **Bug Fixes**
  - Expanded lint and validation diagnostics to 67 rules, including input-related errors.

- **Documentation**
  - Updated CLI, editor, integration, architecture, specification, and provider documentation to reflect current capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->