### PR TITLE
release: v0.53.0 — leaf pricing package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.53.0] — 2026-08-07
 
 ### Changed
 - **Single source of truth for model pricing + catalog: the new leaf `pricing` package.** Model prices lived in `cost/pricing.go` and were mirrored by hand in `validator/lint_model.go`'s DIP108 catalog (and again in tracker) — the exact drift trap #189 had to maintain by hand. Prices now live in one embedded data file, **`pricing/prices.json`**, loaded by a leaf `pricing` package (imports nothing from dippin) that exposes `ModelPrice`, a neutral `Usage`, one `Cost()` calc, and a total alias-resolving `Lookup()`. `cost.DefaultPricing()` projects the catalog (public API unchanged); `validator`'s DIP108 derives its known-model set from it (the hand-mirrored maps are deleted). Each entry carries a `source` URL + `as_of` date (provenance travels with the number), and a `"priced": false` flag marks known-but-unpriced models (e.g. Qwen). Purely internal — `dippin cost`/`lint` output is unchanged, verified by the existing price-assertion and `TestLintExamples` suites. Downstream consumers (tracker) can now import `github.com/2389-research/dippin-lang/pricing` directly instead of maintaining their own table. Phase 1 of the pricing-tooling design (`docs/superpowers/specs/2026-08-07-pricing-package-and-autosync-design.md`); the daily auto-sync via machine-readable aggregators follows.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.53.0] — 2026-08-07
+
+### Changed
+- **Single source of truth for model pricing + catalog: the new leaf `pricing` package.** Model prices lived in `cost/pricing.go` and were mirrored by hand in `validator/lint_model.go`'s DIP108 catalog (and again in tracker) — the exact drift trap #189 had to maintain by hand. Prices now live in one embedded data file, **`pricing/prices.json`**, loaded by a leaf `pricing` package (imports nothing from dippin) that exposes `ModelPrice`, a neutral `Usage`, one `Cost()` calc, and a total alias-resolving `Lookup()`. `cost.DefaultPricing()` projects the catalog (public API unchanged); `validator`'s DIP108 derives its known-model set from it (the hand-mirrored maps are deleted). Each entry carries a `source` URL + `as_of` date (provenance travels with the number), and a `"priced": false` flag marks known-but-unpriced models (e.g. Qwen). Purely internal — `dippin cost`/`lint` output is unchanged, verified by the existing price-assertion and `TestLintExamples` suites. Downstream consumers (tracker) can now import `github.com/2389-research/dippin-lang/pricing` directly instead of maintaining their own table. Phase 1 of the pricing-tooling design (`docs/superpowers/specs/2026-08-07-pricing-package-and-autosync-design.md`); the daily auto-sync via machine-readable aggregators follows.
+
 ## [v0.52.0] — 2026-08-07
 
 ### Added


### PR DESCRIPTION
Promotes changelog to v0.53.0. New public `pricing` package (single source of truth for models + prices); internal refactor, no behavior change. Tagging lets tracker import `github.com/2389-research/dippin-lang/pricing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788734829&installation_model_id=21126&pr_number=196&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F196&signature=796134973e70d5d184fc6d5188d2ee724c582ebb8d0df794ecb52892bb3c2b7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized model pricing and catalog data through the new pricing package.
  * Added support for model aliases, usage-based cost calculation, provenance metadata, and clear indicators for models without pricing.
  * Pricing and validator catalogs are now derived from a shared source while preserving existing command-line behavior.

* **Documentation**
  * Added the v0.53.0 changelog entry dated August 7, 2026, documenting the pricing improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->