### PR TITLE
release: v0.55.0 — fmt --migrate non-equivalent exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.55.0] — 2026-08-10
 
 ### Changed
 - **`fmt --migrate` now signals non-runtime-equivalent conversions with a distinct exit code 4** ([#186](https://github.com/2389-research/dippin-lang/issues/186)). A non-self `retry_target` (retry jumps to a *different* node) migrates to a `loop` edge, but the engine dispatches the retry outcome on a channel that reads node attributes, never the edges block — so the loop edge is ignored and the retry silently becomes a self-retry. Previously this exited `3` ("review needed"), indistinguishable from equivalent-but-review cases. It now exits **`4`** (`ExitMigrateNonEquivalent`) with an explicit `NOT runtime-equivalent … do not use as a drop-in` error, so bulk migrations can separate safe conversions (0), review-but-equivalent (3), and non-equivalent (4). The output is still emitted (best-effort) with a sharper in-file marker. This is an interim safety signal; the underlying design gap — dip 2 has no representation the retry engine reads for non-self retry routing or retry-exhaustion fallback — is tracked separately for a proper fix.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,12 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.55.0] — 2026-08-10
+
+### Changed
+- **`fmt --migrate` now signals non-runtime-equivalent conversions with a distinct exit code 4** ([#186](https://github.com/2389-research/dippin-lang/issues/186)). A non-self `retry_target` (retry jumps to a *different* node) migrates to a `loop` edge, but the engine dispatches the retry outcome on a channel that reads node attributes, never the edges block — so the loop edge is ignored and the retry silently becomes a self-retry. Previously this exited `3` ("review needed"), indistinguishable from equivalent-but-review cases. It now exits **`4`** (`ExitMigrateNonEquivalent`) with an explicit `NOT runtime-equivalent … do not use as a drop-in` error, so bulk migrations can separate safe conversions (0), review-but-equivalent (3), and non-equivalent (4). The output is still emitted (best-effort) with a sharper in-file marker. This is an interim safety signal; the underlying design gap — dip 2 has no representation the retry engine reads for non-self retry routing or retry-exhaustion fallback — is tracked separately for a proper fix.
+
+
 ## [v0.54.1] — 2026-08-08
 
 ### Fixed


### PR DESCRIPTION
Promotes changelog to v0.55.0. `fmt --migrate` now exits 4 (distinct from 3) for non-runtime-equivalent conversions (non-self retry_target), so the bulk dip-2 migration in pipelines can separate safe/review/non-equivalent files. Interim stopgap for #186; proper fix (dip-2 retry channel) tracked in #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788967670&installation_model_id=21126&pr_number=207&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F207&signature=90a551d408ecbb48634b75562dc0ef7f6690dd72b806ca710a6a1a7a97c2638a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the v0.55.0 release notes dated August 10, 2026.
  * Documented updated `fmt --migrate` behavior for non-self `retry_target` routing:
    * Returns exit code 4 when conversions are not runtime-equivalent.
    * Provides an explicit warning and in-file markers while producing best-effort output.
    * Continues using exit code 3 for equivalent conversions that require review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->