### PR TITLE
feat: pricing staleness checker + models.dev sync tool (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Pricing staleness checker + assistive sync tool** (`cmd/pricing-sync`, Phase 2 of the pricing-tooling design). `just check-prices` reports catalog entries whose `as_of` is older than a freshness window (default 45 days) or missing a source, and exits non-zero — usable as a CI/pre-commit re-verification reminder (it currently flags the 2026-06-10 batch). `just sync-prices` fetches the machine-readable **models.dev** aggregator (JSON, no auth, no HTML scraping), diffs it against `pricing/prices.json`, and reports candidate changes — new models, price deltas (with a `--tolerance` to suppress small ones), and upstream deprecations. It is **report-only** and never edits the catalog: detection is mechanical, but authoritative verification is not (no provider publishes price as data), so a human confirms each candidate against its official `source`. The staleness logic lives in the `pricing` package (`StaleEntries`, pure/deterministic); the diff engine is pure and fixture-tested.
+
 ## [v0.53.0] — 2026-08-07
 
 ### Changed

--- a/Justfile
+++ b/Justfile
@@ -168,3 +168,11 @@ clean:
     rm -f dippin cover.out cover_filtered.out cover_check.out site/static/dippin.wasm site/static/wasm_exec.js
     rm -rf site/public
     @echo "Cleaned."
+
+# Report catalog entries overdue for price re-verification (as_of age)
+check-prices:
+    go run ./cmd/pricing-sync check
+
+# Diff the catalog against models.dev and report candidate changes (report-only)
+sync-prices:
+    go run ./cmd/pricing-sync sync

--- a/cmd/pricing-sync/check.go
+++ b/cmd/pricing-sync/check.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/2389-research/dippin-lang/pricing"
+)
+
+// runCheck prints the staleness report and exits non-zero if any entry is
+// overdue — so it can gate CI / pre-commit as a re-verification reminder.
+func runCheck(args []string) int {
+	fs := flag.NewFlagSet("check", flag.ContinueOnError)
+	days := fs.Int("max-age-days", maxAgeDays, "flag entries whose as_of is older than this")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	stale := pricing.StaleEntries(nowUTC(), time.Duration(*days)*24*time.Hour)
+	if len(stale) == 0 {
+		fmt.Printf("pricing: all entries verified within %d days\n", *days)
+		return 0
+	}
+	fmt.Printf("pricing: %d entr%s need re-verification (window %d days):\n",
+		len(stale), plural(len(stale)), *days)
+	for _, s := range stale {
+		fmt.Fprintf(os.Stdout, "  %-10s %-28s %s\n", s.Provider, s.Model, describeStale(s))
+	}
+	return 1
+}
+
+func describeStale(s pricing.Staleness) string {
+	switch s.Reason {
+	case "no-source":
+		return "no source URL"
+	case "bad-date":
+		return fmt.Sprintf("unparseable as_of %q", s.AsOf)
+	default:
+		return fmt.Sprintf("as_of %s (%d days old)", s.AsOf, s.AgeDays)
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}

--- a/cmd/pricing-sync/main.go
+++ b/cmd/pricing-sync/main.go
@@ -1,0 +1,50 @@
+// Command pricing-sync is the assistive tooling for keeping pricing/prices.json
+// current. It never edits the catalog itself — it reports.
+//
+//	pricing-sync check              staleness report (AsOf age / missing source)
+//	pricing-sync sync               diff the catalog against machine-readable
+//	                                aggregators (models.dev) and report candidates
+//
+// Detection is mechanical; authoritative verification is not (no provider
+// publishes price as data), so this prints proposals for a human to confirm
+// against each entry's official Source. See
+// docs/superpowers/specs/2026-08-07-pricing-package-and-autosync-design.md.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// stdOut is the report destination; a var so tests can capture output.
+var stdOut io.Writer = os.Stdout
+
+func printfOut(format string, a ...any) { fmt.Fprintf(stdOut, format, a...) }
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: pricing-sync <check|sync> [--max-age-days N]")
+		return 2
+	}
+	switch args[0] {
+	case "check":
+		return runCheck(args[1:])
+	case "sync":
+		return runSync(context.Background(), args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q (want check|sync)\n", args[0])
+		return 2
+	}
+}
+
+// maxAgeDays is the default freshness window before an entry is flagged stale.
+const maxAgeDays = 45
+
+func nowUTC() time.Time { return time.Now().UTC() }

