### PR TITLE
fix: exempt file/secret inputs from DIP159 dead-input check (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **DIP159 no longer false-positives a `file`/`secret` input consumed via its staged path** ([#215](https://github.com/2389-research/dippin-lang/issues/215), regression in v0.56.0). A `file` or `secret` input is consumed out-of-band by reading its staged path in a shell command — and DIP157 forbids `${inputs.x}` inside a `command:` — so it is legitimately never `${inputs.x}`-referenced. DIP159 was flagging it as a dead input, a DIP157/DIP159 pincer that made the documented staged-file pattern un-lintable (surfaced adopting v0.56.0 in tracker). `file` and `secret` inputs are now exempt from DIP159; `text`/`number`/`bool`/`enum` are still dead-input-checked.
+
+
 ## [v0.56.0] — 2026-08-10
 
 ### Added

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1524,11 +1524,14 @@ supports it.
 
 **Severity**: Warning
 
-A declared input is never referenced — not as `${inputs.x}` in any prompt or
-tool command, nor as `inputs.x` in any edge condition. It is dead within the
-graph, usually a leftover declaration or a typo in the reference. (A host may
-still collect it out of band, which is why this is advisory, mirroring DIP107
-for dead node outputs.)
+A `text`/`number`/`bool`/`enum` input is never referenced — not as `${inputs.x}`
+in any prompt or tool command, nor as `inputs.x` in any edge condition. It is
+dead within the graph, usually a leftover declaration or a typo in the
+reference. `file` and `secret` inputs are **exempt**: they are consumed
+out-of-band by reading their staged path in a shell (and `${inputs.x}` is
+forbidden in a `command:` by DIP157), so they are legitimately never
+interpolation-referenced. (A host may still collect any input out of band,
+which is why this is advisory, mirroring DIP107 for dead node outputs.)
 
 ```text
 warning[DIP159]: declared input "target_branch" is never referenced

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -213,7 +213,7 @@ func inputsExplanations() map[string]Explanation {
 		DIP159: {
 			Code:    DIP159,
 			Summary: "declared input is never referenced (dead input)",
-			Trigger: "An input is declared but never referenced as ${inputs.x} in a prompt or tool command, nor as inputs.x in an edge condition. It is dead within the graph — likely a leftover or a typo in the reference — though a host may still collect it. Advisory, mirroring DIP107 for dead node outputs.",
+			Trigger: "A text/number/bool/enum input is declared but never referenced as ${inputs.x} in a prompt or tool command, nor as inputs.x in an edge condition — dead within the graph, likely a leftover or a typo. file and secret inputs are exempt: they are consumed out-of-band by reading their staged path in a shell (DIP157 forbids ${inputs.x} in a command), so they are legitimately never interpolation-referenced. Advisory, mirroring DIP107 for dead node outputs.",
 			Fix:     "Reference the input where it is meant to be used, or remove the declaration.",
 			Example: "inputs\n  used: text\n  unused: text  # DIP159: no node references ${inputs.unused}",
 		},

--- a/validator/lint_inputs.go
+++ b/validator/lint_inputs.go
@@ -323,7 +323,7 @@ func lintDeadInputs(w *ir.Workflow) []Diagnostic {
 	referenced := referencedInputNames(w)
 	var diags []Diagnostic
 	for _, in := range w.Inputs {
-		if referenced[in.Name] {
+		if deadInputExempt(in) || referenced[in.Name] {
 			continue
 		}
 		diags = append(diags, Diagnostic{
@@ -335,6 +335,14 @@ func lintDeadInputs(w *ir.Workflow) []Diagnostic {
 		})
 	}
 	return diags
+}
+
+// deadInputExempt reports whether an input is exempt from the DIP159 dead-input
+// check. file and secret inputs are consumed out-of-band by reading their staged
+// path in a shell (DIP157 forbids ${inputs.x} in a command), so they are
+// legitimately never interpolation-referenced (issue #215).
+func deadInputExempt(in *ir.Input) bool {
+	return in.Type == "file" || in.Type == "secret"
 }
 
 // referencedInputNames collects every input name mentioned as ${inputs.x} in a

--- a/validator/lint_inputs_test.go
+++ b/validator/lint_inputs_test.go
@@ -447,3 +447,40 @@ func indexOf(s, sub string) int {
 	}
 	return -1
 }
+
+// TestDIP159FileSecretExempt covers #215: a file/secret input is consumed by
+// reading its staged path in a command (DIP157 forbids ${inputs.x} there), so
+// it is legitimately never ${inputs.x}-referenced and must NOT trip DIP159.
+func TestDIP159FileSecretExempt(t *testing.T) {
+	src := `workflow W
+  goal: t
+  start: Setup
+  exit: Setup
+  inputs
+    spec: file
+    token: secret
+  tool Setup
+    command:
+      if [ -f .tracker/inputs/spec ]; then cp .tracker/inputs/spec SPEC.md; fi
+`
+	if hasCode(lintSrc(t, src), "DIP159") {
+		t.Errorf("file/secret inputs consumed via staged path must not trip DIP159: %v", lintSrc(t, src))
+	}
+}
+
+// TestDIP159StillFiresForValueTypes: text/number/bool/enum are still checked.
+func TestDIP159StillFiresForValueTypes(t *testing.T) {
+	src := `workflow W
+  goal: t
+  start: A
+  exit: A
+  inputs
+    unused: text
+  agent A
+    prompt:
+      nothing referenced
+`
+	if !hasCode(lintSrc(t, src), "DIP159") {
+		t.Error("a dead text input should still fire DIP159")
+	}
+}


### PR DESCRIPTION
Fixes #215 — a false-positive **regression in v0.56.0** that's blocking tracker's adoption.

## The pincer
A `file`/`secret` input is consumed out-of-band by reading its **staged path** in a shell command (the runtime stages the value to a 0600 file). And **DIP157** forbids `${inputs.x}` inside a `command:`. So the workflow reads the staged file by its fixed path and never writes `${inputs.spec}` anywhere → **DIP159** then flags `spec` as a dead input. The two lints together made the documented staged-file pattern un-lintable.

## Fix
`file` and `secret` inputs are exempt from DIP159 (they're consumed by staged path, not interpolation). `text`/`number`/`bool`/`enum` are still dead-input-checked. Two tests: the exemption holds; a dead `text` input still fires. Explanation + `docs/validation.md` updated. Complexity kept in budget via a `deadInputExempt` helper.

This lets tracker drop the cosmetic `${inputs.spec}` prompt-mention workaround its flagships currently carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788974146&installation_model_id=21126&pr_number=217&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F217&signature=9072b0ce8eb04e45222b64029468f5a030326be5c74914145c1b4ca44f364c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dead-input validation to exclude `file` and `secret` inputs consumed through staged paths.
  * Continued reporting unused `text`, `number`, `bool`, and `enum` inputs.

* **Documentation**
  * Clarified the updated dead-input validation behavior in the documentation and changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->