### PR TITLE
release: v0.56.0 — input constraint + dead-input lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.56.0] — 2026-08-10
 
 ### Added
 - **Input constraint + dead-input lints (DIP158, DIP159) — Phase 2 of the `inputs` feature** ([#190](https://github.com/2389-research/dippin-lang/issues/190)). **DIP158** (error) validates an input's constraints against its declared type: an `enum` `default` must be one of its `options`, a `number`'s `min` must not exceed its `max`, a `pattern` must be a valid regex, and a constraint must apply to the type it's set on (`pattern`/`max_length`/`multiline` → text/secret, `min`/`max` → number, `options` → enum) — so `max_length` on a `bool` or `options` on a `text` is flagged. **DIP159** (warning) flags a declared input that no prompt, tool command, or edge condition references (a dead input, mirroring DIP107). Brings the catalog to **69 codes (DIP101–DIP159)**. Remaining Phase 3: DIP160 (cross-file subgraph arity), DIP161 (chain-attack input flow).

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,12 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.56.0] — 2026-08-10
+
+### Added
+- **Input constraint + dead-input lints (DIP158, DIP159) — Phase 2 of the `inputs` feature** ([#190](https://github.com/2389-research/dippin-lang/issues/190)). **DIP158** (error) validates an input's constraints against its declared type: an `enum` `default` must be one of its `options`, a `number`'s `min` must not exceed its `max`, a `pattern` must be a valid regex, and a constraint must apply to the type it's set on (`pattern`/`max_length`/`multiline` → text/secret, `min`/`max` → number, `options` → enum) — so `max_length` on a `bool` or `options` on a `text` is flagged. **DIP159** (warning) flags a declared input that no prompt, tool command, or edge condition references (a dead input, mirroring DIP107). Brings the catalog to **69 codes (DIP101–DIP159)**. Remaining Phase 3: DIP160 (cross-file subgraph arity), DIP161 (chain-attack input flow).
+
+
 ## [v0.55.0] — 2026-08-10
 
 ### Changed


### PR DESCRIPTION
Promotes changelog to v0.56.0 (DIP158/DIP159, #190 Phase 2). This release also exercises the upgraded release workflow (#185) — the tag runs checkout@v5/setup-go@v6/goreleaser-action@v7, so it confirms the Node-20 deprecation annotations are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788972942&installation_model_id=21126&pr_number=214&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F214&signature=6d11d98de8cdd7c9e87a2da8f0cf3ef16d18402fecae66fce1c09d27a4f72817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Published the v0.56.0 release notes dated August 10, 2026.
  - Documented new linting diagnostics for invalid input constraints and unreferenced inputs.
  - Expanded the diagnostic catalog to 69 codes.
  - Added details about planned Phase 3 input improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->