### PR TITLE
feat(pricing-sync): drift suppress-list to silence dispositioned candidates (#211)

### DIFF
--- a/.github/workflows/pricing-sync.yml
+++ b/.github/workflows/pricing-sync.yml
@@ -69,6 +69,8 @@ jobs:
             echo
             echo "> ⚠️ **Human-gated.** Confirm each candidate against the model's official \`source\` URL before editing \`pricing/prices.json\`. models.dev is a detection aid, not an authority — it can reflect introductory or discounted rates (an intro price vs. the durable list price)."
             echo
+            echo "> Already-dispositioned candidates are filtered by \`cmd/pricing-sync/drift_suppressions.json\` (they re-surface if the aggregator value changes or the entry's \`review_by\` passes). To silence a persistent false alarm, add an entry there."
+            echo
             echo '### Price / deprecation drift (`sync --existing-only --tolerance 0.02`)'
             echo '```'
             cat drift.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **pricing-sync drift suppress-list** ([#211](https://github.com/2389-research/dippin-lang/issues/211)). The daily drift Action re-opened the same issue (#201, #206) for the same persistently-deferred candidates — models.dev's intro-vs-durable price for `claude-sonnet-5`, JS-gated Mistral/Cohere pages, and unreliable `deprecated` flags on active OpenAI/Gemini models. `cmd/pricing-sync` now carries a checked-in `drift_suppressions.json` (keyed on `provider`/`model`/`kind` + the dispositioned `aggregator_value`, with a `reason` and a `review_by` date). `sync` filters a suppressed candidate **unless** the aggregator's reported value has changed from the dispositioned one, or the `review_by` date has passed — either re-surfaces it for fresh review. So the daily Action only opens/updates an issue on a genuinely new or changed candidate. Seeded with the nine entries stable across #201 and #206.
+
 ## [v0.59.1] — 2026-08-10
 
 ### Fixed

--- a/cmd/pricing-sync/drift_suppressions.json
+++ b/cmd/pricing-sync/drift_suppressions.json
@@ -1,0 +1,74 @@
+[
+  {
+    "provider": "anthropic",
+    "model": "claude-sonnet-5",
+    "kind": "price",
+    "aggregator_value": "2/10",
+    "reason": "models.dev reports the introductory rate; catalog 3/15 is the durable list price. Dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  },
+  {
+    "provider": "cohere",
+    "model": "command-r-08-2024",
+    "kind": "price",
+    "aggregator_value": "0.15/0.6",
+    "reason": "Cohere's official pricing page is JS-gated and not machine-verifiable; catalog value is the last human-verified rate. Dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  },
+  {
+    "provider": "mistral",
+    "model": "mistral-nemo",
+    "kind": "price",
+    "aggregator_value": "0.15/0.15",
+    "reason": "Mistral's official pricing page is JS-gated and not machine-verifiable; catalog value is the last human-verified rate. Dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  },
+  {
+    "provider": "mistral",
+    "model": "mistral-small-2603",
+    "kind": "price",
+    "aggregator_value": "0.15/0.6",
+    "reason": "Mistral's official pricing page is JS-gated and not machine-verifiable; catalog value is the last human-verified rate. Dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  },
+  {
+    "provider": "gemini",
+    "model": "gemini-2.0-flash",
+    "kind": "deprecated",
+    "aggregator_value": "deprecated",
+    "reason": "models.dev flags this deprecated, but it remains callable on the first-party Google API. Unreliable aggregator deprecation flag; dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  },
+  {
+    "provider": "gemini",
+    "model": "gemini-3.1-flash-lite-preview",
+    "kind": "deprecated",
+    "aggregator_value": "deprecated",
+    "reason": "models.dev flags this deprecated, but it remains callable on the first-party Google API. Unreliable aggregator deprecation flag; dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  },
+  {
+    "provider": "openai",
+    "model": "gpt-4.1-nano",
+    "kind": "deprecated",
+    "aggregator_value": "deprecated",
+    "reason": "models.dev flags this deprecated, but it remains callable on the first-party OpenAI API. Unreliable aggregator deprecation flag; dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  },
+  {
+    "provider": "openai",
+    "model": "o3-mini",
+    "kind": "deprecated",
+    "aggregator_value": "deprecated",
+    "reason": "models.dev flags this deprecated, but it remains callable on the first-party OpenAI API. Unreliable aggregator deprecation flag; dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  },
+  {
+    "provider": "openai",
+    "model": "o4-mini",
+    "kind": "deprecated",
+    "aggregator_value": "deprecated",
+    "reason": "models.dev flags this deprecated, but it remains callable on the first-party OpenAI API. Unreliable aggregator deprecation flag; dispositioned in the #201/#206 triage.",
+    "review_by": "2026-11-08"
+  }
+]

--- a/cmd/pricing-sync/suppress.go
+++ b/cmd/pricing-sync/suppress.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"time"
+)
+
+//go:embed drift_suppressions.json
+var suppressionsJSON []byte
+
+// suppression records a drift candidate a human has already dispositioned so the
+// daily sync stops re-flagging it — until its review_by date passes, or until the
+// aggregator's reported value changes from the one dispositioned here (either
+// re-surfaces the candidate for fresh review). Keyed on provider/model/kind plus
+// the canonical aggregator value (see change.Agg).
+type suppression struct {
+	Provider   string `json:"provider"`
+	Model      string `json:"model"`
+	Kind       string `json:"kind"` // "price" | "deprecated" | "new"
+	Aggregator string `json:"aggregator_value"`
+	Reason     string `json:"reason"`
+	ReviewBy   string `json:"review_by"` // YYYY-MM-DD
+}
+
+// loadSuppressions parses the embedded checked-in suppress-list.
+func loadSuppressions() ([]suppression, error) {
+	var out []suppression
+	if err := json.Unmarshal(suppressionsJSON, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// active reports whether the suppression is still in effect at now (before its
+// review_by date). A missing or malformed review_by is treated as expired, so a
+// bad entry re-surfaces the candidate rather than hiding it indefinitely.
+func (s suppression) active(now time.Time) bool {
+	t, err := time.Parse("2006-01-02", s.ReviewBy)
+	if err != nil {
+		return false
+	}
+	return now.Before(t)
+}
+
+// matches reports whether the suppression covers this change: same identity and
+// the same aggregator value that was dispositioned. A changed aggregator value
+// won't match, so the candidate re-surfaces.
+func (s suppression) matches(c change) bool {
+	return s.Provider == c.Provider && s.Model == c.Model &&
+		s.Kind == c.Kind && s.Aggregator == c.Agg
+}
+
+// applySuppressions drops changes covered by an active suppression, returning the
+// survivors and the count suppressed.
+func applySuppressions(changes []change, sups []suppression, now time.Time) ([]change, int) {
+	kept := changes[:0]
+	suppressed := 0
+	for _, c := range changes {
+		if suppressedBy(c, sups, now) {
+			suppressed++
+			continue
+		}
+		kept = append(kept, c)
+	}
+	return kept, suppressed
+}
+
+func suppressedBy(c change, sups []suppression, now time.Time) bool {
+	for _, s := range sups {
+		if s.active(now) && s.matches(c) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/pricing-sync/sync.go
+++ b/cmd/pricing-sync/sync.go
@@ -28,6 +28,10 @@ type change struct {
 	Provider string
 	Model    string
 	Detail   string
+	// Agg is the canonical aggregator-side value used to match a suppression:
+	// "%.4g/%.4g" input/output for new/price changes, "deprecated" for a
+	// deprecation flag. A suppression only applies while this value is unchanged.
+	Agg string
 }
 
 // runSync fetches machine-readable aggregators, diffs against the embedded
@@ -41,21 +45,32 @@ func runSync(ctx context.Context, args []string) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	sups, err := loadSuppressions()
+	if err != nil {
+		fmt.Fprintf(errOut, "pricing-sync: bad drift_suppressions.json: %v\n", err)
+		return 1
+	}
 	cands, err := modelsDevFetcher{}.Fetch(ctx)
 	if err != nil {
 		fmt.Fprintf(errOut, "pricing-sync: fetch failed: %v\n", err)
 		return 1
 	}
-	return reportChanges(cands, *tol, *existingOnly, *failOnChanges)
+	return reportChanges(cands, *tol, *existingOnly, *failOnChanges, sups, time.Now())
 }
 
-// reportChanges diffs, optionally filters, prints, and returns the exit code.
-func reportChanges(cands []candidate, tol float64, existingOnly, failOnChanges bool) int {
+// reportChanges diffs, filters (drop-new + suppress-list), prints, and returns
+// the exit code. Suppressed candidates are dispositioned drift the daily Action
+// should not re-open an issue for (see drift_suppressions.json).
+func reportChanges(cands []candidate, tol float64, existingOnly, failOnChanges bool, sups []suppression, now time.Time) int {
 	changes := diff(cands, tol)
 	if existingOnly {
 		changes = dropNew(changes)
 	}
+	changes, suppressed := applySuppressions(changes, sups, now)
 	printChanges(changes, len(cands))
+	if suppressed > 0 {
+		printfOut("pricing-sync: %d dispositioned candidate(s) suppressed via drift_suppressions.json\n", suppressed)
+	}
 	if failOnChanges && len(changes) > 0 {
 		return 1
 	}
@@ -96,22 +111,23 @@ func diff(cands []candidate, tol float64) []change {
 }
 
 func appendChange(out []change, c candidate, tol float64) []change {
+	agg := fmt.Sprintf("%.4g/%.4g", c.InputPerM, c.OutputPerM)
 	p, found := pricing.LookupProvider(c.Provider, c.Model)
 	if !found {
 		return append(out, change{Kind: "new", Provider: c.Provider, Model: c.Model,
-			Detail: fmt.Sprintf("%.4g/%.4g per MTok (not in catalog)", c.InputPerM, c.OutputPerM)})
+			Detail: fmt.Sprintf("%s per MTok (not in catalog)", agg), Agg: agg})
 	}
 	if !p.Priced {
 		return out
 	}
 	if c.Deprecated {
 		out = append(out, change{Kind: "deprecated", Provider: c.Provider, Model: c.Model,
-			Detail: "aggregator marks deprecated"})
+			Detail: "aggregator marks deprecated", Agg: "deprecated"})
 	}
 	if priceDiffers(p, c, tol) {
 		out = append(out, change{Kind: "price", Provider: c.Provider, Model: c.Model,
-			Detail: fmt.Sprintf("catalog %.4g/%.4g → aggregator %.4g/%.4g",
-				p.InputPerM, p.OutputPerM, c.InputPerM, c.OutputPerM)})
+			Detail: fmt.Sprintf("catalog %.4g/%.4g → aggregator %s",
+				p.InputPerM, p.OutputPerM, agg), Agg: agg})
 	}
 	return out
 }

--- a/cmd/pricing-sync/sync_test.go
+++ b/cmd/pricing-sync/sync_test.go
@@ -1,6 +1,72 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+var testNow = time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+
+func TestApplySuppressions_FiltersActiveDispositioned(t *testing.T) {
+	changes := []change{
+		{Kind: "price", Provider: "anthropic", Model: "claude-sonnet-5", Agg: "2/10"},
+		{Kind: "deprecated", Provider: "openai", Model: "o3-mini", Agg: "deprecated"},
+		{Kind: "price", Provider: "openai", Model: "gpt-9-real", Agg: "5/20"}, // not suppressed
+	}
+	sups := []suppression{
+		{Provider: "anthropic", Model: "claude-sonnet-5", Kind: "price", Aggregator: "2/10", ReviewBy: "2026-11-08"},
+		{Provider: "openai", Model: "o3-mini", Kind: "deprecated", Aggregator: "deprecated", ReviewBy: "2026-11-08"},
+	}
+	kept, n := applySuppressions(changes, sups, testNow)
+	if n != 2 {
+		t.Fatalf("suppressed = %d, want 2", n)
+	}
+	if len(kept) != 1 || kept[0].Model != "gpt-9-real" {
+		t.Errorf("kept = %+v, want only gpt-9-real", kept)
+	}
+}
+
+func TestApplySuppressions_ReSurfacesOnChangedAggValue(t *testing.T) {
+	// The aggregator now reports 1/8 instead of the dispositioned 2/10 — the
+	// disposition no longer applies, so it must re-surface.
+	changes := []change{{Kind: "price", Provider: "anthropic", Model: "claude-sonnet-5", Agg: "1/8"}}
+	sups := []suppression{{Provider: "anthropic", Model: "claude-sonnet-5", Kind: "price", Aggregator: "2/10", ReviewBy: "2026-11-08"}}
+	kept, n := applySuppressions(changes, sups, testNow)
+	if n != 0 || len(kept) != 1 {
+		t.Errorf("changed aggregator value must re-surface; kept=%+v suppressed=%d", kept, n)
+	}
+}
+
+func TestApplySuppressions_ExpiredReviewByReSurfaces(t *testing.T) {
+	changes := []change{{Kind: "price", Provider: "anthropic", Model: "claude-sonnet-5", Agg: "2/10"}}
+	sups := []suppression{{Provider: "anthropic", Model: "claude-sonnet-5", Kind: "price", Aggregator: "2/10", ReviewBy: "2026-01-01"}}
+	kept, n := applySuppressions(changes, sups, testNow)
+	if n != 0 || len(kept) != 1 {
+		t.Errorf("expired suppression (past review_by) must re-surface; kept=%+v suppressed=%d", kept, n)
+	}
+}
+
+// TestEmbeddedSuppressionsWellFormed guards the checked-in drift_suppressions.json:
+// it parses, every entry has the required fields, a valid kind, and a parseable
+// review_by date (a malformed date silently disables a suppression, so fail loud).
+func TestEmbeddedSuppressionsWellFormed(t *testing.T) {
+	sups, err := loadSuppressions()
+	if err != nil {
+		t.Fatalf("embedded drift_suppressions.json does not parse: %v", err)
+	}
+	validKind := map[string]bool{"price": true, "deprecated": true, "new": true}
+	for _, s := range sups {
+		if s.Provider == "" || s.Model == "" || s.Aggregator == "" || s.Reason == "" {
+			t.Errorf("incomplete suppression: %+v", s)
+		}
+		if !validKind[s.Kind] {
+			t.Errorf("%s/%s: invalid kind %q", s.Provider, s.Model, s.Kind)
+		}
+		if _, err := time.Parse("2006-01-02", s.ReviewBy); err != nil {
+			t.Errorf("%s/%s: review_by %q is not YYYY-MM-DD", s.Provider, s.Model, s.ReviewBy)
+		}
+	}
+}
 
 // findChange returns the change for a model, or nil.
 func findChange(changes []change, model string) *change {


### PR DESCRIPTION
## What

The daily pricing-drift Action re-opened the same issue (#201, #206) for the same persistently-deferred candidates — models.dev's intro-vs-durable price for `claude-sonnet-5`, JS-gated Mistral/Cohere pages, and unreliable `deprecated` flags on active OpenAI/Gemini models. Each run re-flagged them → recurring noise requiring re-disposition.

## How

`cmd/pricing-sync` now carries a checked-in **`drift_suppressions.json`**, each entry keyed on `provider`/`model`/`kind` + the dispositioned `aggregator_value`, with a `reason` and a `review_by` date. `sync` filters a suppressed candidate **unless**:
- the aggregator's reported value has **changed** from the dispositioned one (→ re-surfaces for fresh review), or
- the entry's **`review_by`** date has passed (→ re-surfaces to force periodic re-verification).

So the daily Action's `changed=true` grep finds nothing for dispositioned entries, and only opens/updates an issue on a genuinely new or changed candidate.

Seeded with the **nine entries stable across #201 and #206** (`claude-sonnet-5` price; `command-r-08-2024`, `mistral-nemo`, `mistral-small-2603` prices; `gemini-2.0-flash`, `gemini-3.1-flash-lite-preview`, `gpt-4.1-nano`, `o3-mini`, `o4-mini` deprecated flags), each with `review_by: 2026-11-08`.

## Notes / decisions

- Placed the file in `cmd/pricing-sync/` (embedded by the tool that consumes it) rather than `pricing/` as the issue illustratively suggested — keeps the leaf `pricing` package limited to price data, no new public API. 
- Tests cover match, re-surface-on-changed-value, `review_by` expiry, and embedded-file well-formedness.

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788982571&installation_model_id=21126&pr_number=233&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F233&signature=63e1c92f74ac5e7ed905eb3b2fde64730a1754ebea2d338619ece836749a7eda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->