### PR TITLE
fix(pricing): price gpt-5.2-codex as an alias of gpt-5.2 (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **`gpt-5.2-codex` now prices instead of escaping cost ceilings** ([#209](https://github.com/2389-research/dippin-lang/issues/209)). tracker's cutover to `dippin-lang/pricing` (tracker#558) surfaced that `gpt-5.2-codex` was absent from the catalog, so `pricing.Lookup` returned `found=false` and it priced at **$0**, silently escaping `--max-cost`. Verified 2026-08-10 (LiteLLM + OpenRouter agree, consistent with `gpt-5.3-codex` at its base rate on OpenAI's official page): it bills at the `gpt-5.2` rate ($1.75/$14), so it's now an **alias** of `gpt-5.2`. (`gpt-5.2-mini`, the other model in #209, does not exist in any source — official, LiteLLM, or OpenRouter — and remains a tracker-side catalog fix.)
+
+
 ## [v0.56.0] — 2026-08-10
 
 ### Added

--- a/pricing/prices.json
+++ b/pricing/prices.json
@@ -626,7 +626,10 @@
       "input_per_m": 1.75,
       "output_per_m": 14,
       "source": "https://developers.openai.com/api/docs/pricing",
-      "as_of": "2026-06-10"
+      "as_of": "2026-08-10",
+      "aliases": [
+        "gpt-5.2-codex"
+      ]
     },
     {
       "provider": "openai",

--- a/pricing/prices_test.go
+++ b/pricing/prices_test.go
@@ -92,3 +92,21 @@ func TestCost(t *testing.T) {
 		t.Errorf("absolute cached-input cost = %v, want 0.5", got)
 	}
 }
+
+// TestGPT52CodexAlias covers #209: gpt-5.2-codex bills at the gpt-5.2 rate
+// (confirmed 2026-08-10 by LiteLLM + OpenRouter; consistent with gpt-5.3-codex
+// pricing at its base rate on the official page), modeled as an alias.
+func TestGPT52CodexAlias(t *testing.T) {
+	base, ok := LookupProvider("openai", "gpt-5.2")
+	if !ok {
+		t.Fatal("gpt-5.2 must be priced")
+	}
+	codex, ok := LookupProvider("openai", "gpt-5.2-codex")
+	if !ok {
+		t.Fatal("gpt-5.2-codex must resolve (issue #209 budget escape)")
+	}
+	if codex.InputPerM != base.InputPerM || codex.OutputPerM != base.OutputPerM {
+		t.Errorf("gpt-5.2-codex %v/%v != gpt-5.2 %v/%v",
+			codex.InputPerM, codex.OutputPerM, base.InputPerM, base.OutputPerM)
+	}
+}


### PR DESCRIPTION
Fixes the priceable half of #209. `gpt-5.2-codex` was absent from `prices.json`, so post-tracker#558 it priced at **$0** and escaped `--max-cost`.

Re-verified 2026-08-10 across all sources: **LiteLLM** (`gpt-5.2-codex` = 1.75/14) and **OpenRouter** (`gpt-5.2-codex` = 0.00000175/0.000014) agree it bills at the **gpt-5.2 base rate ($1.75/$14)**, consistent with OpenAI's own `gpt-5.3-codex` being listed at its base rate on the official pricing page. Modeled as an **alias** of `gpt-5.2` so it inherits that officially-verified price + source.

`gpt-5.2-mini` (the other model in #209) appears in **no** source — not OpenAI's page, not LiteLLM, not OpenRouter — so it's a nonexistent/stale ID that remains a tracker-side catalog fix (noted on the issue).

Regression test locks in that `gpt-5.2-codex` resolves to the `gpt-5.2` price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788974004&installation_model_id=21126&pr_number=216&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F216&signature=310c8ec51341ed5979c7eeb7168228ab1ad6ef0123916584a94d79cfe037aa2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added pricing recognition for `gpt-5.2-codex`, matching `gpt-5.2` at $1.75 input and $14 output per million tokens.
  * Prevented unrecognized pricing for this model from bypassing cost ceilings.

* **Documentation**
  * Added an Unreleased changelog entry documenting the new model alias and pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->