### PR TITLE
docs: full docs+website sync to current code (v0.51.x–v0.55.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Every analysis command (`validate`, `lint`, `doctor`, `parse`, `cost`, `coverage
 |---------|-------------|
 | `dippin pack [-o <out>] [--dry-run] <entry.dip>` | Build a deterministic `.dipx` bundle from a `.dip` entry |
 | `dippin unpack [-o <dir>] [--force] <bundle.dipx>` | Atomic extract via staging dir + rename |
-| `dippin inspect [--format text\|json] <bundle.dipx>` | Print manifest, identity hash, and file list |
+| `dippin inspect [--format text\|json] <bundle.dipx>` | Print manifest, identity hash, file list, and the entry workflow's declared inputs |
+| `dippin inputs [--format text\|json] <file>` | Print a workflow's declared `inputs` schema (typed JSON for host collection) |
 
 ### Editor & Tooling
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,7 +30,7 @@ When changing code that affects observable behavior, check these before committi
 2. **New/changed DIP codes** → update `validation.md`, `README.md` diagnostics table, `llm-reference.md`
 3. **New/changed CLI commands** → update `cli.md`, `README.md` commands table
 4. **New/changed operators** → update `syntax.md`, `edges.md`, `llm-reference.md`, `docs/GRAMMAR.ebnf`
-5. **New/changed providers or models** → verify against live sources, update `lint_model.go`, `pricing.go`, `llm-reference.md`
+5. **New/changed providers or models** → verify against official provider docs, then edit the single source of truth **`pricing/prices.json`** (embedded by the leaf `pricing` package; both `cost` and `validator`'s DIP108 catalog derive from it — do **not** hand-edit `cost/pricing.go` or `validator/lint_model.go` model tables). Set each entry's `source` URL and `as_of` date; use `"priced": false` for a recognized-but-unverifiable model. Run `just check-prices` to surface overdue entries and `just sync-prices` to diff against models.dev. Update `docs/pricing-integration.md` and the supported-provider list if a provider is added.
 6. **New analysis output** → update `analysis.md` JSON schemas
 7. **Architecture changes** → update `architecture.md` package map and dependency graph
 8. **Version release** → update `CHANGELOG.md`, create GitHub release with notes
@@ -51,4 +51,4 @@ When auditing docs for accuracy:
 
 6. **JSON schemas vs struct tags**: Every field in `analysis.md` JSON examples must match the `json:` struct tags in the corresponding Go types.
 
-7. **Model catalog vs reality**: Model names and pricing must be verified against official provider documentation. Source URLs must be current. The "Last verified" date in code comments must be updated.
+7. **Model catalog vs reality**: Model names and pricing live in `pricing/prices.json` and must be verified against official provider documentation. Each entry's `source` URL must be current and its `as_of` date updated on verification (`just check-prices` flags overdue entries). `cost/pricing.go` and `validator/lint_model.go` derive from this file — they carry no hand-maintained model table.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,8 @@ dippin-lang/
 ├── pricing/            # Leaf: single source of truth for model catalog + prices
 │   ├── prices.json     # Embedded catalog (provider, price, aliases, source, as_of)
 │   ├── pricing.go      # ModelPrice, Usage, Cost(), Lookup() — no dippin imports
-│   └── load.go         # //go:embed loader → lookup index
+│   ├── load.go         # //go:embed loader → lookup index
+│   └── staleness.go    # StaleEntries: flags entries overdue for re-verification
 │
 ├── cost/               # Cost estimation engine
 │   ├── cost.go         # Per-node cost analysis with turn/token heuristics
@@ -166,9 +167,10 @@ dippin-lang/
 │   ├── flatten.go      # Inline referenced workflows into one flat ir.Workflow
 │   └── resolver.go     # Resolver interface + disk-backed ref loading (imports parser)
 │
-└── cmd/dippin/         # CLI entry point
+├── cmd/dippin/         # CLI entry point
     ├── main.go         # os.Args → Run()
     ├── cli.go          # Command dispatch and global flag handling
+    ├── cmd_inputs.go   # inputs command (typed inputs-schema introspection)
     ├── cmd_parse.go    # parse command
     ├── cmd_validate.go # validate command
     ├── cmd_check.go    # check command
@@ -192,8 +194,12 @@ dippin-lang/
     ├── cmd_lsp.go      # lsp command
     ├── cmd_pack.go     # pack command (.dipx producer)
     ├── cmd_unpack.go   # unpack command (.dipx → directory)
-    ├── cmd_inspect.go  # inspect command (.dipx → manifest summary)
+    ├── cmd_inspect.go  # inspect command (.dipx → manifest + entry inputs schema)
     └── cmd_spec.go     # spec command (print full language specification)
+
+└── cmd/pricing-sync/   # Maintainer tool: pricing freshness (not part of the dippin binary)
+    ├── check.go        # `check`: staleness report over prices.json (exits non-zero if overdue)
+    └── sync.go         # `sync`: diff prices.json against models.dev, report candidates
 ```
 
 ### Loader Tier (dipx)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -777,9 +777,31 @@ dippin unpack [-o <destdir>] [--force] <bundle.dipx>
 
 ---
 
+### inputs
+
+Print a workflow's declared `inputs` schema — the typed, introspectable contract a host uses to collect values before a run.
+
+```bash
+dippin inputs [--format text|json] <file>
+```
+
+**Flags**:
+
+- `--format text|json` — output format (default `text`); an unrecognized value is a usage error
+
+**Output**: the declared inputs in declaration order. `--format json` emits a stable array a host can render into a form or walk conversationally — each entry carries `name`, `type`, `required`, and any declared attributes (`default`, `prompt`, `description`, `options`, `pattern`, `min`, `max`, `max_length`, `multiline`). Defaults are **typed** (a `number` default is a JSON number, a `bool` a JSON bool); a workflow with no `inputs` block emits `[]`, never `null`. See [Context and Variables](context.md) for the `${inputs.x}` namespace and the DIP155–DIP157 lints.
+
+```bash
+dippin inputs --format json build_product.dip
+```
+
+**Exit codes**: `0` ok; `1` load/parse error; `2` usage error.
+
+---
+
 ### inspect
 
-Print a `.dipx` bundle's manifest, identity hash, and file list.
+Print a `.dipx` bundle's manifest, identity hash, file list, and — for the verified (default) path — the entry workflow's declared `inputs` schema, so a host can enumerate what to collect without unpacking.
 
 ```bash
 dippin inspect [--format text|json] [--no-verify] <bundle.dipx>
@@ -790,7 +812,7 @@ dippin inspect [--format text|json] [--no-verify] <bundle.dipx>
 - `--format text|json` — output format (default `text`)
 - `--no-verify` — reserved; v1 always integrity-verifies (the flag prints a stderr advisory)
 
-The bundle's `identity` is the SHA-256 of the manifest bytes as stored on disk — a stable content-addressable id suitable for caching and runtime resolution.
+The bundle's `identity` is the SHA-256 of the manifest bytes as stored on disk — a stable content-addressable id suitable for caching and runtime resolution. The `--format json` payload includes an `inputs` array (the entry workflow's schema, same shape as `dippin inputs`); the manifest-only `--no-verify` path omits the key.
 
 **Exit codes**: bundle ladder.
 

--- a/site/content/cli.md
+++ b/site/content/cli.md
@@ -1,6 +1,6 @@
 ---
 title: "CLI Reference"
-description: "Complete command reference for the Dippin toolchain: 18 commands for authoring, export, analysis, and bundling AI pipeline workflows — parse, validate, lint, check, fmt, simulate, cost, coverage, doctor, test, watch, pack, unpack, inspect, and more."
+description: "Complete command reference for the Dippin toolchain: commands for authoring, export, analysis, introspection, and bundling AI pipeline workflows — parse, validate, lint, check, fmt, simulate, cost, coverage, doctor, test, watch, inputs, pack, unpack, inspect, and more."
 section_label: "Reference"
 subtitle: "Every command in the dippin toolchain — authoring, export, analysis, and bundles."
 ---
@@ -165,7 +165,13 @@ Bundle commands (`pack`, `unpack`, `inspect`) use a finer ladder so tooling can 
 </div>
 
 <div class="cmd-card">
+  <h3>inputs</h3>
+  <div class="cmd-usage">dippin inputs [--format text|json] &lt;file&gt;</div>
+  <p>Print a workflow's declared <code>inputs</code> schema — the typed, introspectable contract a host uses to collect values before a run. <code>--format json</code> emits a stable array in declaration order (each entry with <code>name</code>, <code>type</code>, <code>required</code>, and any declared attributes); defaults are typed (a <code>number</code> default is a JSON number), and a workflow with no inputs emits <code>[]</code>, never <code>null</code>.</p>
+</div>
+
+<div class="cmd-card">
   <h3>inspect</h3>
   <div class="cmd-usage">dippin inspect [--no-verify] [--format text|json] &lt;bundle.dipx&gt;</div>
-  <p>Print a bundle's manifest, identity hash (SHA-256 over the manifest bytes-as-stored), and per-file checksums. Integrity-verifies by default; <code>--no-verify</code> skips hash verification (forensic mode).</p>
+  <p>Print a bundle's manifest, identity hash (SHA-256 over the manifest bytes-as-stored), and per-file checksums. The verified <code>--format json</code> payload also includes the entry workflow's declared <code>inputs</code> schema (so a host can enumerate what to collect without unpacking). Integrity-verifies by default; <code>--no-verify</code> skips hash verification (forensic mode).</p>
 </div>

--- a/site/content/glossary.md
+++ b/site/content/glossary.md
@@ -23,6 +23,8 @@ subtitle: "Terms you'll encounter authoring .dip files and using the dippin tool
 
 **marker_grep / ctx.tool_marker** — `marker_grep` is a regex on a `tool` node, matched line-by-line against the command's stdout; the matched value populates `ctx.tool_marker`, the tool's outcome channel for routing (e.g. via `on` or `when`).
 
+**inputs** — A workflow-level block declaring what a caller must supply (the callee-side signature), whether a human at the entry point or a parent via a subgraph's `params:`. Each entry is `name: type` (`text`, `number`, `bool`, `enum`, `file`, `secret`) with optional attributes (`required`, `default`, `prompt`, `description`, `options`, `pattern`, `min`, `max`, `max_length`, `multiline`). Read in prompts/conditions as `${inputs.name}` — a **closed** namespace: a reference to an undeclared input is a lint error (DIP156), unlike the open `ctx`. Introspect with `dippin inputs`.
+
 **Defaults** — A workflow-wide block setting values inherited by all nodes unless overridden. Common keys: `model`, `provider`, `fidelity`, `retry`, `tool_commands_allow`, `tool_denylist_add`.
 
 **Goal** — A short string at the top of a workflow stating the pipeline's purpose. Surfaces in `dippin doctor` reports and is shown to operators.

--- a/site/content/validation.md
+++ b/site/content/validation.md
@@ -128,7 +128,7 @@ These flag likely bugs or questionable patterns. Warnings alone exit 0.
 
 <div class="diag-card warning">
   <span class="diag-code">DIP108</span> — Unknown Model/Provider
-  <p>The model or provider isn't in the recognized list. Verified against official provider documentation.</p>
+  <p>The model or provider isn't in the recognized catalog (Anthropic, OpenAI, Google/Gemini, DeepSeek, xAI/Grok, Mistral, Cohere, Z.AI/GLM, Moonshot/Kimi, MiniMax, Qwen), which is verified against official provider docs. A dotted ID and its dashed form resolve to the same model (<code>claude-haiku-4.5</code> == <code>claude-haiku-4-5</code>); extend the catalog for private models with <code>--extra-models</code>.</p>
   <pre>warning[DIP108]: unknown model/provider combination
   --&gt; pipeline.dip:15:5</pre>
 </div>


### PR DESCRIPTION
Systematic audit of `docs/`, `site/content/`, `README.md`, and `CONTRIBUTING.md` against everything shipped this cycle. Found and fixed the surfaces the incremental per-feature sweeps missed:

- **`dippin inputs` command was undocumented** (shipped in v0.51.0) — added to `docs/cli.md`, `site/content/cli.md`, and the README commands table; noted that `dippin inspect` now surfaces the entry workflow's inputs schema in its JSON.
- **CONTRIBUTING was actively wrong** — it told contributors to edit `cost/pricing.go` + `validator/lint_model.go` for model/price changes, but those now *derive* from the single source of truth `pricing/prices.json`. Corrected both the update-checklist and the accuracy-verification sections; referenced `just check-prices` / `sync-prices`.
- **architecture.md** — added `pricing/staleness.go`, `cmd_inputs.go`, and the `cmd/pricing-sync` maintainer tool to the package tree.
- **glossary** — added the `inputs` block + the `${inputs.x}` closed namespace.
- **site DIP108 card** — current 11-provider catalog + the dotted/dashed version-fold note (#188).

Verified present (no change needed) from prior sweeps: the inputs prose in `context.md`/`syntax.md`/`validation.md`/`language.md`/`skill.md`/`llm-reference.md`, DIP155–157, the 67-code counts, the `fmt --migrate` exit-4 note, and provider currency in living docs. Historical changelog/blog entries left frozen by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788968554&installation_model_id=21126&pr_number=208&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F208&signature=dd94932c8462c4befb012a91fcf16fb763622081470c654d5e4cd5615a0a3e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documented the new `dippin inputs` command for viewing workflow input schemas in text or JSON.
  - Updated `dippin inspect` documentation to include entry workflow inputs in verified JSON output.
  - Documented typed defaults, empty schemas, input references, and supported input types.

- **Documentation**
  - Clarified pricing catalog guidance, model validation, catalog extensions, and generated-file workflows.
  - Added architecture and glossary references for workflow inputs and pricing maintenance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->