--- a/cmd/pricing-sync/parse.go
+++ b/cmd/pricing-sync/parse.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+)
+
+// errOut is the destination for diagnostics; a var so tests can capture it.
+var errOut = os.Stderr
+
+// aggregatorProvider maps a models.dev provider id to our canonical provider
+// key. Only mapped providers yield candidates; unknown providers are skipped
+// (rather than proposing every model under an unrecognized provider as "new").
+var aggregatorProvider = map[string]string{
+	"anthropic":  "anthropic",
+	"openai":     "openai",
+	"google":     "gemini",
+	"google-ai":  "gemini",
+	"xai":        "grok",
+	"deepseek":   "deepseek",
+	"mistral":    "mistral",
+	"cohere":     "cohere",
+	"zhipuai":    "zai",
+	"zai":        "zai",
+	"z-ai":       "zai",
+	"moonshotai": "moonshot",
+	"moonshot":   "moonshot",
+	"minimax":    "minimax",
+	"alibaba":    "qwen",
+	"qwen":       "qwen",
+}
+
+// modelsDevModel is the per-model shape we consume from models.dev's api.json.
+// Extra fields are ignored; a schema drift yields fewer/no candidates (safe for
+// an assistive, report-only tool) rather than a corrupt catalog.
+type modelsDevModel struct {
+	ID   string `json:"id"`
+	Cost struct {
+		Input  float64 `json:"input"`
+		Output float64 `json:"output"`
+	} `json:"cost"`
+	Status string `json:"status"`
+}
+
+type modelsDevProvider struct {
+	Models map[string]modelsDevModel `json:"models"`
+}
+
+// parseModelsDev turns models.dev's api.json into normalized candidates for the
+// providers we recognize.
+func parseModelsDev(body []byte) ([]candidate, error) {
+	var raw map[string]modelsDevProvider
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	var out []candidate
+	for aggProv, node := range raw {
+		ours, ok := aggregatorProvider[aggProv]
+		if !ok {
+			continue
+		}
+		out = append(out, candidatesForProvider(ours, node)...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		return out[i].Model < out[j].Model
+	})
+	return out, nil
+}
+
+func candidatesForProvider(provider string, node modelsDevProvider) []candidate {
+	var out []candidate
+	for id, m := range node.Models {
+		modelID := m.ID
+		if modelID == "" {
+			modelID = id
+		}
+		out = append(out, candidate{
+			Provider:   provider,
+			Model:      modelID,
+			InputPerM:  m.Cost.Input,
+			OutputPerM: m.Cost.Output,
+			Deprecated: m.Status == "deprecated",
+		})
+	}
+	return out
+}
+
+// printChanges renders the sync report.
+func printChanges(changes []change, scanned int) {
+	if len(changes) == 0 {
+		printfOut("pricing-sync: catalog agrees with models.dev across %d scanned models\n", scanned)
+		return
+	}
+	printfOut("pricing-sync: %d candidate change(s) from models.dev (%d models scanned) — confirm against each official source before editing prices.json:\n", len(changes), scanned)
+	for _, c := range changes {
+		printfOut("  [%-10s] %-10s %-28s %s\n", c.Kind, c.Provider, c.Model, c.Detail)
+	}
+}

