### PR TITLE
fix(doctor): apply cross-file DIP146 supersession in the health card (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 ### Added
 - **pricing-sync drift suppress-list** ([#211](https://github.com/2389-research/dippin-lang/issues/211)). The daily drift Action re-opened the same issue (#201, #206) for the same persistently-deferred candidates — models.dev's intro-vs-durable price for `claude-sonnet-5`, JS-gated Mistral/Cohere pages, and unreliable `deprecated` flags on active OpenAI/Gemini models. `cmd/pricing-sync` now carries a checked-in `drift_suppressions.json` (keyed on `provider`/`model`/`kind` + the dispositioned `aggregator_value`, with a `reason` and a `review_by` date). `sync` filters a suppressed candidate **unless** the aggregator's reported value has changed from the dispositioned one, or the `review_by` date has passed — either re-surfaces it for fresh review. So the daily Action only opens/updates an issue on a genuinely new or changed candidate. Seeded with the nine entries stable across #201 and #206.
 
+### Fixed
+- **`dippin doctor` now applies the cross-file DIP146 pass / DIP143 supersession** ([#101](https://github.com/2389-research/dippin-lang/issues/101), deferred from #89). Doctor's lint summary previously computed lint inside the `doctor` package and never saw the CLI-layer cross-file resolution, so a fully-restricted (or agent-less) resolved child left a stale DIP143 hint in the health card that `lint`/`check`/`watch` had already superseded. Doctor now receives the cross-file-adjusted diagnostics via a new `doctor.DiagnoseFromDiagnostics` seam (the CLI owns the native pass; `doctor` still imports no CLI code), so its hint count matches the other commands. Only the tool_access pass is threaded in — DIP160 cross-file input arity is a Warning and folding it into the score is a separate change. Score/Grade are unaffected (they react only to errors and warnings).
+
 ## [v0.59.1] — 2026-08-10
 
 ### Fixed

--- a/cmd/dippin/cmd_doctor.go
+++ b/cmd/dippin/cmd_doctor.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/2389-research/dippin-lang/doctor"
+	"github.com/2389-research/dippin-lang/validator"
 )
 
 // CmdDoctor produces a health report card for a workflow.
@@ -20,14 +21,16 @@ func (c *CLI) CmdDoctor(args []string) ExitCode {
 		return ExitError
 	}
 
-	// Note: doctor's lint summary does NOT apply the cross-file DIP146 pass /
-	// DIP143 supersession. doctor.DiagnoseWithOptions composes validator.LintWithOptions inside the
-	// doctor package and surfaces only hint COUNTS, not per-line diagnostics, so
-	// the CLI-layer cross-file pass can't reach it without a layering change. The
-	// effect is minor (a DIP143 vs DIP146 hint is counted the same; only a
-	// fully-restricted child differs by one hint). `dippin lint`/`check`/`watch`
-	// carry the precise DIP146 behavior. (#89)
-	report := doctor.DiagnoseWithOptions(w, lintOptions(extraModels))
+	// doctor's hint count now reflects the cross-file DIP146 pass / DIP143
+	// supersession: the native pass lives here in cmd/dippin (which doctor must
+	// not import), so we run it and hand doctor the corrected diagnostics via
+	// DiagnoseFromDiagnostics. Only the tool_access pass is applied — DIP160
+	// cross-file input arity is a Warning and folding it in would change doctor's
+	// score, out of scope for this hint-count fix. (#101, follows #89)
+	diags := append(validator.Validate(w).Diagnostics,
+		validator.LintWithOptions(w, lintOptions(extraModels)).Diagnostics...)
+	diags = applyCrossFileToolAccess(diags, w, path)
+	report := doctor.DiagnoseFromDiagnostics(w, diags)
 	return c.renderDoctorReport(report)
 }
 

--- a/cmd/dippin/cmd_doctor_test.go
+++ b/cmd/dippin/cmd_doctor_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/2389-research/dippin-lang/doctor"
+	"github.com/2389-research/dippin-lang/validator"
+)
+
+// doctorHints computes the doctor lint-hint count the CLI way: validate + lint,
+// then the cross-file tool_access supersession, then DiagnoseFromDiagnostics —
+// mirroring CmdDoctor.
+func doctorHints(t *testing.T, dir, entry string) int {
+	t.Helper()
+	w, err := loadWorkflow(dir + "/" + entry)
+	if err != nil {
+		t.Fatalf("load %s: %v", entry, err)
+	}
+	diags := append(validator.Validate(w).Diagnostics,
+		validator.LintWithOptions(w, validator.Options{}).Diagnostics...)
+	diags = applyCrossFileToolAccess(diags, w, dir+"/"+entry)
+	return doctor.DiagnoseFromDiagnostics(w, diags).Lint.Hints
+}
+
+// TestDoctor_CrossFileSupersedesDIP143 proves doctor's hint count now reflects
+// the cross-file pass: a fully-restricted resolved child supersedes the per-file
+// DIP143 advisory, so doctor reports one fewer hint than the pass-free summary
+// (#101). This is exactly the "only a fully-restricted child differs by one hint"
+// case the prior known-limitation note described.
+func TestDoctor_CrossFileSupersedesDIP143(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip": entryRestrictsRefs("child.dip"),
+		"child.dip": childFullRestrict,
+	})
+	w, err := loadWorkflow(dir + "/entry.dip")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Pass-free summary (old behavior): the entry declares tool_access and
+	// references a child, so validator.Lint emits the DIP143 advisory (a hint).
+	before := doctor.DiagnoseWithOptions(w, validator.Options{}).Lint.Hints
+	after := doctorHints(t, dir, "entry.dip")
+
+	if before == 0 {
+		t.Fatal("expected the pass-free summary to carry a DIP143 hint to supersede")
+	}
+	if after != before-1 {
+		t.Errorf("cross-file supersession should drop one hint: before=%d after=%d", before, after)
+	}
+}
+
+// TestDoctor_CrossFileZeroIntentKeepsHintCount confirms a zero-intent child swaps
+// DIP143 for DIP146 (both hints) — the count is unchanged, but the pass still runs.
+func TestDoctor_CrossFileZeroIntentKeepsHintCount(t *testing.T) {
+	dir := writeWorkflows(t, map[string]string{
+		"entry.dip": entryRestrictsRefs("child.dip"),
+		"child.dip": childZeroIntent,
+	})
+	w, err := loadWorkflow(dir + "/entry.dip")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	before := doctor.DiagnoseWithOptions(w, validator.Options{}).Lint.Hints
+	after := doctorHints(t, dir, "entry.dip")
+	if after != before {
+		t.Errorf("zero-intent child swaps DIP143→DIP146 (both hints); count should hold: before=%d after=%d", before, after)
+	}
+}

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -53,15 +53,28 @@ type Suggestion struct {
 
 // DiagnoseWithOptions produces a health Report, threading per-invocation lint
 // options (e.g. a scoped extra-models catalog) into the lint pass so doctor's
-// DIP108 summary matches `dippin lint --extra-models`.
+// DIP108 summary matches `dippin lint --extra-models`. It computes validate +
+// lint internally and therefore does NOT apply the CLI-layer cross-file DIP146
+// resolution; a caller that has run that pass should use DiagnoseFromDiagnostics.
 func DiagnoseWithOptions(w *ir.Workflow, opts validator.Options) *Report {
 	valResult := validator.Validate(w)
 	lintResult := validator.LintWithOptions(w, opts)
+	diags := append(append([]validator.Diagnostic{}, valResult.Diagnostics...), lintResult.Diagnostics...)
+	return DiagnoseFromDiagnostics(w, diags)
+}
+
+// DiagnoseFromDiagnostics builds a health Report from a caller-supplied diagnostic
+// set (validate + lint, plus any adjustments the caller made). This is the seam
+// that lets the CLI thread in its cross-file DIP146/DIP143 supersession — the
+// native pass lives in cmd/dippin, which doctor must not import, so the CLI runs
+// it and hands doctor the corrected diagnostics. Score/Grade react only to errors
+// and warnings, so a cross-file hint adjustment changes only the hint count.
+func DiagnoseFromDiagnostics(w *ir.Workflow, diags []validator.Diagnostic) *Report {
 	covReport := coverage.Analyze(w)
 	costReport := cost.Analyze(w, cost.DefaultPricing())
 
 	r := &Report{}
-	r.Lint = buildLintSummary(valResult, lintResult)
+	r.Lint = buildLintSummary(diags)
 	r.Coverage = buildCovSummary(covReport)
 	r.Cost = CostSummary{Total: costReport.Total}
 	r.Score = computeScore(r)
@@ -70,13 +83,10 @@ func DiagnoseWithOptions(w *ir.Workflow, opts validator.Options) *Report {
 	return r
 }
 
-// buildLintSummary counts errors, warnings, and hints from both passes.
-func buildLintSummary(val, lint validator.Result) LintSummary {
+// buildLintSummary counts errors, warnings, and hints across the diagnostic set.
+func buildLintSummary(diags []validator.Diagnostic) LintSummary {
 	var s LintSummary
-	for _, d := range val.Diagnostics {
-		classifyDiagnostic(&s, d)
-	}
-	for _, d := range lint.Diagnostics {
+	for _, d := range diags {
 		classifyDiagnostic(&s, d)
 	}
 	return s


### PR DESCRIPTION
## What

Deferred from #89. `dippin doctor`'s lint summary computed lint **inside** the `doctor` package and never saw the CLI-layer cross-file DIP146 pass / DIP143 supersession that `lint`/`check`/`watch` apply. So a fully-restricted (or agent-less) resolved child left a stale DIP143 hint in the health card that the other commands had already superseded.

## How (layering-respecting DI)

The native cross-file pass lives in `cmd/dippin` (which `doctor` must not import). New seam:

- `doctor.DiagnoseFromDiagnostics(w, diags)` — builds the report from caller-supplied diagnostics.
- `DiagnoseWithOptions` stays as a thin wrapper (computes validate+lint, delegates) for callers that don't need cross-file resolution.
- `CmdDoctor` now runs validate + lint, applies `applyCrossFileToolAccess`, and passes the corrected set to `DiagnoseFromDiagnostics`.

`doctor` imports no CLI code; the CLI owns the pass.

## Scope

Only the **tool_access** pass is threaded in. DIP160 cross-file input arity is a **Warning**, and `computeScore` reacts only to errors/warnings — folding it in would change doctor's score, a separate change. This fix touches **only the hint count**; Score/Grade/Suggestions are unaffected. This is exactly the "only a fully-restricted child differs by one hint" case the prior known-limitation note described.

Tests: a full-restrict child drops one hint; a zero-intent child swaps DIP143→DIP146 (count holds).

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788982893&installation_model_id=21126&pr_number=234&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F234&signature=f4ea081600cbfcf28144de714c21c0a27456930717c4bb16bb1028b76384dfdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated `dippin doctor` to account for cross-file-adjusted diagnostics consistently with lint, check, and watch.
  - Correctly handles tool-access restrictions and superseded diagnostics in doctor hints.
  - Preserved existing score and grade behavior.

- **Tests**
  - Added regression coverage for fully restricted and zero-intent child workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->