### PR TITLE
release: v0.59.1 — OpenAI per-family cache_read_mult fix (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.59.1] — 2026-08-10
 
 ### Fixed
 - **OpenAI `cache_read_mult` is now per-family, not a flat 0.1×** ([#225](https://github.com/2389-research/dippin-lang/issues/225)). v0.57.0 (#210) set `cache_read_mult: 0.1` for every OpenAI model, but OpenAI's cached-input discount varies by family: the **gpt-4o** family is **0.5×** ($2.50 → $1.25 cached) and the **gpt-4.1** family is **0.25×** ($2.00 → $0.50 cached); only the **GPT-5** family is **0.1×**. The flat value underpriced gpt-4o/gpt-4.1 cache reads by 2.5–5×, so a consumer trusting `pricing.Cost` under-enforced cost caps for those models. Verified 2026-08-10 against developers.openai.com/api/docs/pricing and corrected: `gpt-4o`/`gpt-4o-mini` → 0.5, `gpt-4.1`/`gpt-4.1-mini`/`gpt-4.1-nano` → 0.25; GPT-5 family unchanged. Found adopting v0.57.0 in tracker (tracker#562).

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.59.1] — 2026-08-10
+
+### Fixed
+- **OpenAI `cache_read_mult` is now per-family, not a flat 0.1×** ([#225](https://github.com/2389-research/dippin-lang/issues/225)). v0.57.0 (#210) set `cache_read_mult: 0.1` for every OpenAI model, but OpenAI's cached-input discount varies by family: the **gpt-4o** family is **0.5×** ($2.50 → $1.25 cached) and the **gpt-4.1** family is **0.25×** ($2.00 → $0.50 cached); only the **GPT-5** family is **0.1×**. The flat value underpriced gpt-4o/gpt-4.1 cache reads by 2.5–5×, so a consumer trusting `pricing.Cost` under-enforced cost caps for those models. Verified 2026-08-10 against developers.openai.com/api/docs/pricing and corrected: `gpt-4o`/`gpt-4o-mini` → 0.5, `gpt-4.1`/`gpt-4.1-mini`/`gpt-4.1-nano` → 0.25; GPT-5 family unchanged. Found adopting v0.57.0 in tracker (tracker#562).
+
 ## [v0.59.0] — 2026-08-10
 
 ### Changed


### PR DESCRIPTION
Cuts **v0.59.1** (patch). Renames the `[Unreleased]` changelog section (#225 OpenAI per-family cache-read fix) to `[v0.59.1]`.

After merge, tag `v0.59.1` to trigger GoReleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788981624&installation_model_id=21126&pr_number=231&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F231&signature=e79ffa1df6454a223a9c95d7d76f1b7a7162c4bfd58fd52cb3b93aec955e2047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published the v0.59.1 release notes dated August 10, 2026.
  * Documented corrected OpenAI cache-read multipliers:
    * 0.5× for GPT-4o models
    * 0.25× for GPT-4.1 models
    * 0.1× for GPT-5 models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->