--- a/cmd/pricing-sync/sync.go
+++ b/cmd/pricing-sync/sync.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/2389-research/dippin-lang/pricing"
+)
+
+// candidate is one model+price as reported by an aggregator, normalized to our
+// per-1M-token convention.
+type candidate struct {
+	Provider   string
+	Model      string
+	InputPerM  float64
+	OutputPerM float64
+	Deprecated bool
+}
+
+// change is a proposed catalog edit for a human to confirm against the official source.
+type change struct {
+	Kind     string // "new" | "price" | "deprecated"
+	Provider string
+	Model    string
+	Detail   string
+}
+
+// runSync fetches machine-readable aggregators, diffs against the embedded
+// catalog, and prints candidate changes. It never writes prices.json — the
+// aggregators drive detection, not authority.
+func runSync(ctx context.Context, args []string) int {
+	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
+	tol := fs.Float64("tolerance", 0.0, "ignore price deltas at or below this fraction (e.g. 0.05 = 5%)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	cands, err := modelsDevFetcher{}.Fetch(ctx)
+	if err != nil {
+		fmt.Fprintf(errOut, "pricing-sync: fetch failed: %v\n", err)
+		return 1
+	}
+	changes := diff(cands, *tol)
+	printChanges(changes, len(cands))
+	return 0
+}
+
+// diff compares aggregator candidates against the embedded catalog. It is pure
+// (no I/O) so it is unit-tested with fixtures. tol suppresses small price
+// deltas. Unknown-to-us models are proposed as adds; known models with a
+// materially different price are proposed as updates; models the aggregator
+// marks deprecated are surfaced.
+func diff(cands []candidate, tol float64) []change {
+	var out []change
+	for _, c := range cands {
+		out = appendChange(out, c, tol)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		return out[i].Model < out[j].Model
+	})
+	return out
+}
+
+func appendChange(out []change, c candidate, tol float64) []change {
+	p, found := pricing.LookupProvider(c.Provider, c.Model)
+	if !found {
+		return append(out, change{Kind: "new", Provider: c.Provider, Model: c.Model,
+			Detail: fmt.Sprintf("%.4g/%.4g per MTok (not in catalog)", c.InputPerM, c.OutputPerM)})
+	}
+	if !p.Priced {
+		return out
+	}
+	if c.Deprecated {
+		out = append(out, change{Kind: "deprecated", Provider: c.Provider, Model: c.Model,
+			Detail: "aggregator marks deprecated"})
+	}
+	if priceDiffers(p, c, tol) {
+		out = append(out, change{Kind: "price", Provider: c.Provider, Model: c.Model,
+			Detail: fmt.Sprintf("catalog %.4g/%.4g → aggregator %.4g/%.4g",
+				p.InputPerM, p.OutputPerM, c.InputPerM, c.OutputPerM)})
+	}
+	return out
+}
+
+// priceDiffers reports whether input or output differs by more than tol (a
+// fraction of the catalog value; tol=0 means any difference).
+func priceDiffers(p pricing.ModelPrice, c candidate, tol float64) bool {
+	return exceeds(p.InputPerM, c.InputPerM, tol) || exceeds(p.OutputPerM, c.OutputPerM, tol)
+}
+
+func exceeds(have, got, tol float64) bool {
+	if have == got {
+		return false
+	}
+	if have == 0 {
+		return true
+	}
+	d := (got - have) / have
+	if d < 0 {
+		d = -d
+	}
+	return d > tol
+}
+
+// --- models.dev fetcher ---
+
+const modelsDevURL = "https://models.dev/api.json"
+
+type modelsDevFetcher struct{}
+
+func (modelsDevFetcher) Fetch(ctx context.Context) ([]candidate, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsDevURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("models.dev returned %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return parseModelsDev(body)
+}

--- a/cmd/pricing-sync/sync_test.go
+++ b/cmd/pricing-sync/sync_test.go
@@ -1,0 +1,86 @@
+package main
+
+import "testing"
+
+// findChange returns the change for a model, or nil.
+func findChange(changes []change, model string) *change {
+	for i := range changes {
+		if changes[i].Model == model {
+			return &changes[i]
+		}
+	}
+	return nil
+}
+
+func TestDiffClassifiesChanges(t *testing.T) {
+	cands := []candidate{
+		// Known + same price as the catalog → no change.
+		{Provider: "anthropic", Model: "claude-opus-5", InputPerM: 5, OutputPerM: 25},
+		// Known + different price → "price".
+		{Provider: "anthropic", Model: "claude-sonnet-5", InputPerM: 4, OutputPerM: 20},
+		// Not in catalog → "new".
+		{Provider: "openai", Model: "gpt-6-imaginary", InputPerM: 1, OutputPerM: 2},
+		// Known + aggregator says deprecated → "deprecated".
+		{Provider: "anthropic", Model: "claude-opus-5", InputPerM: 5, OutputPerM: 25, Deprecated: true},
+	}
+	changes := diff(cands, 0)
+
+	if c := findChange(changes, "gpt-6-imaginary"); c == nil || c.Kind != "new" {
+		t.Errorf("gpt-6-imaginary should be a 'new' change, got %+v", c)
+	}
+	if c := findChange(changes, "claude-sonnet-5"); c == nil || c.Kind != "price" {
+		t.Errorf("claude-sonnet-5 price delta should be a 'price' change, got %+v", c)
+	}
+	// The same-price opus-5 candidate must not produce a price change; the
+	// deprecated one must produce a 'deprecated' change.
+	var sawDeprecated bool
+	for _, c := range changes {
+		if c.Model == "claude-opus-5" && c.Kind == "price" {
+			t.Error("claude-opus-5 at catalog price must not yield a price change")
+		}
+		if c.Model == "claude-opus-5" && c.Kind == "deprecated" {
+			sawDeprecated = true
+		}
+	}
+	if !sawDeprecated {
+		t.Error("expected a 'deprecated' change for the deprecated opus-5 candidate")
+	}
+}
+
+func TestDiffToleranceSuppressesSmallDeltas(t *testing.T) {
+	// sonnet-5 catalog is 3/15; a 4% output bump under a 5% tolerance is ignored.
+	cands := []candidate{{Provider: "anthropic", Model: "claude-sonnet-5", InputPerM: 3, OutputPerM: 15.6}}
+	if got := diff(cands, 0.05); len(got) != 0 {
+		t.Errorf("4%% delta under 5%% tolerance should be suppressed, got %+v", got)
+	}
+	if got := diff(cands, 0.0); len(got) != 1 {
+		t.Errorf("with zero tolerance the delta should surface, got %+v", got)
+	}
+}
+
+func TestParseModelsDevMapsProvidersAndSkipsUnknown(t *testing.T) {
+	body := []byte(`{
+	  "anthropic": {"models": {"claude-opus-5": {"id":"claude-opus-5","cost":{"input":5,"output":25}}}},
+	  "google":    {"models": {"gemini-3.6-flash": {"id":"gemini-3.6-flash","cost":{"input":1.5,"output":7.5}}}},
+	  "some-unknown-provider": {"models": {"whatever": {"id":"whatever","cost":{"input":1,"output":1}}}}
+	}`)
+	cands, err := parseModelsDev(body)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var haveGemini, haveUnknown bool
+	for _, c := range cands {
+		if c.Provider == "gemini" && c.Model == "gemini-3.6-flash" {
+			haveGemini = true // google → gemini mapping
+		}
+		if c.Model == "whatever" {
+			haveUnknown = true
+		}
+	}
+	if !haveGemini {
+		t.Error("google provider must map to gemini")
+	}
+	if haveUnknown {
+		t.Error("unknown provider must be skipped")
+	}
+}

--- a/pricing/staleness.go
+++ b/pricing/staleness.go
@@ -1,0 +1,90 @@
+package pricing
+
+import (
+	"sort"
+	"time"
+)
+
+// Staleness flags one catalog entry whose provenance needs attention: its AsOf
+// date is older than the allowed age, or its Source URL is empty/unparseable.
+type Staleness struct {
+	Provider string
+	Model    string
+	AsOf     string
+	AgeDays  int    // days since AsOf; -1 if AsOf is missing/unparseable
+	Reason   string // "stale" | "no-source" | "bad-date"
+}
+
+// StaleEntries reports every catalog entry that is overdue for re-verification
+// as of now, using maxAge as the freshness window. now and maxAge are
+// parameters (not time.Now) so the check is deterministic and testable. Alias
+// keys are not reported separately — each model is reported once under its
+// declared provider/id.
+func StaleEntries(now time.Time, maxAge time.Duration) []Staleness {
+	out := gatherStale(now, maxAge)
+	sort.Slice(out, func(i, j int) bool { return lessStaleness(out[i], out[j]) })
+	return out
+}
+
+// gatherStale collects the stale entries (canonical ids only), unsorted.
+func gatherStale(now time.Time, maxAge time.Duration) []Staleness {
+	var out []Staleness
+	for provider, models := range index.byProvider {
+		out = append(out, staleForProvider(provider, models, now, maxAge)...)
+	}
+	return out
+}
+
+// staleForProvider evaluates one provider's models, skipping alias keys.
+func staleForProvider(provider string, models map[string]ModelPrice, now time.Time, maxAge time.Duration) []Staleness {
+	var out []Staleness
+	for id, p := range models {
+		if isAliasKey(provider, id, p) {
+			continue
+		}
+		if s, ok := evaluateStaleness(provider, id, p, now, maxAge); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// lessStaleness orders staleness reports by provider then model.
+func lessStaleness(a, b Staleness) bool {
+	if a.Provider != b.Provider {
+		return a.Provider < b.Provider
+	}
+	return a.Model < b.Model
+}
+
+// isAliasKey reports whether id is one of p's alias spellings rather than its
+// canonical model id, so aliases aren't double-reported.
+func isAliasKey(_ string, id string, p ModelPrice) bool {
+	for _, a := range p.Aliases {
+		if a == id {
+			return true
+		}
+	}
+	return false
+}
+
+// evaluateStaleness classifies a single entry; ok is false when it is fresh.
+func evaluateStaleness(provider, id string, p ModelPrice, now time.Time, maxAge time.Duration) (Staleness, bool) {
+	s := Staleness{Provider: provider, Model: id, AsOf: p.AsOf, AgeDays: -1}
+	if p.Source == "" {
+		s.Reason = "no-source"
+		return s, true
+	}
+	t, err := time.Parse("2006-01-02", p.AsOf)
+	if err != nil {
+		s.Reason = "bad-date"
+		return s, true
+	}
+	age := now.Sub(t)
+	s.AgeDays = int(age.Hours() / 24)
+	if age > maxAge {
+		s.Reason = "stale"
+		return s, true
+	}
+	return Staleness{}, false
+}

--- a/pricing/staleness_test.go
+++ b/pricing/staleness_test.go
@@ -1,0 +1,50 @@
+package pricing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStaleEntriesFlagsOldAsOf(t *testing.T) {
+	// A generous window: nothing is stale far enough back.
+	early := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	if got := StaleEntries(early, 365*24*time.Hour); len(got) != 0 {
+		t.Errorf("with a 1-year window in mid-2026, want 0 stale, got %d: %+v", len(got), got)
+	}
+
+	// A 60-day window well after the 2026-06-10 batch: those entries are stale,
+	// the 2026-08-07 additions are not.
+	now := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	stale := StaleEntries(now, 60*24*time.Hour)
+	if len(stale) == 0 {
+		t.Fatal("expected the 2026-06-10 entries to be stale under a 60-day window")
+	}
+	for _, s := range stale {
+		if s.Reason != "stale" {
+			t.Errorf("%s/%s: reason %q, want stale", s.Provider, s.Model, s.Reason)
+		}
+		if s.AsOf == "2026-08-07" {
+			t.Errorf("%s/%s dated 2026-08-07 must not be stale under a 60-day window as of 2026-09-01", s.Provider, s.Model)
+		}
+	}
+}
+
+func TestStaleEntriesDeterministicOrder(t *testing.T) {
+	now := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)
+	a := StaleEntries(now, 24*time.Hour)
+	b := StaleEntries(now, 24*time.Hour)
+	if len(a) != len(b) {
+		t.Fatal("nondeterministic length")
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("order differs at %d: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+	// Sorted by provider then model.
+	for i := 1; i < len(a); i++ {
+		if a[i-1].Provider > a[i].Provider {
+			t.Errorf("not sorted by provider at %d", i)
+		}
+	}
+}


### PR DESCRIPTION
Phase 2 of the pricing-tooling design (`docs/superpowers/specs/2026-08-07-pricing-package-and-autosync-design.md`). Builds on the leaf `pricing` package (v0.53.0).

## `just check-prices` — staleness checker
Reports catalog entries whose `as_of` is older than a freshness window (default 45 days) or missing a `source`, and **exits non-zero** — usable as a CI/pre-commit re-verification reminder. Right now it flags the 2026-06-10 batch (DeepSeek/Mistral/Cohere/older Anthropic), which is the point. Logic lives in `pricing.StaleEntries` (pure, deterministic — takes `now`/`maxAge` as params, fully unit-tested).

## `just sync-prices` — assistive aggregator diff
Fetches **models.dev** (`api.json` — machine-readable JSON, no auth, **no HTML scraping**), diffs it against `pricing/prices.json`, and reports candidate changes: **new** models, **price** deltas (with `--tolerance` to suppress small ones), and **deprecated** (upstream `status`). 

**Report-only — it never edits the catalog.** Detection is mechanical; authoritative verification is not (no provider publishes price as data), so a human confirms each candidate against its official `source`. Validated live against models.dev (258 models scanned): it already caught real drift (`command-r-08-2024` dropped to 0.15/0.6 vs our stale 0.5/1.5) and correctly surfaced the `claude-sonnet-5` intro-vs-durable price nuance (2/10 upstream vs our durable 3/15) — exactly why this stays human-gated.

The diff engine and the models.dev parser are pure and **fixture-tested** (no network in tests). The live fetcher is best-effort: a models.dev schema drift yields fewer/no candidates, never a corrupt catalog.

## Next (Phase 3)
The daily GitHub Action wrapping `sync` — cross-check models.dev against LiteLLM + OpenRouter, open a PR with evidence, and auto-merge/patch only on ≥2-source agreement (the auto-release safety policy, still pending your final confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788735451&installation_model_id=21126&pr_number=197&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F197&signature=1e62fdebefa89a11abc4c4e53cc9d366bb2110bd7cc20ad417fa9b51fcfd3d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pricing freshness checks to identify stale, missing-source, or invalid catalog entries.
  * Added a report-only synchronization tool that compares catalog pricing with the upstream models.dev catalog.
  * Reports new models, price changes, and upstream deprecations without modifying catalog files.
  * Added `just check-prices` and `just sync-prices` commands.

* **Tests**
  * Added coverage for staleness detection, provider mapping, change classification, and price tolerance handling.

* **Documentation**
  * Documented the new pricing verification and synchronization commands in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->