### PR TITLE
fix(pricing): correct gpt-4.1-nano + deepseek-v4-pro from daily drift triage (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ## [Unreleased]
 
+### Fixed
+- **Corrected two stale prices flagged by the daily drift check** (#201, verified against official docs 2026-08-08): `openai/gpt-4.1-nano` was $0.05/$0.20 but is **$0.10/$0.40**; `deepseek/deepseek-v4-pro` was $1.74/$3.48 (pre-discount list) but the launch discount has become the standing price at **$0.435/$0.87**. Other drift candidates were dispositioned as non-issues — `claude-sonnet-5` 2/10 is the intro rate through 2026-08-31 (durable 3/15 kept); `o3-mini`/`o4-mini`/`gpt-4.1-nano` "deprecated" were false positives from models.dev (official docs list them active). `mistral-nemo`, `mistral-small-2603`, and `cohere/command-r-08-2024` could not be verified from official pages (JS-gated) and were left unchanged pending manual verification.
+
+
+## [Unreleased]
+
 ### Added
 - **Daily pricing-drift detection (Phase 3), human-gated.** A scheduled GitHub Action (`.github/workflows/pricing-sync.yml`) runs `pricing-sync` daily and, when it finds **price or deprecation drift for models already in the catalog**, opens/updates a single rolling `pricing-drift` issue with the evidence. It **never edits `prices.json` or opens a code PR** — a human confirms each candidate against its official `source` (models.dev can reflect intro/discounted rates, so this stays gated). New `sync --existing-only` flag keeps the daily signal actionable (drops the hundreds of upstream image/tts/embedding models dippin doesn't price); `sync --fail-on-changes` for CI gating.
 - **`docs/pricing-integration.md`** — how a downstream consumer (tracker) pins and integrates the `pricing` package: version floor (`v0.53.0`), the `Lookup`/`Cost` API, mapping `llm.Usage → pricing.Usage`, keeping capability metadata in the consumer, and the current **cache-pricing caveat** (the `ModelPrice` cache fields exist but `prices.json` doesn't populate them yet, so `Cost` computes cache traffic at $0 until it does).

--- a/pricing/prices.json
+++ b/pricing/prices.json
@@ -215,10 +215,10 @@
     {
       "provider": "deepseek",
       "model": "deepseek-v4-pro",
-      "input_per_m": 1.74,
-      "output_per_m": 3.48,
+      "input_per_m": 0.435,
+      "output_per_m": 0.87,
       "source": "https://api-docs.deepseek.com/quick_start/pricing",
-      "as_of": "2026-06-10"
+      "as_of": "2026-08-08"
     },
     {
       "provider": "gemini",
@@ -559,10 +559,10 @@
     {
       "provider": "openai",
       "model": "gpt-4.1-nano",
-      "input_per_m": 0.05,
-      "output_per_m": 0.2,
+      "input_per_m": 0.1,
+      "output_per_m": 0.4,
       "source": "https://developers.openai.com/api/docs/pricing",
-      "as_of": "2026-06-10"
+      "as_of": "2026-08-08"
     },
     {
       "provider": "openai",


### PR DESCRIPTION
Triage of the daily drift check (#201). Each candidate verified against official provider docs on 2026-08-08 — the human-gate step the daily Action is designed for.

**Corrected (official-confirmed):**
- `openai/gpt-4.1-nano`: 0.05/0.20 → **0.10/0.40** (we were half the real price)
- `deepseek/deepseek-v4-pro`: 1.74/3.48 → **0.435/0.87** (the launch discount became the standing list price)

**Dispositioned as non-issues:**
- `claude-sonnet-5` 2/10 is the intro rate through 2026-08-31; durable 3/15 kept.
- `o3-mini`, `o4-mini`, `gpt-4.1-nano` "deprecated" flags were **false positives** from models.dev — official docs list all three active. (Useful signal: models.dev's deprecation flag is unreliable; the human-gate correctly caught it.)
- `gemini-2.0-flash` (shut down 2026-06-01) already documented; `gemini-3.1-flash-lite-preview` superseded by the GA entry we already carry.

**Deferred (unverifiable):** `mistral-nemo`, `mistral-small-2603`, `cohere/command-r-08-2024` — official pricing pages are JS-gated; not adopting models.dev's numbers without official confirmation. Left unchanged (already flagged uncertain).

Validates the whole subsystem end-to-end: the Action detected real drift, and the human-gate both fixed genuine errors and rejected intro-price/false-positive noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788793101&installation_model_id=21126&pr_number=202&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F202&signature=45fe71bee65eeec81f4d437ee619caf3760eb5395cc418975f26ab0c54c1aabe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pricing information for DeepSeek V4 Pro and OpenAI GPT-4.1 Nano.
  * Updated pricing effective dates to August 8, 2026.
* **Documentation**
  * Added changelog entries describing the pricing corrections and related review outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->