### PR TITLE
release: v0.58.0 — DIP160 subgraph input arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.58.0] — 2026-08-10
 
 ### Added
 - **DIP160 — cross-file subgraph input arity (inputs Phase 3)** ([#190](https://github.com/2389-research/dippin-lang/issues/190)). A `subgraph` node whose `params:` omits an input the referenced child declares `required: true` now warns: the child would start with that input unset. It's a cross-file check (like DIP146) run by `validate`/`check`/`watch` — it resolves and parses the child to read its `inputs`, skipped for `.dipx` bundles and unreadable children. Catalog now **70 codes (DIP101–DIP160)**.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,15 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.58.0] — 2026-08-10
+
+### Added
+- **DIP160 — cross-file subgraph input arity (inputs Phase 3)** ([#190](https://github.com/2389-research/dippin-lang/issues/190)). A `subgraph` node whose `params:` omits an input the referenced child declares `required: true` now warns: the child would start with that input unset. It's a cross-file check (like DIP146) run by `validate`/`check`/`watch` — it resolves and parses the child to read its `inputs`, skipped for `.dipx` bundles and unreadable children. Catalog now **70 codes (DIP101–DIP160)**.
+
+### Note
+- **DIP161 dropped from the plan.** The originally-planned "untrusted input flows into a tool-bearing agent" lint has no clean, non-noisy trigger: for `text`/`number`/`enum` inputs, feeding caller input into a tool-capable agent is the normal agentic pattern (every idea-to-pr workflow), and for `file`/`secret` inputs `${inputs.x}` resolves to a staged *path*, not the value (see #215), so flagging it would repeat the DIP159 false-positive mistake. The genuinely-dangerous case — an input reference in a tool `command:` — is already covered by DIP157. Phase 3 is DIP160 only; #190's input lints are complete.
+
+
 ## [v0.57.0] — 2026-08-10
 
 ### Added


### PR DESCRIPTION
Promotes changelog to v0.58.0 (DIP160, #190 Phase 3 — completes the inputs feature's lints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU7HSXYSm6n1moA3RzCeUR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788975894&installation_model_id=21126&pr_number=223&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F223&signature=a9750123bf914ef3eae09e32f70a97afc78835bd81cd8e36d829dbaefe4211fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->