### PR TITLE
release: v0.54.0 — pricing sync tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.54.0] — 2026-08-07
 
 ### Added
 - **Pricing staleness checker + assistive sync tool** (`cmd/pricing-sync`, Phase 2 of the pricing-tooling design). `just check-prices` reports catalog entries whose `as_of` is older than a freshness window (default 45 days) or missing a source, and exits non-zero — usable as a CI/pre-commit re-verification reminder (it currently flags the 2026-06-10 batch). `just sync-prices` fetches the machine-readable **models.dev** aggregator (JSON, no auth, no HTML scraping), diffs it against `pricing/prices.json`, and reports candidate changes — new models, price deltas (with a `--tolerance` to suppress small ones), and upstream deprecations. It is **report-only** and never edits the catalog: detection is mechanical, but authoritative verification is not (no provider publishes price as data), so a human confirms each candidate against its official `source`. The staleness logic lives in the `pricing` package (`StaleEntries`, pure/deterministic); the diff engine is pure and fixture-tested.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.54.0] — 2026-08-07
+
+### Added
+- **Pricing staleness checker + assistive sync tool** (`cmd/pricing-sync`, Phase 2 of the pricing-tooling design). `just check-prices` reports catalog entries whose `as_of` is older than a freshness window (default 45 days) or missing a source, and exits non-zero — usable as a CI/pre-commit re-verification reminder (it currently flags the 2026-06-10 batch). `just sync-prices` fetches the machine-readable **models.dev** aggregator (JSON, no auth, no HTML scraping), diffs it against `pricing/prices.json`, and reports candidate changes — new models, price deltas (with a `--tolerance` to suppress small ones), and upstream deprecations. It is **report-only** and never edits the catalog: detection is mechanical, but authoritative verification is not (no provider publishes price as data), so a human confirms each candidate against its official `source`. The staleness logic lives in the `pricing` package (`StaleEntries`, pure/deterministic); the diff engine is pure and fixture-tested.
+
 ## [v0.53.0] — 2026-08-07
 
 ### Changed


### PR DESCRIPTION
Promotes changelog to v0.54.0 (Phase 2 pricing tooling: staleness checker + models.dev sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788737492&installation_model_id=21126&pr_number=199&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F199&signature=d5dc73ce175171d2e4869a2361bbb728924d69784f24a04eb8cc5e8f714d2cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published the v0.54.0 release notes dated August 7, 2026.
  * Documented new pricing freshness checks and report-only synchronization tooling.
  * Added guidance on source validation, comparison results, tolerance filtering, deprecation reports, and required human verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->