### PR TITLE
release: v0.56.1 — DIP159 regression fix + gpt-5.2-codex pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.56.1] — 2026-08-10
 
 ### Fixed
 - **`gpt-5.2-codex` now prices instead of escaping cost ceilings** ([#209](https://github.com/2389-research/dippin-lang/issues/209)). tracker's cutover to `dippin-lang/pricing` (tracker#558) surfaced that `gpt-5.2-codex` was absent from the catalog, so `pricing.Lookup` returned `found=false` and it priced at **$0**, silently escaping `--max-cost`. Verified 2026-08-10 (LiteLLM + OpenRouter agree, consistent with `gpt-5.3-codex` at its base rate on OpenAI's official page): it bills at the `gpt-5.2` rate ($1.75/$14), so it's now an **alias** of `gpt-5.2`. (`gpt-5.2-mini`, the other model in #209, does not exist in any source — official, LiteLLM, or OpenRouter — and remains a tracker-side catalog fix.)

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,13 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.56.1] — 2026-08-10
+
+### Fixed
+- **`gpt-5.2-codex` now prices instead of escaping cost ceilings** ([#209](https://github.com/2389-research/dippin-lang/issues/209)). tracker's cutover to `dippin-lang/pricing` (tracker#558) surfaced that `gpt-5.2-codex` was absent from the catalog, so `pricing.Lookup` returned `found=false` and it priced at **$0**, silently escaping `--max-cost`. Verified 2026-08-10 (LiteLLM + OpenRouter agree, consistent with `gpt-5.3-codex` at its base rate on OpenAI's official page): it bills at the `gpt-5.2` rate ($1.75/$14), so it's now an **alias** of `gpt-5.2`. (`gpt-5.2-mini`, the other model in #209, does not exist in any source — official, LiteLLM, or OpenRouter — and remains a tracker-side catalog fix.)
+- **DIP159 no longer false-positives a `file`/`secret` input consumed via its staged path** ([#215](https://github.com/2389-research/dippin-lang/issues/215), regression in v0.56.0). A `file` or `secret` input is consumed out-of-band by reading its staged path in a shell command — and DIP157 forbids `${inputs.x}` inside a `command:` — so it is legitimately never `${inputs.x}`-referenced. DIP159 was flagging it as a dead input, a DIP157/DIP159 pincer that made the documented staged-file pattern un-lintable (surfaced adopting v0.56.0 in tracker). `file` and `secret` inputs are now exempt from DIP159; `text`/`number`/`bool`/`enum` are still dead-input-checked.
+
+
 ## [v0.56.0] — 2026-08-10
 
 ### Added


### PR DESCRIPTION
Patch: (1) DIP159 no longer false-positives file/secret inputs consumed via staged path (v0.56.0 regression blocking tracker adoption, #215); (2) gpt-5.2-codex now prices as an alias of gpt-5.2 instead of escaping --max-cost (#209). Both surfaced by tracker's v0.56.0/pricing adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788974566&installation_model_id=21126&pr_number=219&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F219&signature=165489a88dbeb30db9673cae98e82a7d6f886f38103e5ac3b8c0ebd6bd575133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->