### PR TITLE
release: v0.54.1 — pricing corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.54.1] — 2026-08-08
 
 ### Fixed
 - **Corrected two stale prices flagged by the daily drift check** (#201, verified against official docs 2026-08-08): `openai/gpt-4.1-nano` was $0.05/$0.20 but is **$0.10/$0.40**; `deepseek/deepseek-v4-pro` was $1.74/$3.48 (pre-discount list) but the launch discount has become the standing price at **$0.435/$0.87**. Other drift candidates were dispositioned as non-issues — `claude-sonnet-5` 2/10 is the intro rate through 2026-08-31 (durable 3/15 kept); `o3-mini`/`o4-mini`/`gpt-4.1-nano` "deprecated" were false positives from models.dev (official docs list them active). `mistral-nemo`, `mistral-small-2603`, and `cohere/command-r-08-2024` could not be verified from official pages (JS-gated) and were left unchanged pending manual verification.
 
 
-## [Unreleased]
+## [v0.54.1] — 2026-08-08
 
 ### Added
 - **Daily pricing-drift detection (Phase 3), human-gated.** A scheduled GitHub Action (`.github/workflows/pricing-sync.yml`) runs `pricing-sync` daily and, when it finds **price or deprecation drift for models already in the catalog**, opens/updates a single rolling `pricing-drift` issue with the evidence. It **never edits `prices.json` or opens a code PR** — a human confirms each candidate against its official `source` (models.dev can reflect intro/discounted rates, so this stays gated). New `sync --existing-only` flag keeps the daily signal actionable (drops the hundreds of upstream image/tts/embedding models dippin doesn't price); `sync --fail-on-changes` for CI gating.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,18 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.54.1] — 2026-08-08
+
+### Fixed
+- **Corrected two stale prices flagged by the daily drift check** (#201, verified against official docs 2026-08-08): `openai/gpt-4.1-nano` was $0.05/$0.20 but is **$0.10/$0.40**; `deepseek/deepseek-v4-pro` was $1.74/$3.48 (pre-discount list) but the launch discount has become the standing price at **$0.435/$0.87**. Other drift candidates were dispositioned as non-issues — `claude-sonnet-5` 2/10 is the intro rate through 2026-08-31 (durable 3/15 kept); `o3-mini`/`o4-mini`/`gpt-4.1-nano` "deprecated" were false positives from models.dev (official docs list them active). `mistral-nemo`, `mistral-small-2603`, and `cohere/command-r-08-2024` could not be verified from official pages (JS-gated) and were left unchanged pending manual verification.
+
+
+## [v0.54.1] — 2026-08-08
+
+### Added
+- **Daily pricing-drift detection (Phase 3), human-gated.** A scheduled GitHub Action (`.github/workflows/pricing-sync.yml`) runs `pricing-sync` daily and, when it finds **price or deprecation drift for models already in the catalog**, opens/updates a single rolling `pricing-drift` issue with the evidence. It **never edits `prices.json` or opens a code PR** — a human confirms each candidate against its official `source` (models.dev can reflect intro/discounted rates, so this stays gated). New `sync --existing-only` flag keeps the daily signal actionable (drops the hundreds of upstream image/tts/embedding models dippin doesn't price); `sync --fail-on-changes` for CI gating.
+- **`docs/pricing-integration.md`** — how a downstream consumer (tracker) pins and integrates the `pricing` package: version floor (`v0.53.0`), the `Lookup`/`Cost` API, mapping `llm.Usage → pricing.Usage`, keeping capability metadata in the consumer, and the current **cache-pricing caveat** (the `ModelPrice` cache fields exist but `prices.json` doesn't populate them yet, so `Cost` computes cache traffic at $0 until it does).
+
 ## [v0.54.0] — 2026-08-07
 
 ### Added


### PR DESCRIPTION
Patch: gpt-4.1-nano $0.10/$0.40 and deepseek-v4-pro $0.435/$0.87 (official-verified via daily drift triage #201/#202). Corrects cost output for pinned consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788793268&installation_model_id=21126&pr_number=203&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F203&signature=f5e8115098bb7b6aa71ed0b63db0479cfc25879c0628654ff1aa32cf05d44645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.54.1.
  * Documented corrections to two model prices.
  * Added details about pricing-drift detection, scheduled checks, issue tracking, and synchronization options.
  * Documented downstream pricing-package integration and its cache-pricing limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->