### PR TITLE
ci: upgrade release actions to Node-24 majors + pin GoReleaser (#185)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,21 +17,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #185 — eliminates the two deprecation annotations the release workflow emitted.

## Changes (all verified against official release notes, not guessed)
| Action | Was | Now | Why |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | v5.0.0 = "use node 24" (the Node-24 major) |
| `actions/setup-go` | v5 | **v6** | v6.0.0 = "Upgrade Nodejs runtime from node20 to node 24" |
| `goreleaser/goreleaser-action` | v6 | **v7** | v7.0.0 = "feat!: node 24" |
| GoReleaser `version` | `latest` | `~> v2` | the explicit constraint the action warned it would otherwise imply; matches `.goreleaser.yml` `version: 2` |

Each action is pinned to the **major where the Node-24 runtime landed** (confirmed via the GitHub releases API). Their breaking changes don't touch the inputs used here: setup-go v6's toolchain-selection change doesn't affect `go-version: '1.25'`/`cache`; goreleaser-action v7's ESM migration doesn't affect `distribution`/`version`/`args`; checkout v5 keeps `fetch-depth`.

## On "exercise the release workflow safely"
I did **not** cut a throwaway tag — a tag push triggers a real cross-platform release + Homebrew publish, which isn't a safe test artifact. The YAML is validated and the version bumps are verified against upstream. The annotation-free confirmation lands on the **next real release** (imminent — Phase 2 and other work are queued); if any annotation persists there, it's a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788972761&installation_model_id=21126&pr_number=213&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F213&signature=32f47a6e3de451ef9f4d20af8c1c7b1e26655fb6bbb40f82696ecfdda454eeb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process tooling to newer versions.
  * Improved release consistency by standardizing the GoReleaser version line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->