### PR TITLE
feat: daily pricing-drift Action (Phase 3, human-gated) + tracker integration guide

### DIFF
--- a/.github/workflows/pricing-sync.yml
+++ b/.github/workflows/pricing-sync.yml
@@ -1,0 +1,91 @@
+name: Pricing sync
+
+# Daily drift detection for pricing/prices.json. HUMAN-GATED by design: this
+# job never edits the catalog or opens a code PR — it opens/updates a single
+# rolling issue when it finds actionable drift, and a human confirms each change
+# against the model's official `source` before editing prices.json.
+#
+# Detection is mechanical (models.dev is machine-readable JSON); authoritative
+# verification is not (no provider publishes price as data). See
+# docs/superpowers/specs/2026-08-07-pricing-package-and-autosync-design.md and
+# docs/pricing-integration.md.
+
+on:
+  schedule:
+    - cron: "17 7 * * *" # daily 07:17 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: pricing-sync
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: Detect pricing drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Staleness report
+        id: stale
+        run: |
+          go run ./cmd/pricing-sync check > stale.txt 2>&1 || true
+          cat stale.txt
+
+      - name: Drift report (existing-model price/deprecation changes vs models.dev)
+        id: drift
+        run: |
+          # --existing-only keeps the signal actionable: price and deprecation
+          # drift for models we already carry, not the hundreds of upstream
+          # image/tts/embedding models we don't price.
+          set +e
+          go run ./cmd/pricing-sync sync --existing-only --tolerance 0.02 > drift.txt 2>&1
+          cat drift.txt
+          # A candidate line is indented and starts with "[".
+          if grep -qE '^\s+\[' drift.txt; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upsert drift issue
+        if: steps.drift.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Assemble the issue body from the tool's own output files (trusted;
+          # no github.event.* input is used anywhere in this workflow).
+          {
+            echo "Automated daily check found **price or deprecation drift** for models already in \`pricing/prices.json\`, and/or entries overdue for re-verification."
+            echo
+            echo "> ⚠️ **Human-gated.** Confirm each candidate against the model's official \`source\` URL before editing \`pricing/prices.json\`. models.dev is a detection aid, not an authority — it can reflect introductory or discounted rates (an intro price vs. the durable list price)."
+            echo
+            echo '### Price / deprecation drift (`sync --existing-only --tolerance 0.02`)'
+            echo '```'
+            cat drift.txt
+            echo '```'
+            echo
+            echo '### Staleness (`check`)'
+            echo '```'
+            cat stale.txt
+            echo '```'
+            echo
+            echo "Re-run locally: \`just sync-prices\` and \`just check-prices\`."
+          } > body.md
+
+          gh label create pricing-drift --color BFD4F2 --description "Automated pricing catalog drift" 2>/dev/null || true
+          existing="$(gh issue list --state open --label pricing-drift --json number --jq '.[0].number' || true)"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file body.md
+          else
+            gh issue create --title "Pricing drift detected vs models.dev" --label pricing-drift --body-file body.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Daily pricing-drift detection (Phase 3), human-gated.** A scheduled GitHub Action (`.github/workflows/pricing-sync.yml`) runs `pricing-sync` daily and, when it finds **price or deprecation drift for models already in the catalog**, opens/updates a single rolling `pricing-drift` issue with the evidence. It **never edits `prices.json` or opens a code PR** — a human confirms each candidate against its official `source` (models.dev can reflect intro/discounted rates, so this stays gated). New `sync --existing-only` flag keeps the daily signal actionable (drops the hundreds of upstream image/tts/embedding models dippin doesn't price); `sync --fail-on-changes` for CI gating.
+- **`docs/pricing-integration.md`** — how a downstream consumer (tracker) pins and integrates the `pricing` package: version floor (`v0.53.0`), the `Lookup`/`Cost` API, mapping `llm.Usage → pricing.Usage`, keeping capability metadata in the consumer, and the current **cache-pricing caveat** (the `ModelPrice` cache fields exist but `prices.json` doesn't populate them yet, so `Cost` computes cache traffic at $0 until it does).
+
 ## [v0.54.0] — 2026-08-07
 
 ### Added

--- a/cmd/pricing-sync/sync.go
+++ b/cmd/pricing-sync/sync.go
@@ -36,6 +36,8 @@ type change struct {
 func runSync(ctx context.Context, args []string) int {
 	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
 	tol := fs.Float64("tolerance", 0.0, "ignore price deltas at or below this fraction (e.g. 0.05 = 5%)")
+	existingOnly := fs.Bool("existing-only", false, "report only price/deprecation drift for models already in the catalog (drop 'new'); the low-noise daily signal")
+	failOnChanges := fs.Bool("fail-on-changes", false, "exit non-zero when any candidate is reported (for CI gating)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -44,9 +46,34 @@ func runSync(ctx context.Context, args []string) int {
 		fmt.Fprintf(errOut, "pricing-sync: fetch failed: %v\n", err)
 		return 1
 	}
-	changes := diff(cands, *tol)
+	return reportChanges(cands, *tol, *existingOnly, *failOnChanges)
+}
+
+// reportChanges diffs, optionally filters, prints, and returns the exit code.
+func reportChanges(cands []candidate, tol float64, existingOnly, failOnChanges bool) int {
+	changes := diff(cands, tol)
+	if existingOnly {
+		changes = dropNew(changes)
+	}
 	printChanges(changes, len(cands))
+	if failOnChanges && len(changes) > 0 {
+		return 1
+	}
 	return 0
+}
+
+// dropNew filters out "new" (upstream-only) candidates, leaving price and
+// deprecation drift for models already in our catalog — the actionable,
+// low-noise signal (models.dev lists hundreds of image/tts/embedding models we
+// deliberately don't price).
+func dropNew(changes []change) []change {
+	out := changes[:0]
+	for _, c := range changes {
+		if c.Kind != "new" {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // diff compares aggregator candidates against the embedded catalog. It is pure

--- a/cmd/pricing-sync/sync_test.go
+++ b/cmd/pricing-sync/sync_test.go
@@ -84,3 +84,20 @@ func TestParseModelsDevMapsProvidersAndSkipsUnknown(t *testing.T) {
 		t.Error("unknown provider must be skipped")
 	}
 }
+
+func TestDropNewKeepsOnlyExistingModelDrift(t *testing.T) {
+	changes := []change{
+		{Kind: "new", Provider: "openai", Model: "gpt-6-imaginary"},
+		{Kind: "price", Provider: "anthropic", Model: "claude-sonnet-5"},
+		{Kind: "deprecated", Provider: "gemini", Model: "gemini-2.0-flash"},
+	}
+	got := dropNew(changes)
+	if len(got) != 2 {
+		t.Fatalf("dropNew kept %d, want 2 (price+deprecated)", len(got))
+	}
+	for _, c := range got {
+		if c.Kind == "new" {
+			t.Errorf("dropNew leaked a 'new' change: %+v", c)
+		}
+	}
+}

--- a/docs/pricing-integration.md
+++ b/docs/pricing-integration.md
@@ -1,0 +1,120 @@
+# Integrating the `pricing` package (for tracker and other consumers)
+
+`github.com/2389-research/dippin-lang/pricing` is the single source of truth for
+LLM model prices and the model catalog. It is a **leaf package** — it imports
+nothing from the rest of dippin — so a consumer can depend on it without pulling
+in the parser, validator, or analysis machinery.
+
+This guide is written for **tracker** (which today maintains its own pricing
+table, tracker #518) but applies to any consumer.
+
+## Version to pin
+
+- **Floor:** `v0.53.0` — the release that introduced the `pricing` package.
+- **Recommended:** the latest tag (currently **`v0.54.0`**), which adds
+  `pricing.StaleEntries` and the sync tooling. Nothing in `v0.54.0` changes the
+  `Lookup`/`Cost` API a consumer uses.
+
+```sh
+go get github.com/2389-research/dippin-lang@v0.54.0
+```
+
+Consumers **pin a specific tag** — never `@latest` — per dippin's release model.
+
+## The API
+
+```go
+import "github.com/2389-research/dippin-lang/pricing"
+
+type ModelPrice struct {
+    InputPerM, OutputPerM float64 // USD per 1M tokens
+    CachedInputPerM       float64 // OpenAI-style absolute cached-input price (0 = use mult)
+    CacheReadMult         float64 // Anthropic/Gemini "0.1x" convention (0 = default)
+    CacheWriteMult        float64
+    Aliases               []string
+    Priced                bool    // false = in catalog but no established price (e.g. Qwen)
+    Source, AsOf          string  // provenance: published-price URL + verification date
+}
+
+type Usage struct{ Input, Output, CacheRead, CacheWrite, Reasoning int }
+
+func Cost(u Usage, p ModelPrice) float64            // the one cost calc — call this
+func Lookup(model string) (ModelPrice, bool)         // alias- and version-fold-resolving
+func LookupProvider(provider, model string) (ModelPrice, bool)
+```
+
+- **Version-separator fold:** `Lookup`/`LookupProvider` treat `claude-haiku-4.5`
+  and `claude-haiku-4-5` as the same model (issue #188).
+- **Provider aliases:** `LookupProvider` resolves `google→gemini`, `xai→grok`,
+  `kimi→moonshot`.
+- **Policy is the caller's.** `found=false` means unknown — you decide what that
+  means (tracker's budget path: treat as `$0` + warning, never a hard fail). A
+  `found=true` with `Priced=false` means recognized-but-unpriced (e.g. Qwen):
+  price it as `$0`, but don't warn that the model is unknown.
+
+## How tracker should integrate
+
+1. **Delete tracker's own price table.** Replace every price lookup with
+   `pricing.LookupProvider(provider, model)`.
+
+2. **Map `llm.Usage` → `pricing.Usage` and call `pricing.Cost`.** Don't
+   reimplement the arithmetic — there is one implementation, so there is nothing
+   to drift.
+
+   ```go
+   func costUSD(provider, model string, u llm.Usage) (float64, bool) {
+       p, ok := pricing.LookupProvider(provider, model)
+       if !ok {
+           return 0, false // caller policy: $0 + warning, never a hard fail
+       }
+       return pricing.Cost(pricing.Usage{
+           Input:      u.PromptTokens,
+           Output:     u.CompletionTokens,
+           CacheRead:  u.CacheReadTokens,
+           CacheWrite: u.CacheWriteTokens,
+           Reasoning:  u.ReasoningTokens,
+       }, p), true
+   }
+   ```
+
+3. **Keep capability metadata in tracker.** Context window, tool/vision/reasoning
+   support, and max-output are runtime concerns — they stay in tracker's
+   `ModelInfo`. Only the money fields + aliases come from `pricing`. Have
+   `ModelInfo` call `pricing.LookupProvider` for the price part.
+
+4. **Move the #518 drift test down.** The "published price is the source of
+   truth" guarantee now lives in `pricing/prices_test.go` (every entry has a
+   `Source` + well-formed `AsOf`, no duplicate keys). Delete tracker's copy.
+
+## Important caveat: cache pricing is not yet populated
+
+`ModelPrice` carries the cache fields (matching tracker #518's shape), **but
+dippin's `prices.json` does not populate them yet** — dippin's own estimator
+models base input/output only. So today `CachedInputPerM`, `CacheReadMult`, and
+`CacheWriteMult` are all `0`, and `pricing.Cost` therefore computes **cache
+traffic at $0**.
+
+If tracker prices cache reads/writes, you have two choices until dippin's
+`prices.json` carries cache rates:
+
+- **Keep tracker's cache-rate table** for the cache terms only, and use
+  `pricing` for base input/output; or
+- **Accept base-only costing** for now.
+
+Populating cache rates in `prices.json` (and teaching the sync tool to pull them
+from the aggregators) is planned — track it so the day it lands, tracker can
+drop its remaining cache table.
+
+## Keeping prices current
+
+dippin owns the freshness process (you consume a pinned tag and adopt new
+releases):
+
+- `just check-prices` — flags catalog entries overdue for re-verification.
+- `just sync-prices` — diffs `prices.json` against models.dev and reports
+  candidates (report-only; a human confirms against each official `source`).
+- A daily GitHub Action opens a rolling issue when it detects price/deprecation
+  drift for existing models.
+
+When dippin cuts a new tag with refreshed prices, tracker bumps its pin to adopt
+it — the same flow tracker already uses for every other dippin feature.


### PR DESCRIPTION
Phase 3 of the pricing-tooling design. Completes the pricing subsystem.

## Daily drift Action (human-gated)
`.github/workflows/pricing-sync.yml` runs `pricing-sync` on a daily cron. When it finds **price or deprecation drift for models already in `prices.json`**, it opens/updates a single rolling **`pricing-drift` issue** with the evidence (drift + staleness reports).

**It never edits `prices.json` and never opens a code PR.** Detection is mechanical (models.dev JSON); authoritative verification is not, so a human confirms each candidate against its official `source` before editing. models.dev can reflect intro/discounted rates (the live run already showed `claude-sonnet-5` at the 2/10 intro vs our 3/15 durable) — exactly why this stays gated. No `github.event.*` input is used, so no workflow-injection surface.

New flags: `sync --existing-only` (drops upstream-only "new" models — the hundreds of image/tts/embedding entries dippin doesn't price — leaving the actionable signal) and `sync --fail-on-changes` (CI gating).

## Tracker integration guide
`docs/pricing-integration.md`: what version to pin (**floor v0.53.0**, recommended latest **v0.54.0**), the `Lookup`/`Cost` API, mapping `llm.Usage → pricing.Usage`, keeping capability metadata in tracker, moving the #518 drift test down — and the **cache-pricing caveat**: `ModelPrice` carries the cache fields but `prices.json` doesn't populate them yet, so `pricing.Cost` computes cache traffic at $0 until it does; tracker keeps its cache-rate table for those terms until then.

## Auto-release policy
Shipped **fully human-gated** (issue only), per the safer default. The ≥2-source (models.dev + LiteLLM + OpenRouter) auto-merge/auto-patch subset is a deliberate follow-up once we've watched the daily signal for false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788737950&installation_model_id=21126&pr_number=200&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F200&signature=4c8258275b5ef75238594284e05729c610f0ece6373a945438edcbe7400bd98f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to report only existing-model pricing changes and return a failure status when pricing drift is detected.
  * Added automated daily pricing-staleness and drift checks with manual triggering and human review.
  * Consolidated findings into a single tracked issue for easier follow-up.

* **Documentation**
  * Added guidance for integrating pricing data, resolving models and providers, mapping usage to costs, and maintaining current pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->