### PR TITLE
release: v0.59.0 — lossless dip 2 retry-channel migration + ModelPrice.Deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.59.0] — 2026-08-10
 
 ### Changed
 - **`dip 2` re-admits the retry channel as a node attribute; `fmt --migrate` is now lossless** ([#204](https://github.com/2389-research/dippin-lang/issues/204), [#186](https://github.com/2389-research/dippin-lang/issues/186)). The retry channel — `retry_target` and the retry-exhaustion route — is addressed to the engine's retry dispatcher, which reads it from the **node**, never from the `edges` block. The #134/#136 redesign had rejected these under `dip 2` and made `fmt --migrate` rewrite them into `on fail`/`loop` edges, but the engine doesn't consult edges for retries, so that conversion was a latent data-loss bug (a non-self `retry_target` silently became a self-retry — the old exit-code `4` "not runtime-equivalent" stopgap). Now: `dip 2` **accepts** `retry_target` unchanged and accepts the retry-exhaustion route under the new spelling **`fallback_retry_target`** (the `dip 2` name disambiguates it from an `on fail` edge); `dip 1` keeps `fallback_target`. `dippin fmt --migrate` is a **lossless** version bump — it keeps the channel on the node and only relabels `fallback_target` → `fallback_retry_target`. A node may carry both a `fallback_retry_target` (retry-exhaustion route) and an `on fail` edge (genuine-failure route); they are distinct channels and both survive migration.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,16 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.59.0] — 2026-08-10
+
+### Changed
+- **`dip 2` re-admits the retry channel as a node attribute; `fmt --migrate` is now lossless** ([#204](https://github.com/2389-research/dippin-lang/issues/204), [#186](https://github.com/2389-research/dippin-lang/issues/186)). The retry channel — `retry_target` and the retry-exhaustion route — is addressed to the engine's retry dispatcher, which reads it from the **node**, never from the `edges` block. The #134/#136 redesign had rejected these under `dip 2` and made `fmt --migrate` rewrite them into `on fail`/`loop` edges, but the engine doesn't consult edges for retries, so that conversion was a latent data-loss bug (a non-self `retry_target` silently became a self-retry — the old exit-code `4` "not runtime-equivalent" stopgap). Now: `dip 2` **accepts** `retry_target` unchanged and accepts the retry-exhaustion route under the new spelling **`fallback_retry_target`** (the `dip 2` name disambiguates it from an `on fail` edge); `dip 1` keeps `fallback_target`. `dippin fmt --migrate` is a **lossless** version bump — it keeps the channel on the node and only relabels `fallback_target` → `fallback_retry_target`. A node may carry both a `fallback_retry_target` (retry-exhaustion route) and an `on fail` edge (genuine-failure route); they are distinct channels and both survive migration.
+- **Removed `fmt --migrate` exit code `4`.** With migration now lossless there is no non-runtime-equivalent case; `3` (author review) is retained and currently unused by migration.
+
+### Added
+- **`ModelPrice.Deprecated` marks models retired on the first-party provider API** ([#224](https://github.com/2389-research/dippin-lang/issues/224)). The catalog carries some Anthropic models (`claude-opus-4-1`, `claude-opus-4-0`, `claude-sonnet-4-0`, `claude-haiku-3-5`) that the live first-party Anthropic API rejects with `not_found` — they're retired there but still bill on Bedrock/Vertex passthrough, so they stay priced in the catalog. They now carry `"deprecated": true` (exposed as `ModelPrice.Deprecated`), so a consumer treating the catalog as a first-party allowlist can filter them out. Catalog membership ≠ first-party callability; `priced` (is there a price) and `deprecated` (retired on the first-party API) are independent. Current models are `Deprecated=false`.
+
+
 ## [v0.58.0] — 2026-08-10
 
 ### Added


### PR DESCRIPTION
Cuts **v0.59.0**. Renames the `[Unreleased]` changelog section (Option A #204/#186 + ModelPrice.Deprecated #224) to `[v0.59.0]`.

After merge, tag `v0.59.0` to trigger GoReleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788980817&installation_model_id=21126&pr_number=229&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F229&signature=e84187c243a5c087697b957c9e255c6886e8f3990c1ec8167d6d90a9395e85e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry routing preservation for node attributes in `dip 2`.
  * Introduced the `fallback_retry_target` option.
  * Added deprecation metadata for models retired from first-party provider APIs.

* **Improvements**
  * Made `fmt --migrate` lossless by relabeling only `fallback_target`.
  * Removed migration exit code 4.

* **Documentation**
  * Published the v0.59.0 release notes dated 2026-08-10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->