### PR TITLE
release: v0.57.0 — cache pricing rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.57.0] — 2026-08-10
 
 ### Added
 - **`prices.json` now carries cache read/write rates for the verified providers** ([#210](https://github.com/2389-research/dippin-lang/issues/210)). `pricing.ModelPrice`/`pricing.Cost` have always honored cache fields, but the data left them unset, so cache traffic priced at $0 and consumers (tracker) overlaid their own cache table — two tables that could drift. Verified 2026-08-10 against official docs and populated: **Anthropic** `cache_read_mult: 0.1` + `cache_write_mult: 1.25` (0.1× read, 1.25× 5-minute write, uniform across models); **OpenAI** and **Gemini** `cache_read_mult: 0.1` (0.1× read; OpenAI has no per-token write charge, Gemini's cache cost is an hourly storage fee outside the per-token schema). The other providers (DeepSeek, Mistral, Cohere, xAI, Z.AI, Moonshot, MiniMax, Qwen) are left at 0 — their cache conventions weren't verifiable from official pages, so a consumer keeps overlaying those until they are. A downstream consumer can now drop its cache overlay for Anthropic/OpenAI/Gemini and read the rates from `pricing`.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,12 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.57.0] — 2026-08-10
+
+### Added
+- **`prices.json` now carries cache read/write rates for the verified providers** ([#210](https://github.com/2389-research/dippin-lang/issues/210)). `pricing.ModelPrice`/`pricing.Cost` have always honored cache fields, but the data left them unset, so cache traffic priced at $0 and consumers (tracker) overlaid their own cache table — two tables that could drift. Verified 2026-08-10 against official docs and populated: **Anthropic** `cache_read_mult: 0.1` + `cache_write_mult: 1.25` (0.1× read, 1.25× 5-minute write, uniform across models); **OpenAI** and **Gemini** `cache_read_mult: 0.1` (0.1× read; OpenAI has no per-token write charge, Gemini's cache cost is an hourly storage fee outside the per-token schema). The other providers (DeepSeek, Mistral, Cohere, xAI, Z.AI, Moonshot, MiniMax, Qwen) are left at 0 — their cache conventions weren't verifiable from official pages, so a consumer keeps overlaying those until they are. A downstream consumer can now drop its cache overlay for Anthropic/OpenAI/Gemini and read the rates from `pricing`.
+
+
 ## [v0.56.1] — 2026-08-10
 
 ### Fixed


### PR DESCRIPTION
Promotes changelog to v0.57.0: prices.json now carries cache read/write rates for Anthropic/OpenAI/Gemini (#210). Tagging lets tracker adopt and drop its cache overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788975131&installation_model_id=21126&pr_number=221&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F221&signature=b5308e5fc0ba5f84fbd83e518699573456b54abfc77ed00287c78c157bdd2415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->