### PR TITLE
release: v0.52.0 — frontier model pricing + catalog refresh (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.52.0] — 2026-08-07
 
 ### Added
 - **Frontier model pricing + catalog refresh** ([#189](https://github.com/2389-research/dippin-lang/issues/189)). `dippin cost` reported **$0** and `dippin lint` fired spurious **DIP108** for a raft of current frontier models simply absent from the tables. Added, each verified against official provider docs on 2026-08-07 (source URLs recorded in `cost/pricing.go`): **Anthropic** `claude-opus-5` ($5/$25), `claude-sonnet-5` ($3/$15 durable; intro $2/$10 through 2026-08-31); **OpenAI** `gpt-5.6-sol` ($5/$30), `gpt-5.6-terra` ($2/$12), `gpt-5.6-luna` ($0.20/$1.20); **Gemini** `gemini-3.6-flash` ($1.50/$7.50), `gemini-3.5-flash` ($1.50/$9), `gemini-3.5-flash-lite` ($0.30/$2.50); **xAI** `grok-4.5` ($2/$6 base), `grok-build-0.1` ($1/$2). Plus three **new providers**: **Z.AI / GLM** (`zai` — glm-5.2/5.1/5/5-turbo/4.7/4.6/4.5 family), **Moonshot / Kimi** (`moonshot`+`kimi` — `kimi-k3` $3/$15), and **MiniMax** (`minimax` — MiniMax-M3/M2.7/M2.5/M2.1/M2). All base-tier list prices (large-prompt and cache tiers are out of dippin's schema).

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,15 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.52.0] — 2026-08-07
+
+### Added
+- **Frontier model pricing + catalog refresh** ([#189](https://github.com/2389-research/dippin-lang/issues/189)). `dippin cost` reported **$0** and `dippin lint` fired spurious **DIP108** for a raft of current frontier models simply absent from the tables. Added, each verified against official provider docs on 2026-08-07 (source URLs recorded in `cost/pricing.go`): **Anthropic** `claude-opus-5` ($5/$25), `claude-sonnet-5` ($3/$15 durable; intro $2/$10 through 2026-08-31); **OpenAI** `gpt-5.6-sol` ($5/$30), `gpt-5.6-terra` ($2/$12), `gpt-5.6-luna` ($0.20/$1.20); **Gemini** `gemini-3.6-flash` ($1.50/$7.50), `gemini-3.5-flash` ($1.50/$9), `gemini-3.5-flash-lite` ($0.30/$2.50); **xAI** `grok-4.5` ($2/$6 base), `grok-build-0.1` ($1/$2). Plus three **new providers**: **Z.AI / GLM** (`zai` — glm-5.2/5.1/5/5-turbo/4.7/4.6/4.5 family), **Moonshot / Kimi** (`moonshot`+`kimi` — `kimi-k3` $3/$15), and **MiniMax** (`minimax` — MiniMax-M3/M2.7/M2.5/M2.1/M2). All base-tier list prices (large-prompt and cache tiers are out of dippin's schema).
+- **Qwen recognized by the linter** (`qwen` — qwen3.7-max/plus, qwen3.6-flash). Its international per-token USD pricing is console-gated and could not be verified from an official page, so Qwen is in the model catalog (no more DIP108) but has **no cost-table row yet** — a follow-up.
+
+### Docs
+- Swept the living docs and website to current code: diagnostic-code counts and ranges corrected to **67 codes (DIP001–DIP010, DIP101–DIP157)** across `CLAUDE.md`, `AGENTS.md`, `README.md`, `docs/`, and `site/content/`; the `inputs` block and `${inputs.*}` namespace added to `docs/llm-reference.md` (feeds the embedded spec) with DIP155–DIP157; corrected the `skill.md` canonical section order (**inputs → defaults → vars**, not defaults → inputs); updated the supported-provider list.
+
 ## [v0.51.1] — 2026-08-07
 
 ### Fixed


### PR DESCRIPTION
Promotes the `[Unreleased]` changelog section to **v0.52.0**. Minor release (new providers + frontier models).

Contents (all merged via #193):
- Frontier pricing verified against official docs 2026-08-07: Claude 5 (opus-5/sonnet-5), GPT-5.6, Gemini 3.5/3.6, grok-4.5/grok-build.
- New providers: Z.AI/GLM, Moonshot/Kimi, MiniMax. Qwen recognized by the linter (unpriced — USD console-gated).
- Docs/site synced: 67 codes (DIP001–DIP010, DIP101–DIP157); `inputs` added to llm-reference; skill.md section order corrected.

Cutting the tag delivers this to pinned consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788712441&installation_model_id=21126&pr_number=194&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F194&signature=e5e0ec7cb9794547e40a2695dba561204dfa5f5617997e754e3b96e74af71cd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three additional providers.
  * Added recognition for Qwen models, even when pricing information is unavailable.
  * Updated the frontier model catalog and pricing details.

* **Documentation**
  * Synchronized documentation for diagnostic ranges, inputs, canonical section ordering, and supported providers.
  * Published the v0.52.0 release changelog dated August 7, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->