### PR TITLE
docs: type all untyped fenced code blocks in docs/ (MD040) (#86)

### DIFF
--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -8,7 +8,7 @@ Generate from template: `dippin new minimal`, `dippin new parallel`, `dippin new
 
 ## Grammar (simplified BNF)
 
-```
+```dippin
 workflow <Name>
   goal: "<text>"
   [requires: <dep1>, <dep2>, ...]
@@ -71,7 +71,7 @@ All kinds also accept: `label`, `reads`, `writes`, `retry_policy`, `max_retries`
 
 ## Edge Conditions
 
-```
+```dippin
 when <variable> <op> <value>
 when <expr> and <expr>
 when <expr> or <expr>
@@ -116,7 +116,7 @@ Tool nodes that declare `marker_grep:` are also treated as exhaustive (typed rou
 
 This means the common pattern below is valid with zero warnings:
 
-```
+```dippin
 Gate -> Fix when ctx.outcome = fail
 Gate -> Next when ctx.outcome = success
 ```
@@ -125,7 +125,7 @@ Gate -> Next when ctx.outcome = success
 
 ## Example: Conditional Routing
 
-```
+```dippin
 workflow ReviewPipeline
   goal: "Review code and route by outcome"
   start: Analyze

--- a/docs/DIPPIN_DESIGN_PLAN.md
+++ b/docs/DIPPIN_DESIGN_PLAN.md
@@ -10,7 +10,7 @@ The runtime is a production Go pipeline engine that executes AI-driven workflows
 
 **Dippin** replaces DOT as the authoring format while keeping DOT as an export target. The architecture is:
 
-```
+```text
 Dippin source → Parser → Canonical IR → Execution Engine
                                       → DOT Export (visualization)
                                       → Linter / Validator
@@ -808,7 +808,7 @@ This is critical for predictable behavior. When multiple sources can set the sam
 
 ### Precedence (lowest to highest, higher wins)
 
-```
+```text
 1. Built-in engine defaults     (e.g., model: claude-sonnet-4-5, max_retries: 2)
 2. Workflow defaults             (the `defaults` block in the .dip file)
 3. Imported module defaults      (the `defaults` block in an imported .dip file)
@@ -988,7 +988,7 @@ type SuggestedFix struct {
 
 ### Example diagnostic output
 
-```
+```text
 error[DIP003]: unknown node reference "InterpretX" in edge
   --> pipeline.dip:45:5
    |
@@ -1431,7 +1431,7 @@ All runtime-generated Dippin output goes through the same validator pipeline tha
 
 ## Appendix A: Suggested Repo Layout
 
-```
+```text
 dippin/
 ├── SPEC.md                    # Formal syntax specification
 ├── ir/

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -33,7 +33,7 @@ dippin cost pipeline.dip
 
 **Output:**
 
-```
+```text
 ═══ Cost Estimate ═════════════════════════════════════════
                                 Min Expected      Max
   ──────────────────────── ──────── ──────── ────────
@@ -96,7 +96,7 @@ dippin coverage pipeline.dip
 
 **Output:**
 
-```
+```text
 ═══ Coverage Analysis ═════════════════════════════════════
 ─── Edge Coverage ─────────────────────────────────────────
   ✓ SetupWorkspace               no_conditions
@@ -157,7 +157,7 @@ dippin doctor pipeline.dip
 
 **Output:**
 
-```
+```text
 ═══ Health Report Card ════════════════════════════════════
   Grade: A  Score: 95/100
 
@@ -217,7 +217,7 @@ dippin optimize pipeline.dip
 
 **Output:**
 
-```
+```text
 ═══ Optimization Report ═══════════════════════════════════
 ─── Cost Summary ──────────────────────────────────────────
   Current:   $3.59 (expected)
@@ -293,7 +293,7 @@ dippin diff v1.dip v2.dip
 
 **Output:**
 
-```
+```text
 ═══ Semantic Diff ═════════════════════════════════════════
 ─── Nodes ─────────────────────────────────────────────────
   + FinalQualityGate
@@ -385,7 +385,7 @@ dippin unused pipeline.dip
 
 **Output:**
 
-```
+```text
 ═══ Unused Nodes ══════════════════════════════════════════
   ✗ AbandonedReview              agent (Abandoned Review)
   ✗ OrphanCleanup                tool

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ All downstream consumers program against the **canonical IR** — a set of Go st
 
 ## Package Map
 
-```
+```text
 dippin-lang/
 ├── ir/                 # Canonical intermediate representation (types only)
 │   ├── ir.go           # Workflow, Node, NodeConfig, RetryConfig, NodeIO

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ graph LR
     CMD --> E["Info / Testing<br>version, help, explain, test, spec"]
 ```
 
-```
+```shell
 dippin [--format text|json] <command> [args]
 ```
 

--- a/docs/edges.md
+++ b/docs/edges.md
@@ -49,7 +49,7 @@ All edges are defined in the `edges` block at the bottom of a workflow:
 
 Each edge is a single line:
 
-```
+```dippin
 <FromID> -> <ToID> [on <token> | when <condition>] [label: <text>] [choice: <key>] [weight: <int>] [loop] [override: true]
 ```
 

--- a/docs/evolution_report.md
+++ b/docs/evolution_report.md
@@ -108,7 +108,7 @@ type RetryConfig struct {
 ```
 
 **Dippin Syntax**:
-```
+```dippin
 agent analyze_code:
   prompt: "Analyze this code"
   retry_policy: aggressive
@@ -163,7 +163,7 @@ type AgentConfig struct {
 **Proposed Solution**:
 
 **1. Document valid fidelity levels in the spec**:
-```
+```dippin
 fidelity: full | summary:high | summary:medium | summary:low | compact | truncate
 ```
 
@@ -195,7 +195,7 @@ type FidelityConfig struct {
 
 **Runtime Has** (`stylesheet.go`):
 - CSS-like syntax for per-node LLM config via selectors:
-  ```
+  ```text
   * { model: gpt-4; provider: openai; }
   .coder { model: o1; reasoning_effort: high; }
   #critical_gate { max_retries: 5; }
@@ -212,7 +212,7 @@ type FidelityConfig struct {
 
 Add a top-level `stylesheet` block to Dippin syntax:
 
-```
+```dippin
 workflow analyze_codebase:
   start: scan
   exit: report
@@ -288,7 +288,7 @@ type ParallelBranch struct {
 ```
 
 **Dippin Syntax**:
-```
+```dippin
 parallel analyze:
   branch:
     target: lint
@@ -323,7 +323,7 @@ type SubgraphConfig struct {
 **Proposed Solution** (v1.5):
 
 Add top-level `params` block to Dippin:
-```
+```dippin
 workflow security_scan:
   params:
     repo_path: string  # Required
@@ -448,7 +448,7 @@ type WorkflowDefaults struct {
 - No namespacing enforcement (any key can be accessed)
 
 **Examples**:
-```
+```text
 outcome=success
 outcome!=fail && tool_stdout contains PASSED
 not outcome=retry || human_response startswith yes
@@ -467,7 +467,7 @@ status in completed,partial_success,success
   - `Value`: string literal
 
 **Examples** (after parsing):
-```
+```go
 CondCompare{Variable: "ctx.outcome", Op: "=", Value: "success"}
 CondAnd{
   Left: CondCompare{Variable: "ctx.outcome", Op: "!=", Value: "fail"},
@@ -534,7 +534,7 @@ CondAnd{
 ### The Runtime's Implementation (`stylesheet.go`)
 
 **Syntax**: CSS-like rules in `model_stylesheet` graph attribute (string):
-```
+```text
 * { model: gpt-4o; provider: openai; }
 .coder { model: o1; reasoning_effort: high; }
 #critical_gate { max_retries: 5; retry_policy: aggressive; }
@@ -639,7 +639,7 @@ type Workflow struct {
 - Apply explicit node config last (overrides everything)
 
 **Example resolution**:
-```
+```text
 Node: agent scan, class: [coder]
 
 Matches:
@@ -756,7 +756,7 @@ type WorkflowDefaults struct {
 ```
 
 **Dippin Syntax**:
-```
+```dippin
 workflow analyze:
   defaults:
     fidelity: summary:high
@@ -766,7 +766,7 @@ workflow analyze:
 #### 5.3 Add Validation for Fidelity Values
 
 **DIP-new: Invalid Fidelity Level**
-```
+```text
 Code: DIP113
 Severity: Error
 Message: node "analyze" has invalid fidelity "sumary:high" (typo)
@@ -778,7 +778,7 @@ Help: valid values are: full, summary:high, summary:medium, summary:low, compact
 The `compaction_threshold` field (intended for token-budget-based compaction) is not yet implemented in the runtime. Mark it as **experimental** in Dippin spec and ignore it in v1 validation.
 
 **Future semantics** (v2+):
-```
+```dippin
 agent analyze:
   compaction_threshold: 0.75
   # When context size exceeds 75% of model's context window,
@@ -837,7 +837,7 @@ Events are a **runtime observability layer**, not a workflow modeling primitive.
 
 **Post-v1 Extension** (if needed):
 Add an optional `on_event:` hook for external integrations:
-```
+```dippin
 workflow deploy:
   on_event:
     stage_failed:
@@ -912,7 +912,7 @@ This would be syntactic sugar for configuring the engine's event handler, not a 
 **Missing checks to add**:
 
 **DIP110: Handler Registration** (semantic)
-```
+```text
 Code: DIP110
 Severity: Error
 Message: node "analyze" references unregistered handler "codergen"
@@ -921,7 +921,7 @@ Help: ensure the handler is registered in the engine's HandlerRegistry before ex
 **Implementation**: `ValidateSemantic(w *Workflow, registry *HandlerRegistry)` function (mirrors the runtime's)
 
 **DIP111: Invalid Attribute Types** (semantic)
-```
+```text
 Code: DIP111
 Severity: Error
 Message: node "retry_node" has invalid max_retries "abc": must be a non-negative integer
@@ -929,7 +929,7 @@ Help: change max_retries to a valid integer (e.g., 3)
 ```
 
 **DIP112: Missing Fail Edge on Conditional Node** (warning)
-```
+```text
 Code: DIP112
 Severity: Warning
 Message: node "validate" is a conditional but has no fail edge
@@ -937,7 +937,7 @@ Help: add an edge with condition "ctx.outcome != success" or "ctx.outcome = fail
 ```
 
 **DIP113: Inconsistent Edge Label Usage** (warning)
-```
+```text
 Code: DIP113
 Severity: Warning
 Message: node "validate" has 3 outgoing edges but only 2 are labeled
@@ -945,7 +945,7 @@ Help: either label all edges or remove all labels for consistency
 ```
 
 **DIP114: Invalid Fidelity Level** (error)
-```
+```text
 Code: DIP114
 Severity: Error
 Message: node "analyze" has invalid fidelity "sumary:high"
@@ -993,7 +993,7 @@ $ dippin validate --fix workflow.dip
 3. DIP113: Normalize edge labels (all or none)
 
 **Output**:
-```
+```text
 Applied 3 fixes:
   - Added fail edge validate -> validate (condition: ctx.outcome = fail)
   - Renamed edge target "anlyze" to "analyze"
@@ -1046,7 +1046,7 @@ type SubgraphConfig struct {
 #### 8.1 **Add Parameter Declarations**
 
 Child workflows declare parameters:
-```
+```dippin
 workflow security_scan:
   params:
     repo_path: string          # Required
@@ -1060,7 +1060,7 @@ workflow security_scan:
 ```
 
 Parent workflows pass parameters:
-```
+```dippin
 subgraph run_security_scan:
   ref: ./security_scan.dip
   params:
@@ -1087,7 +1087,7 @@ type Workflow struct {
 #### 8.2 **File-Based Import Resolution**
 
 **Dippin Syntax**:
-```
+```dippin
 subgraph run_scan:
   ref: ./security_scan.dip
   params:
@@ -1114,7 +1114,7 @@ subgraph run_scan:
 - After child completes, parent's `ctx.outcome` is overwritten
 
 **Solution**: Prefix child context keys with subgraph node ID:
-```
+```text
 Parent context before:
   ctx.outcome = "parent_success"
 
@@ -1129,7 +1129,7 @@ Parent context after merge:
 ```
 
 **Dippin Syntax** for accessing child context:
-```
+```dippin
 agent analyze_results:
   prompt: |
     Review the scan results:
@@ -1159,7 +1159,7 @@ agent analyze_results:
 - Default to **inline expansion** for static refs (`.dip` files)
 - Support **runtime dispatch** for dynamic refs (e.g., `${workflow_name}.dip`)
 - Add a `mode:` option:
-  ```
+  ```dippin
   subgraph run_scan:
     ref: ./security_scan.dip
     mode: inline  # or "runtime"
@@ -1172,7 +1172,7 @@ agent analyze_results:
 **DIP-new codes**:
 
 **DIP201: Subgraph Not Found**
-```
+```text
 Code: DIP201
 Severity: Error
 Message: subgraph reference "./security_scan.dip" not found
@@ -1180,7 +1180,7 @@ Help: ensure the file exists relative to the current workflow directory
 ```
 
 **DIP202: Missing Required Parameter**
-```
+```text
 Code: DIP202
 Severity: Error
 Message: subgraph "security_scan" requires parameter "repo_path" but it was not provided
@@ -1188,7 +1188,7 @@ Help: add repo_path: <value> to the params block
 ```
 
 **DIP203: Unknown Parameter**
-```
+```text
 Code: DIP203
 Severity: Warning
 Message: subgraph "security_scan" does not accept parameter "unknown_param"
@@ -1196,7 +1196,7 @@ Help: remove the parameter or check the subgraph's params declaration
 ```
 
 **DIP204: Parameter Type Mismatch**
-```
+```text
 Code: DIP204
 Severity: Error
 Message: parameter "severity" expects type int but got "critical" (string)

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -6,7 +6,7 @@ Compact reference for LLMs generating `.dip` workflow files. Paste into system p
 
 ## Grammar (simplified BNF)
 
-```
+```dippin
 workflow <Name>
   goal: "<text>"
   [requires: <dep1>, <dep2>, ...]
@@ -69,7 +69,7 @@ All kinds also accept: `label`, `reads`, `writes`, `retry_policy`, `max_retries`
 
 ## Edge Conditions
 
-```
+```dippin
 when <variable> <op> <value>
 when <expr> and <expr>
 when <expr> or <expr>
@@ -114,7 +114,7 @@ Tool nodes that declare `marker_grep:` are also treated as exhaustive (typed rou
 
 This means the common pattern below is valid with zero warnings:
 
-```
+```dippin
 Gate -> Fix when ctx.outcome = fail
 Gate -> Next when ctx.outcome = success
 ```
@@ -123,7 +123,7 @@ Gate -> Next when ctx.outcome = success
 
 ## Example: Conditional Routing
 
-```
+```dippin
 workflow ReviewPipeline
   goal: "Review code and route by outcome"
   start: Analyze

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -384,7 +384,7 @@ Parallel nodes fan execution out to multiple branches that run concurrently.
 
 ### Syntax
 
-```
+```dippin
 parallel <ID> -> <target1>, <target2>[, <target3>, ...]
 ```
 
@@ -443,7 +443,7 @@ Fan-in nodes join concurrent branches back together.
 
 ### Syntax
 
-```
+```dippin
 fan_in <ID> <- <source1>, <source2>[, <source3>, ...]
 ```
 

--- a/docs/runtime-response-structured-output-2026-03-31.md
+++ b/docs/runtime-response-structured-output-2026-03-31.md
@@ -134,7 +134,7 @@ for k, v := range cfg.Params {
 
 ### Canonical field ordering in formatted output
 
-```
+```text
 label → model → provider → reasoning_effort → fidelity →
 response_format → response_schema →
 goal_gate → auto_status → max_turns → cmd_timeout →

--- a/docs/superpowers/plans/2026-03-30-interview-mode.md
+++ b/docs/superpowers/plans/2026-03-30-interview-mode.md
@@ -847,7 +847,7 @@ If the upstream output contains no parseable questions (e.g., the agent said "No
 - **DIP127**: Fires if `mode` is not one of `choice`, `freeform`, `interview`.
 - **DIP128**: Fires if `mode: interview` has a `default` value (meaningless — interview doesn't route by selection).
 - **DIP129**: Fires if `mode: interview` has multiple labeled outgoing edges (interview collects answers, not choices).
-```
+```markdown
 
 - [ ] **Step 2: Update the human-specific fields table**
 
@@ -926,7 +926,7 @@ When `cfg.Mode == "interview"`, the runtime is expected to:
   "canceled": false
 }
 ```
-```
+```markdown
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/plans/2026-03-31-blog-posts-6-7-8.md
+++ b/docs/superpowers/plans/2026-03-31-blog-posts-6-7-8.md
@@ -160,7 +160,7 @@ Add the tutorial tag style to the inline `<style>`:
 
 **Section 1: The Linear Baseline** (use `<span class="step-num">1</span>` numbering) — A simple 3-node pipeline. Show the full `.dip` file:
 
-```
+```dippin
 workflow ReviewPipeline
   goal: "Draft, review, and publish a document"
   start: Start
@@ -206,7 +206,7 @@ One paragraph: "This works, but every draft gets published regardless of the rev
 
 **Section 2: Basic Conditions** (step-num 2) — Add `when` conditions to the Review edges:
 
-```
+```dippin
   edges
     Start -> Draft
     Draft -> Review
@@ -233,37 +233,37 @@ One paragraph: "All operators work on string values. The left side is always a c
 
 **Section 4: Compound Conditions** (step-num 4) — Show one example combining conditions:
 
-```
+```dippin
 Review -> Escalate  when ctx.outcome = fail and ctx.feedback contains "security"
 Review -> Draft     when ctx.outcome = fail and ctx.feedback not contains "security"
 ```
 
 Brief note about parentheses for precedence with `or`:
-```
+```dippin
 when (ctx.outcome = fail and ctx.severity = high) or ctx.override = true
 ```
 
 **Section 5: Exhaustive Detection** (step-num 5) — This is the key insight. Show what happens with only one conditional edge:
 
-```
+```dippin
   Review -> Publish  when ctx.outcome = success
   Review -> Exit
 ```
 
-```
+```shell
 $ dippin lint pipeline.dip
 PASS  pipeline.dip  (0 errors, 0 warnings)
 ```
 
 Wait — no DIP101? Explain: the unconditional `Review -> Exit` acts as the fallback. Then show what triggers DIP101:
 
-```
+```dippin
   Review -> Publish  when ctx.outcome = success
 ```
 
 (No fallback, no complementary condition.)
 
-```
+```shell
 $ dippin lint pipeline.dip
 WARN  pipeline.dip
   DIP101: node "Review" has conditional edges but no unconditional fallback
@@ -271,7 +271,7 @@ WARN  pipeline.dip
 
 Then show the fix — add the complementary condition:
 
-```
+```dippin
   Review -> Publish  when ctx.outcome = success
   Review -> Draft    when ctx.outcome = fail
 ```
@@ -280,11 +280,11 @@ Clean lint. Explain: `success`/`fail` and `contains X`/`not contains X` are reco
 
 **Section 6: The ctx. Prefix** (step-num 6) — Show the DIP120 mistake:
 
-```
+```dippin
   Review -> Publish  when outcome = success
 ```
 
-```
+```shell
 $ dippin lint pipeline.dip
 WARN  pipeline.dip
   DIP120: condition references "outcome" without namespace prefix — did you mean "ctx.outcome"?
@@ -374,7 +374,7 @@ Tutorial tag style (same as Task 2):
 
 **Section 1: dippin cost** (step-num 1) — Use `examples/complexity_cleanup.dip` as the example (it has a retry loop, multiple models, tool nodes — good variety). Show the real output:
 
-```
+```text
 $ dippin cost complexity_cleanup.dip
 ═══ Cost Estimate ═════════════════════════════════════════
                                 Min Expected      Max
@@ -402,7 +402,7 @@ Walk through the output: three columns (min/expected/max), by-provider breakdown
 
 **Section 5: dippin optimize** (step-num 5) — Run optimize on the same workflow. Show the real output:
 
-```
+```text
 $ dippin optimize complexity_cleanup.dip
 ═══ Optimization Report ═══════════════════════════════════
 ─── Cost Summary ──────────────────────────────────────────

--- a/docs/superpowers/plans/2026-04-03-runtime-upstream-issues.md
+++ b/docs/superpowers/plans/2026-04-03-runtime-upstream-issues.md
@@ -777,7 +777,7 @@ Read `docs/GRAMMAR.ebnf` and add `"conditional"` to the node kind production rul
 
 Create `examples/conditional_gate.dip`:
 
-```
+```dippin
 workflow ConditionalGate
   goal: "Demonstrate conditional routing without LLM calls"
   start: Analyze

--- a/docs/superpowers/plans/2026-04-06-dippin-spec-command.md
+++ b/docs/superpowers/plans/2026-04-06-dippin-spec-command.md
@@ -148,7 +148,7 @@ The generated spec is a build artifact and should not be tracked.
 
 Add this line after the `# Temp site files` section in `.gitignore`:
 
-```
+```text
 # Generated spec (build artifact)
 docs/generated-spec.md
 ```
@@ -230,7 +230,7 @@ Expected: builds successfully
 
 Run: `./dippin spec | head -3`
 Expected:
-```
+```text
 # Dippin Language Specification
 
 Complete reference for AI agents generating `.dip` workflow files. This document is the canonical, self-contained spec for the dippin DSL and CLI toolchain.

--- a/docs/superpowers/plans/2026-04-16-vars-block.md
+++ b/docs/superpowers/plans/2026-04-16-vars-block.md
@@ -809,4 +809,4 @@ vars
 Closes #5
 EOF
 )"
-```
+```text

--- a/docs/superpowers/plans/2026-04-22-dip26-manager-loop-node.md
+++ b/docs/superpowers/plans/2026-04-22-dip26-manager-loop-node.md
@@ -126,7 +126,7 @@ func TestNodeManagerLoop_IsNodeKind(t *testing.T) {
 
 - [ ] **Step 1.2: Run the test — expect it to fail**
 
-```
+```shell
 just test-pkg ir
 ```
 
@@ -172,7 +172,7 @@ func (ManagerLoopConfig) nodeConfig() {}
 
 - [ ] **Step 1.5: Run the tests to confirm they pass**
 
-```
+```shell
 just test-pkg ir
 ```
 
@@ -251,7 +251,7 @@ func TestParseManagerLoopNode(t *testing.T) {
 
 - [ ] **Step 2.2: Run it to confirm failure**
 
-```
+```shell
 just test-pkg parser
 ```
 
@@ -393,7 +393,7 @@ Complexity note: each helper stays under the 5/7 cyclomatic/cognitive limit. If 
 
 - [ ] **Step 2.7: Run the parser tests**
 
-```
+```shell
 just test-pkg parser
 ```
 
@@ -474,7 +474,7 @@ func TestParseManagerLoop_UnknownFieldHint(t *testing.T) {
 
 - [ ] **Step 2.9: Run tests**
 
-```
+```shell
 just test-pkg parser
 ```
 
@@ -535,7 +535,7 @@ func TestEnsureConditionsParsed_ManagerLoop(t *testing.T) {
 
 - [ ] **Step 3.2: Run it — expect nil Parsed**
 
-```
+```shell
 just test-pkg simulate
 ```
 
@@ -592,7 +592,7 @@ func ensureConditionParsed(c *ir.Condition, nodeID, field string) error {
 
 - [ ] **Step 3.4: Run tests**
 
-```
+```shell
 just test-pkg simulate
 ```
 
@@ -665,7 +665,7 @@ func TestFormatManagerLoop_RoundTrip(t *testing.T) {
 
 - [ ] **Step 4.2: Run — expect failure**
 
-```
+```shell
 just test-pkg formatter
 ```
 
@@ -738,7 +738,7 @@ If `sortedKeys` doesn't already exist in `formatter/`, check for an equivalent h
 
 - [ ] **Step 4.4: Run tests**
 
-```
+```shell
 just test-pkg formatter
 ```
 
@@ -801,7 +801,7 @@ func TestExportDOT_ManagerLoop(t *testing.T) {
 
 - [ ] **Step 5.2: Run — expect failure**
 
-```
+```shell
 just test-pkg export
 ```
 
@@ -885,7 +885,7 @@ Add `"sort"` to the import block if not already present.
 
 - [ ] **Step 5.5: Run tests**
 
-```
+```shell
 just test-pkg export
 ```
 
@@ -950,7 +950,7 @@ func TestMigrate_ManagerLoop(t *testing.T) {
 
 - [ ] **Step 6.2: Run — expect failure**
 
-```
+```shell
 just test-pkg migrate
 ```
 
@@ -1043,7 +1043,7 @@ Check cyclomatic: `buildManagerLoopConfig` has 6 branches. If gocyclo complains,
 
 - [ ] **Step 6.5: Run tests**
 
-```
+```shell
 just test-pkg migrate
 ```
 
@@ -1089,7 +1089,7 @@ func TestManagerLoopCodesRegistered(t *testing.T) {
 
 - [ ] **Step 7.2: Run — expect failure**
 
-```
+```shell
 just test-pkg validator
 ```
 
@@ -1145,7 +1145,7 @@ Explanations[DIP137] = Explanation{
 
 - [ ] **Step 7.5: Run tests**
 
-```
+```shell
 just test-pkg validator
 ```
 
@@ -1282,7 +1282,7 @@ Check whether `hasCode` already exists — `grep "func hasCode" validator/*_test
 
 - [ ] **Step 8.2: Run — expect failure**
 
-```
+```shell
 just test-pkg validator
 ```
 
@@ -1416,7 +1416,7 @@ diags = append(diags, lintManagerLoop(w)...)
 
 - [ ] **Step 8.5: Run tests**
 
-```
+```shell
 just test-pkg validator
 ```
 
@@ -1474,7 +1474,7 @@ func TestLintConditions_StackChildNamespace(t *testing.T) {
 
 - [ ] **Step 9.2: Run — expect failure**
 
-```
+```shell
 just test-pkg validator
 ```
 
@@ -1499,7 +1499,7 @@ var knownNamespaces = map[string]bool{
 
 - [ ] **Step 9.4: Run the test**
 
-```
+```shell
 just test-pkg validator
 ```
 
@@ -1564,7 +1564,7 @@ func TestTemplateNames_IncludesManagerLoop(t *testing.T) {
 
 - [ ] **Step 10.2: Run — expect failure**
 
-```
+```shell
 just test-pkg scaffold
 ```
 
@@ -1619,7 +1619,7 @@ Add `"time"` to imports if not already present.
 
 - [ ] **Step 10.4: Run tests**
 
-```
+```shell
 just test-pkg scaffold
 ```
 
@@ -1688,7 +1688,7 @@ Use whichever values the existing map already uses; don't change existing entrie
 
 - [ ] **Step 11.4: Run**
 
-```
+```shell
 just test-pkg lsp
 ```
 
@@ -1760,7 +1760,7 @@ workflow ManagerLoopDemo
 
 - [ ] **Step 12.3: Run the full check**
 
-```
+```shell
 just build && ./dippin validate examples/manager_loop_demo.dip && ./dippin lint examples/manager_loop_demo.dip && ./dippin fmt examples/manager_loop_demo.dip
 ```
 
@@ -1768,7 +1768,7 @@ Expected: all succeed, lint clean.
 
 - [ ] **Step 12.4: Run the integration suite**
 
-```
+```shell
 just test-pkg validator
 ```
 
@@ -1776,7 +1776,7 @@ just test-pkg validator
 
 - [ ] **Step 12.5: Run validate-examples**
 
-```
+```shell
 just validate-examples
 ```
 
@@ -1836,7 +1836,7 @@ steer_context_value = field_value                      (* inline "k=v, k=v" *)
 
 Extend the block at the bottom (around line 305):
 
-```
+```ebnf
 (* Manager loop: label, subgraph_ref, poll_interval, max_cycles,      *)
 (*   stop_condition, steer_condition, steer_context                   *)
 ```
@@ -1845,7 +1845,7 @@ Extend the block at the bottom (around line 305):
 
 Line 321 lists contextual keywords. Add `manager_loop`:
 
-```
+```ebnf
 (* workflow, agent, human, tool, subgraph, parallel, fan_in,           *)
 (* manager_loop, edges, defaults, vars, when, and, or, not, contains,   *)
 (* startswith, endswith, in, true, false, restart, label, weight        *)
@@ -1925,7 +1925,7 @@ And extend the identifier-in-declaration list (around line 73):
 
 Append to `editors/tree-sitter-dippin/test/corpus/basic.txt`:
 
-```
+```text
 ================================================================================
 Manager loop node
 ================================================================================
@@ -1976,7 +1976,7 @@ tree-sitter-test: tree-sitter-generate
 
 - [ ] **Step 14.5: Generate + run tests**
 
-```
+```shell
 cd editors/tree-sitter-dippin && npm install  # only if node_modules is missing
 just tree-sitter-generate
 just tree-sitter-test
@@ -1988,7 +1988,7 @@ Expected: all corpus cases pass. If the generator isn't installed globally, `npx
 
 Ensure `editors/tree-sitter-dippin/node_modules/` is ignored. Append to `.gitignore` if not:
 
-```
+```text
 # Tree-sitter build deps
 editors/tree-sitter-dippin/node_modules/
 ```
@@ -2024,7 +2024,7 @@ In `.github/workflows/ci.yml`, add a new job (copy the pattern from the `Verify 
 
 - [ ] **Step 14.8: Stage the generated files**
 
-```
+```shell
 git add editors/tree-sitter-dippin/src/parser.c editors/tree-sitter-dippin/src/grammar.json editors/tree-sitter-dippin/src/node-types.json editors/tree-sitter-dippin/src/tree_sitter/
 git add editors/tree-sitter-dippin/tree-sitter.json  # if untracked
 git add editors/tree-sitter-dippin/grammar.js editors/tree-sitter-dippin/queries/highlights.scm editors/tree-sitter-dippin/test/corpus/basic.txt
@@ -2033,7 +2033,7 @@ git add Justfile .gitignore .github/workflows/ci.yml
 
 Verify before committing: `git status` shows no stray file in `node_modules/`. If `package-lock.json` is new (not previously tracked), decide: commit it (reproducible installs) or extend `.gitignore` for consistency with the existing setup. The git status at plan time shows `package-lock.json` as untracked — **commit it**.
 
-```
+```shell
 git add editors/tree-sitter-dippin/package-lock.json
 ```
 
@@ -2055,7 +2055,7 @@ git commit -m "feat(tree-sitter): add manager_loop rule and commit generated par
 
 After merging this PR, the Zed extension needs to point at the new SHA. Don't do this in the PR — do it in a follow-up:
 
-```
+```shell
 # Post-merge, on main:
 git rev-parse HEAD   # copy the merge SHA
 # Edit editors/zed-dippin/extension.toml, update the commit = "..." line
@@ -2147,7 +2147,7 @@ If conditional is missing, also add it. If this doc already has conditional and 
 
 Around lines 11-25, add manager_loop to Composition Nodes:
 
-```
+```text
     subgraph Composition Nodes
         subgraph_node["subgraph<br>Sub-pipeline"]
         manager_loop["manager_loop<br>Supervisor"]
@@ -2158,7 +2158,7 @@ Around lines 11-25, add manager_loop to Composition Nodes:
 
 Around lines 27-34, add a row:
 
-```
+```text
 | `manager_loop` | Supervise a child subgraph with polling and steering | Block with subgraph_ref |
 ```
 
@@ -2250,7 +2250,7 @@ Find the Node Types section (the exploration located it around line 197; verify)
 ```
 
 DOT shape: `house`. See [docs/nodes.md#manager-loop-nodes](docs/nodes.md#manager-loop-nodes).
-```
+```markdown
 
 - [ ] **Step 17.2: site/content/language.md**
 
@@ -2271,7 +2271,7 @@ Find the subgraph section (Step 1's exploration showed it around line 120-145) a
     stop_condition: stack.child.outcome = success
     steer_condition: stack.child.cycles = 5
     steer_context: hint=halfway_through
-```
+```markdown
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -2321,7 +2321,7 @@ Set the release date when tagging (don't date-stamp prematurely).
 
 - [ ] **Step 18.2: Regenerate site changelog**
 
-```
+```shell
 just changelog-md
 ```
 
@@ -2349,7 +2349,7 @@ Review past CHANGELOG entries for cross-repo coordination style.
 Title: `feat: add ir.NodeManagerLoop support to the runtime's pipeline adapter layer`
 
 Body:
-```
+```text
 dippin-lang v0.22.0 (see 2389-research/dippin-lang#26) adds a new IR node
 kind `NodeManagerLoop` that expresses `stack.manager_loop` supervisors.
 The runtime's DOT parser already handles the node via `shape=house`, but the
@@ -2386,7 +2386,7 @@ File the issue in the runtime repository. Copy the issue number and update the d
 
 - [ ] **Step 20.1: Run the full check**
 
-```
+```shell
 just check
 ```
 
@@ -2398,7 +2398,7 @@ Expected: "All checks passed." If any step fails:
 
 - [ ] **Step 20.2: Run tree-sitter check**
 
-```
+```shell
 just tree-sitter-test
 ```
 
@@ -2406,7 +2406,7 @@ Expected: all corpus cases pass.
 
 - [ ] **Step 20.3: Manual round-trip smoke test**
 
-```
+```shell
 ./dippin fmt examples/manager_loop_demo.dip > /tmp/m1.dip
 ./dippin fmt /tmp/m1.dip > /tmp/m2.dip
 diff /tmp/m1.dip /tmp/m2.dip
@@ -2414,7 +2414,7 @@ diff /tmp/m1.dip /tmp/m2.dip
 
 Expected: no diff (idempotent).
 
-```
+```shell
 ./dippin export-dot examples/manager_loop_demo.dip > /tmp/m.dot
 grep 'shape=house' /tmp/m.dot
 grep 'subgraph_ref' /tmp/m.dot
@@ -2423,7 +2423,7 @@ grep 'steer_context' /tmp/m.dot
 
 Expected: all three greps succeed.
 
-```
+```shell
 ./dippin migrate /tmp/m.dot > /tmp/back.dip
 ./dippin validate /tmp/back.dip
 ```
@@ -2432,7 +2432,7 @@ Expected: `/tmp/back.dip` is a valid `.dip` with the manager_loop node preserved
 
 - [ ] **Step 20.4: Self-review the diff**
 
-```
+```shell
 git log --oneline main..HEAD
 git diff main..HEAD --stat
 ```
@@ -2445,7 +2445,7 @@ Check:
 
 - [ ] **Step 20.5: Push and open PR**
 
-```
+```shell
 git push -u origin feat/manager-loop-node
 gh pr create --title "feat: add manager_loop node kind (issue #26)" --body "$(cat <<'EOF'
 ## Summary

--- a/docs/superpowers/plans/2026-04-22-dip28-tool-safety-defaults.md
+++ b/docs/superpowers/plans/2026-04-22-dip28-tool-safety-defaults.md
@@ -88,7 +88,7 @@ graph.Attrs. Refs #28."
 
 Create `parser/testdata/defaults_tool_safety.dip` exactly:
 
-```
+```dippin
 workflow DefaultsToolSafety
   goal: "Test tool-safety defaults parsing"
   start: A
@@ -659,7 +659,7 @@ git commit -m "test(migrate): .dip → DOT → .dip round-trip for tool-safety d
 
 Create `examples/tool_safety.dip`:
 
-```
+```dippin
 workflow ToolSafety
   goal: "Demonstrate tool_commands_allow and tool_denylist_add defaults for constrained shell execution"
   start: Start
@@ -770,7 +770,7 @@ workflow Safe
 ```
 
 Values pass through to the runtime verbatim; dippin-lang does not validate glob syntax.
-```
+```markdown
 
 - [ ] **Step 4: Update `site/static/skill.md`**
 

--- a/docs/superpowers/plans/2026-05-07-dipx-bundle-format.md
+++ b/docs/superpowers/plans/2026-05-07-dipx-bundle-format.md
@@ -780,7 +780,7 @@ Path canonicalization is the front line against zip-slip and Unicode-confusion a
 
 - [ ] **Dispatch security subagent.**
 
-```
+```text
 Agent({
   description: "Phase 2 security gate — Canonicalize",
   subagent_type: "general-purpose",
@@ -807,7 +807,7 @@ Format: severity-ranked list (critical / important / minor). Reference file:line
 
 - [ ] **PAL spot-check** (parallel with the squad subagent):
 
-```
+```text
 mcp__pal__chat({
   prompt: "Audit dipx/resolve.go vs spec § 'Path canonicalization' and § 'Subgraph ref resolution'. Is the resolveLexically + Canonicalize composition sound under adversarial input? Specific concern: do the regular Canonicalize rules and resolveLexically's `..`-tolerance compose without leaving a window where a clever ref string ends up resolving to a path that bypasses one of Canonicalize's rules?",
   model: "gpt-5.2",
@@ -1299,7 +1299,7 @@ The manifest is the trust-on-first-use surface. Bypass here defeats every defens
 
 - [ ] **Dispatch crypto-discipline subagent.**
 
-```
+```text
 Agent({
   description: "Phase 3 gate — manifest TOFU hardening",
   subagent_type: "general-purpose",
@@ -1327,7 +1327,7 @@ Format: severity-ranked list (critical / important / minor). Reference file:line
 
 - [ ] **PAL spot-check**:
 
-```
+```text
 mcp__pal__chat({
   prompt: "Review dipx/manifest.go end-to-end vs the spec's Manifest schema and JSON encoding sections. Specifically: is the duplicate-key detection algorithm correct (no false negatives on nested objects)? Does the format_version validation match the spec's integer-only rule? Is the signatures-key-rejection rule applied at the correct level (top-level only, or recursively)?",
   model: "gpt-5.2",
@@ -1724,7 +1724,7 @@ ZIP I/O is the largest attack surface in the entire format. Parser-confusion, zi
 
 - [ ] **Dispatch security subagent.**
 
-```
+```text
 Agent({
   description: "Phase 4 gate — ZIP feature constraints + streaming caps",
   subagent_type: "general-purpose",
@@ -1750,7 +1750,7 @@ Do NOT propose new features. Format: severity-ranked list. Reference file:line.
 
 - [ ] **Dispatch crypto-discipline subagent (in parallel with security).**
 
-```
+```text
 Agent({
   description: "Phase 4 gate — verifiedBytes type-encoded ordering",
   subagent_type: "general-purpose",
@@ -2743,7 +2743,7 @@ This is the highest-risk phase: the Open orchestrator wires every defense togeth
 
 - [ ] **Dispatch crypto-discipline subagent.**
 
-```
+```text
 Agent({
   description: "Phase 5 gate — Open ordering invariants",
   subagent_type: "general-purpose",
@@ -2773,7 +2773,7 @@ Do NOT propose new features. Format: severity-ranked list. Reference file:line.
 
 - [ ] **PAL end-to-end pass:**
 
-```
+```text
 mcp__pal__chat({
   prompt: "Read the dipx/dipx.go orchestrator + helpers.go + bundle.go end-to-end. Independently verify the spec's Open post-conditions (numbered 1-9) hold. For each post-condition, state which line(s) of code prove it. Flag any post-condition that the code claims to satisfy but actually does not.",
   model: "gpt-5.2",
@@ -3207,7 +3207,7 @@ The Source interface is the contract the runtime swaps in. A subtle wrong shape 
 
 - [ ] **Dispatch runtime-integration subagent.**
 
-```
+```text
 Agent({
   description: "Phase 6 gate — Source interface and runtime contract",
   subagent_type: "general-purpose",
@@ -3600,7 +3600,7 @@ Pack is the single seam where attacker-controlled source trees compromise the *p
 
 - [ ] **Dispatch security subagent.**
 
-```
+```text
 Agent({
   description: "Phase 7 gate — Pack TOCTOU and reproducibility",
   subagent_type: "general-purpose",
@@ -4215,7 +4215,7 @@ CLI is operator-facing. Exit codes, atomicity, and error messages determine whet
 
 - [ ] **Dispatch ops-reliability subagent.**
 
-```
+```text
 Agent({
   description: "Phase 8 gate — CLI operational ergonomics",
   subagent_type: "general-purpose",
@@ -4246,7 +4246,7 @@ Do NOT propose new features. Format: severity-ranked list.
 
 - [ ] **PAL spot-check on the CLI seam:**
 
-```
+```text
 mcp__pal__chat({
   prompt: "Review cmd/dippin/cmd_pack.go, cmd_unpack.go, cmd_inspect.go and the loadSource helper for: (1) error-handling consistency across the three new commands; (2) exit-code mapping correctness; (3) any place where the CLI silently catches and ignores an error.",
   model: "gpt-5.2",
@@ -4328,7 +4328,7 @@ cat /home/clint/code/2389/dippin-lang/Justfile | head -100
 
 Append to `Justfile`:
 
-```
+```shell
 pack-examples:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -4342,7 +4342,7 @@ pack-examples:
 
 Find the existing `check` recipe and add `pack-examples` after `validate-examples`:
 
-```
+```text
 check: build vet fmt-check lint-go test-race releasecheck complexity validate-examples pack-examples tree-sitter-test
 ```
 
@@ -4406,7 +4406,7 @@ Each command exits 0 (or for `lint`, exits 0 with warnings printed but no errors
 
 - [ ] **PAL spec-coverage audit:**
 
-```
+```text
 mcp__pal__chat({
   prompt: "Read the spec at docs/superpowers/specs/2026-05-06-dipx-bundle-format-design.md and the implementation in dipx/ + cmd/dippin/cmd_{pack,unpack,inspect}.go. For every normative MUST in the spec, identify whether there is implementation code that enforces it. List any spec MUST that is NOT enforced. Also list any spec § that is implicitly missing entirely.",
   model: "gpt-5.2",
@@ -4538,7 +4538,7 @@ This is the last gate before declaring the implementation ready for human review
 
 - [ ] **Dispatch three subagents in parallel** (one Agent message with three tool calls):
 
-```
+```text
 [Security squad — final pass]
 Agent({
   description: "Phase 10 final gate — security",
@@ -4594,7 +4594,7 @@ Severity-ranked list.
 
 - [ ] **Final PAL synthesis** (after the three subagents return):
 
-```
+```text
 mcp__pal__chat({
   prompt: "Three squad reviewers just completed final-pass audits of the .dipx implementation. Synthesize their findings into a single severity-ranked list. Identify any cross-cutting issues that no single domain caught (e.g., a security gap that's only exploitable because of an ops gap). Recommend whether this is ready for human PR review.",
   model: "gpt-5.2",

--- a/docs/superpowers/plans/2026-05-08-dipx-v1.1-bundle-2-inspect-overhaul.md
+++ b/docs/superpowers/plans/2026-05-08-dipx-v1.1-bundle-2-inspect-overhaul.md
@@ -815,12 +815,12 @@ EOF
 Use Edit. Match the last existing Fixed bullet (Bundle 5 / P10.9) and append two new ones:
 
 old_string:
-```
+```markdown
 - **`Pack` subgraph parse failures attribute to `ErrSubgraphParse`.** Previously every parse failure surfaced as `ErrEntryParse` regardless of which workflow failed; subgraph failures now correctly classify as `ErrSubgraphParse` with the subgraph's filesystem path. (Bundle 5 / P10.9.)
 ```
 
 new_string:
-```
+```markdown
 - **`Pack` subgraph parse failures attribute to `ErrSubgraphParse`.** Previously every parse failure surfaced as `ErrEntryParse` regardless of which workflow failed; subgraph failures now correctly classify as `ErrSubgraphParse` with the subgraph's filesystem path. (Bundle 5 / P10.9.)
 - **`dippin inspect` emits a structured `status` object.** JSON output's `status` was previously a bare string `"VALID"`; it is now an object with `valid`, `verify_skipped`, `file_count`, `byte_total`, `format_version` per spec § "CLI / inspect command". Text footer now includes the byte total. **Breaking** for JSON consumers parsing `status` as a string. (Bundle 2 / Phase 8 M4, L1, L2.)
 - **`dippin inspect --no-verify` actually skips hash verification.** Previously a no-op (warning printed, full verification still ran). Now routes through a new `dipx.OpenManifest` API that performs only structural-admission steps; tampered bundles can be inspected without integrity errors firing. (Bundle 2 / Phase 10 P10.4.)

--- a/docs/superpowers/plans/2026-05-08-dipx-v1.1-bundle-5-error-attribution.md
+++ b/docs/superpowers/plans/2026-05-08-dipx-v1.1-bundle-5-error-attribution.md
@@ -585,12 +585,12 @@ The `[Unreleased]` block has `### Fixed` and `### Spec` subsections from Bundle 
 Use Edit. The `### Fixed` subsection currently has two bullets ending with `(Bundle 6 / Phase 8 M1.)`. Append two more after it.
 
 old_string (the last existing Fixed bullet — match by the closing `(Bundle 6 / Phase 8 M1.)`):
-```
+```markdown
 - **`dippin pack`/`unpack`/`inspect` exit code 2 (integrity failure) now matches the spec contract.** `isIntegrityErr` previously routed only 5 sentinels to exit 2; 7 others (`ErrUnsupportedFormatVersion`, `ErrFileMissing`, `ErrFileUnexpected`, `ErrEntryNotInManifest`, `ErrRefEscape`, `ErrRefCycle`, `ErrCapExceeded`, `ErrPathUnsafe`) defaulted to user-error 1. Refactored to a sentinel-slice + loop covering all 12 spec-enumerated sentinels. (Bundle 6 / Phase 8 M1.)
 ```
 
 new_string:
-```
+```markdown
 - **`dippin pack`/`unpack`/`inspect` exit code 2 (integrity failure) now matches the spec contract.** `isIntegrityErr` previously routed only 5 sentinels to exit 2; 7 others (`ErrUnsupportedFormatVersion`, `ErrFileMissing`, `ErrFileUnexpected`, `ErrEntryNotInManifest`, `ErrRefEscape`, `ErrRefCycle`, `ErrCapExceeded`, `ErrPathUnsafe`) defaulted to user-error 1. Refactored to a sentinel-slice + loop covering all 12 spec-enumerated sentinels. (Bundle 6 / Phase 8 M1.)
 - **`Open` enriches manifest-decode errors with the bundle path.** `BundleError.Path` for `ErrManifestInvalid` and `ErrUnsupportedFormatVersion` was previously empty or a JSON field name (e.g., `"format_version"`); external callers now always observe the bundle file path. The original Path is preserved in Detail when non-empty. (Bundle 5 / Phase 3 manifest-decoder error-context.)
 - **`Pack` subgraph parse failures attribute to `ErrSubgraphParse`.** Previously every parse failure surfaced as `ErrEntryParse` regardless of which workflow failed; subgraph failures now correctly classify as `ErrSubgraphParse` with the subgraph's filesystem path. (Bundle 5 / P10.9.)

--- a/docs/superpowers/plans/2026-05-08-dipx-v1.1-bundle-6-spec-clarifications.md
+++ b/docs/superpowers/plans/2026-05-08-dipx-v1.1-bundle-6-spec-clarifications.md
@@ -37,7 +37,7 @@
 
 - [ ] **Step 1: Open the spec at line 171** and locate the line that reads:
 
-```
+```text
 2. Separators are forward-slash `/` only. Backslash `\` and any other separator MUST be rejected.
 ```
 
@@ -46,12 +46,12 @@
 Use Edit with `old_string` and `new_string`:
 
 old:
-```
+```text
 2. Separators are forward-slash `/` only. Backslash `\` and any other separator MUST be rejected.
 ```
 
 new:
-```
+```text
 2. Separators are forward-slash `/` only. Backslash `\` MUST be rejected.
 ```
 
@@ -96,7 +96,7 @@ The spec needs a preamble clarifying these three cases AND a normative requireme
 
 The current text at lines 501–503 is:
 
-```
+```markdown
 ### Per-sentinel error context (normative)
 
 | Sentinel | `BundleError.Path` | `BundleError.Detail` | `BundleError.Cause` |
@@ -109,14 +109,14 @@ The current text at lines 501–503 is:
 Use Edit:
 
 old:
-```
+```markdown
 ### Per-sentinel error context (normative)
 
 | Sentinel | `BundleError.Path` | `BundleError.Detail` | `BundleError.Cause` |
 ```
 
 new:
-```
+```markdown
 ### Per-sentinel error context (normative)
 
 `BundleError.Path` carries one of three values depending on where the error originates:
@@ -177,12 +177,12 @@ Expected: lines 217 and 218.
 Use Edit. The current text at lines 217–218 is one paragraph each, very long. Match on the start of step 5 to insert before it.
 
 old:
-```
+```text
 5. **Verify hashes**: for each `files[]` entry: locate the zip entry by canonical path; stream-decompress its bytes through a length-bounded reader (per-file size cap and ratio cap enforced *during* decompression, not after) into a fresh `[]byte`; compute SHA-256; compare to manifest. Mismatch → `*BundleError{Sentinel: ErrHashMismatch, Path: path, Detail: "expected: X, actual: Y"}`. Cap-check accumulated total uncompressed size during this loop.
 ```
 
 new:
-```
+```text
 5. **Verify no extra zip entries**: enumerate non-directory zip entries; reject any whose canonical path does not appear in `files[]` (`ErrFileUnexpected`). This step rejects junk before step 6 spends CPU hashing files the bundle would reject anyway. Implementations MAY fold this check into step 4's manifest-shape validation as long as the externally observable error precedence is preserved.
 6. **Verify hashes**: for each `files[]` entry: locate the zip entry by canonical path; stream-decompress its bytes through a length-bounded reader (per-file size cap and ratio cap enforced *during* decompression, not after) into a fresh `[]byte`; compute SHA-256; compare to manifest. Mismatch → `*BundleError{Sentinel: ErrHashMismatch, Path: path, Detail: "expected: X, actual: Y"}`. Cap-check accumulated total uncompressed size during this loop.
 ```
@@ -192,25 +192,25 @@ new:
 The current list has steps 6 (parse), 7 (walk refs), 8 (normalize), 9 (build). Each must be renumbered up by one. Use four sequential edits, each matching the unique `N. **Word**` prefix of the step:
 
 Edit 1:
-```
+```text
 old: 6. **Parse**: only after step 5 verifies all hashes
 new: 7. **Parse**: only after step 6 verifies all hashes
 ```
 
 Edit 2:
-```
+```text
 old: 7. **Walk refs**
 new: 8. **Walk refs**
 ```
 
 Edit 3:
-```
+```text
 old: 8. **Normalize**: for each parsed workflow
 new: 9. **Normalize**: for each parsed workflow
 ```
 
 Edit 4:
-```
+```text
 old: 9. **Build** the immutable in-memory `Bundle`
 new: 10. **Build** the immutable in-memory `Bundle`
 ```
@@ -234,13 +234,13 @@ Use Edit for each. After completion, re-grep to confirm no stale numbers remain.
 Lines 491–497 list 7 categories. The new step belongs at category 4 (between manifest shape and cap exceeded). Edit the list:
 
 old:
-```
+```text
 3. Manifest shape (format_version, missing required fields, malformed sha256, reserved-key presence, path canonicalization, duplicate paths).
 4. Cap exceeded (during streaming hash verification).
 ```
 
 new:
-```
+```text
 3. Manifest shape (format_version, missing required fields, malformed sha256, reserved-key presence, path canonicalization, duplicate paths).
 4. Extra zip entries (non-directory entries not listed in `files[]`).
 5. Cap exceeded (during streaming hash verification).
@@ -291,12 +291,12 @@ Expected: one line, the (now-renumbered) step 8 in § "Open ordering".
 - [ ] **Step 2: Replace the step 8 text to specify "every manifest-listed workflow"**
 
 old:
-```
+```text
 8. **Walk refs** with tri-color DFS for cycle detection; reject cycles (`ErrRefCycle`), refs that escape `workflows/` (`ErrRefEscape`), and refs that resolve to paths not in `files[]` (`ErrFileMissing`).
 ```
 
 new:
-```
+```text
 8. **Walk refs** with tri-color DFS for cycle detection rooted at **every manifest-listed workflow** (not only `entry`); reject cycles (`ErrRefCycle`), refs that escape `workflows/` (`ErrRefEscape`), and refs that resolve to paths not in `files[]` (`ErrFileMissing`). Walking from every manifest-listed workflow keeps cycle detection symmetric with step 7's parse pass, which already parses every workflow.
 ```
 
@@ -342,12 +342,12 @@ Expected: one line in the table at ~line 575.
 - [ ] **Step 2: Replace the integrity row**
 
 old:
-```
+```text
 | 2 | Integrity failure (`ErrHashMismatch`, `ErrManifestInvalid`, `ErrZipFeatureForbidden`, `ErrZipTruncated`) |
 ```
 
 new:
-```
+```text
 | 2 | Integrity failure (`ErrHashMismatch`, `ErrManifestInvalid`, `ErrUnsupportedFormatVersion`, `ErrZipFeatureForbidden`, `ErrZipTruncated`, `ErrFileMissing`, `ErrFileUnexpected`, `ErrEntryNotInManifest`, `ErrRefEscape`, `ErrRefCycle`, `ErrCapExceeded`, `ErrPathUnsafe`) |
 ```
 
@@ -396,12 +396,12 @@ Expected: one line ~566.
 - [ ] **Step 2: Replace with a line plus an example**
 
 old:
-```
+```markdown
 - `--format=json` emits the manifest plus a status object for machine consumption (`jq`-friendly).
 ```
 
 new:
-````
+````markdown
 - `--format=json` emits the manifest plus a status object for machine consumption (`jq`-friendly). The status object schema is:
 
 ```json
@@ -467,7 +467,7 @@ Expected: one line ~697.
 - [ ] **Step 2: Replace with the ctx-bearing form**
 
 old:
-```
+```go
 src, err := dipx.Load(ctx, path)        // path may be "foo.dip" OR "foo.dipx"
 wf := src.Entry()
 // ... when hitting a subgraph node:
@@ -475,7 +475,7 @@ child, err := src.Workflow(sub.Ref, parentPath)
 ```
 
 new:
-```
+```go
 src, err := dipx.Load(ctx, path)        // path may be "foo.dip" OR "foo.dipx"
 wf := src.Entry()
 // ... when hitting a subgraph node:

--- a/docs/superpowers/plans/2026-05-11-dipx-v1.1-bundle-1-ctx-threading.md
+++ b/docs/superpowers/plans/2026-05-11-dipx-v1.1-bundle-1-ctx-threading.md
@@ -707,12 +707,12 @@ EOF
 After the existing Bundle 2 / Phase 10 P10.4 bullet, append three new ones.
 
 old_string:
-```
+```markdown
 - **`dippin inspect --no-verify` actually skips hash verification.** Previously a no-op (warning printed, full verification still ran). Now routes through a new `dipx.OpenManifest` API that performs only structural-admission steps; tampered bundles can be inspected without integrity errors firing. (Bundle 2 / Phase 10 P10.4.)
 ```
 
 new_string:
-```
+```markdown
 - **`dippin inspect --no-verify` actually skips hash verification.** Previously a no-op (warning printed, full verification still ran). Now routes through a new `dipx.OpenManifest` API that performs only structural-admission steps; tampered bundles can be inspected without integrity errors firing. (Bundle 2 / Phase 10 P10.4.)
 - **`Source.Workflow` now takes `context.Context` as its first argument.** `dirSource.Workflow` checks ctx before disk I/O; `Bundle.Workflow` checks ctx at entry for interface consistency. **Breaking** for external callers (downstream consumers) — bump your dippin-lang import to pick up the new signature. (Bundle 1 / Phase 6 L4.)
 - **`Open` and `Pack` are cancellable mid-loop.** `verifyAllHashes`, `walkSourceTree`, and `writeBundle` now check `ctx.Err()` between each entry/iteration. A long Open against a many-entry bundle or a long Pack against a deep source tree can be cancelled within one entry's processing time instead of running to completion. (Bundle 1 / Phase 10 P10.2, P10.7, P10.10.)

--- a/docs/superpowers/plans/2026-05-19-issue-39-tool-routing-fields.md
+++ b/docs/superpowers/plans/2026-05-19-issue-39-tool-routing-fields.md
@@ -537,7 +537,7 @@ Read the tool node's current shape.
 
 Edit the existing tool node block to include:
 
-```
+```dippin
     marker_grep: '^(pass|fail)$'
     route_required: true
     output_limit: 65536
@@ -1334,7 +1334,7 @@ After the existing prose, append:
 ```
 
 When `marker_grep` is declared, the runtime populates `ctx.tool_marker` and routing edges can reference it instead of `ctx.tool_stdout`. `route_required: true` makes the absence of any match a hard failure. `output_limit` overrides the per-node stdout cap when the command genuinely needs a larger window.
-```
+```markdown
 
 - [ ] **Step 3: Commit**
 
@@ -1515,7 +1515,7 @@ These fields forward to the runtime via DOT export. Routing semantics require an
 - **#42** — DIP138, lint warning when a tool node parses stdout for routing without declaring `marker_grep` / `outputs`.
 - **#43** — normalize boolean parsing (`true` / `yes` / `1` accepted consistently).
 - **#44** — close the existing `outputs` DOT round-trip gap.
-```
+```markdown
 
 - [ ] **Step 3: Verify Hugo build**
 

--- a/docs/superpowers/plans/2026-05-21-issue-40-coverage-redirection.md
+++ b/docs/superpowers/plans/2026-05-21-issue-40-coverage-redirection.md
@@ -305,7 +305,7 @@ Verify with `git log --oneline -3`.
 
 - [ ] Create `examples/coverage_redirection.dip` with the bug pattern from the issue body, wired to a complete workflow so `validate-examples` and `lint-examples` succeed:
 
-```
+```dippin
 workflow CoverageRedirection
   goal: "Demonstrate that file-redirected echoes no longer trip coverage"
   start: RunTests

--- a/docs/superpowers/plans/2026-05-22-v0.31.0-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-v0.31.0-implementation.md
@@ -176,7 +176,7 @@ Expected: All tests pass.
 
 Current code at `docs/validation.md:740-745`:
 
-```
+```text
 warning[DIP127]: node "Gate" has mode "interactive" which is not a recognized human mode
   --> pipeline.dip:12:3
   = help: valid modes: choice, freeform, interview
@@ -184,19 +184,19 @@ warning[DIP127]: node "Gate" has mode "interactive" which is not a recognized hu
 
 Change the `help:` line to:
 
-```
+```text
   = help: valid modes: choice, freeform, interview, yes_no
 ```
 
 Also update the prose at `docs/validation.md:745`:
 
-```
+```text
 **What triggers it**: A human node declares a mode other than `choice`, `freeform`, or `interview`.
 ```
 
 Change to:
 
-```
+```text
 **What triggers it**: A human node declares a mode other than `choice`, `freeform`, `interview`, or `yes_no`.
 ```
 

--- a/docs/superpowers/plans/2026-05-26-issue-41-implementation.md
+++ b/docs/superpowers/plans/2026-05-26-issue-41-implementation.md
@@ -25,7 +25,7 @@
 
 For each non-goal in the spec (§ Non-goals 1–9), file one GitHub issue with title + body. Use `gh issue create`. Title pattern: `follow-up: <non-goal title> (deferred from #41)`. Body template:
 
-```
+```text
 Filed per v0.32.0 spec § Follow-up issues #N.
 See: https://github.com/2389-research/dippin-lang/blob/main/docs/superpowers/specs/2026-05-26-issue-41-design.md#non-goals-v1
 
@@ -51,7 +51,7 @@ Record the assigned issue numbers (e.g., `#56, #57, #58, ...`) for Step 2.
 
 Edit `docs/superpowers/specs/2026-05-26-issue-41-design.md`. For each non-goal bullet, append ` ([#N](https://github.com/2389-research/dippin-lang/issues/N))` to the bullet text. Example:
 
-```
+```text
 1. **`defaults:`-block cascade.** Workflow-level ... Defer until incident data shows per-node annotation is insufficient. ([#56](https://github.com/2389-research/dippin-lang/issues/56))
 ```
 
@@ -846,7 +846,7 @@ git commit -m "test(migrate): round-trip preserves tool_access"
 
 Write `examples/agent_tool_access.dip`:
 
-```
+```dippin
 workflow AgentToolAccess
   goal: "Demonstrate the tool_access agent-node safety primitive (issue #41)"
   start: Plan
@@ -1057,7 +1057,7 @@ Required test set (all live in the runtime repo, under the agent layer or wherev
 
 Open a PR against the runtime repo with an appropriate branch name. The PR body should include:
 
-```
+```markdown
 ## Summary
 
 Coordinated runtime release with dippin-lang v0.32.0. Implements runtime enforcement for the new `tool_access:` agent-node field — see dippin spec at https://github.com/2389-research/dippin-lang/blob/main/docs/superpowers/specs/2026-05-26-issue-41-design.md for the full design.

--- a/docs/superpowers/plans/2026-05-27-issue-52-command-file-implementation.md
+++ b/docs/superpowers/plans/2026-05-27-issue-52-command-file-implementation.md
@@ -25,7 +25,7 @@
 
 Use `gh issue create -R 2389-research/dippin-lang`. Title pattern: `follow-up: <topic> (deferred from #52)`. Body template:
 
-```
+```text
 Filed per v0.33.0 spec § Follow-up issues #N.
 See: https://github.com/2389-research/dippin-lang/blob/main/docs/superpowers/specs/2026-05-27-issue-52-command-file-design.md
 
@@ -941,7 +941,7 @@ Mutually exclusive with `command:` — specifying both is a parse error.
 Loading: CLI entry points (`dippin lint`, `dippin pack`, `dippin validate`, `dippin doctor`) load the file contents into the IR after parse. The LSP and the playground (cmd/wasm) skip loading; they show the path unresolved. The runtime reads `.dipx` bundles where content is already inlined, so the runtime sees no difference from inline `command:`.
 
 Non-goals (deferred): `prompt_file:` / `system_prompt_file:` directives, glob expansion, configurable size cap, DOT round-trip preservation of the directive form. See follow-up issues linked from issue [#52](https://github.com/2389-research/dippin-lang/issues/52).
-```
+```markdown
 
 - [ ] **Step 5: Add CHANGELOG entry stub**
 

--- a/docs/superpowers/plans/2026-05-27-issue-65-prompt-file-implementation.md
+++ b/docs/superpowers/plans/2026-05-27-issue-65-prompt-file-implementation.md
@@ -472,14 +472,14 @@ mkdir -p parser/testdata/prompt_file
 
 Create `parser/testdata/prompt_file/task.md`:
 
-```
+```text
 Review the diff at .ai/scratch/diff.patch.
 fixture: ResolveFileDirectives prompt test
 ```
 
 Create `parser/testdata/prompt_file/persona.md`:
 
-```
+```text
 You are a senior code reviewer.
 fixture: ResolveFileDirectives system_prompt test
 ```
@@ -1144,7 +1144,7 @@ git commit -m "feat(migrate): include prompt/system_prompt file fields in agent 
 
 Create `examples/external_prompts.dip`:
 
-```
+```dippin
 workflow ExternalPrompts
   goal: "Demonstrate prompt_file:/system_prompt_file: directives (issue #65)"
   start: Reviewer
@@ -1161,7 +1161,7 @@ workflow ExternalPrompts
 
 Create `examples/external_prompts/reviewer-persona.md`:
 
-```
+```text
 You are a senior code reviewer. Be concise, direct, and constructive.
 Focus on correctness, security, and maintainability over style.
 ```
@@ -1170,7 +1170,7 @@ Focus on correctness, security, and maintainability over style.
 
 Create `examples/external_prompts/reviewer-task.md`:
 
-```
+```text
 Review the diff at .ai/scratch/diff.patch.
 Report findings ranked by severity (critical, important, minor).
 End with STATUS: success or STATUS: fail.
@@ -1336,7 +1336,7 @@ The two slots are independent — an agent may use any combination of inline `pr
 **Pack-time loading:** `dippin pack` inlines the prompt content into the bundled `.dip` so the `.dipx` is self-contained. The runtime reads inline prompts; no separate file lookup at runtime.
 
 **Non-goals:** defaults-block file-form support and bundled-files `.dipx` redesign are tracked as follow-up issues.
-```
+```markdown
 
 Also add `prompt_file` and `system_prompt_file` rows to the skill.md agent-fields table (if one exists — match the same shape as `command_file:`).
 
@@ -1379,7 +1379,7 @@ If the existing completion entries use a different shape (e.g., snippet form or 
 
 Open `editors/vscode/syntaxes/dippin.tmLanguage.json`. Around line 148 (the agent-field alternation regex that includes `command_file`), add `prompt_file` and `system_prompt_file` to the alternation. The exact form depends on the regex shape — find the line containing `command_file` and extend the alternation in place:
 
-```
+```text
 \\b(model|provider|prompt|system_prompt|prompt_file|system_prompt_file|command_file|...)\\b
 ```
 

--- a/docs/superpowers/plans/2026-05-29-issue-58-branch-tool-access.md
+++ b/docs/superpowers/plans/2026-05-29-issue-58-branch-tool-access.md
@@ -468,7 +468,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 Edit the `parallel split` block in `src` so the `fast` branch reads:
 
-```
+```dippin
   parallel split
     branch: fast
       model: claude-haiku-4-5

--- a/docs/superpowers/plans/2026-05-29-issue-75-writable-paths.md
+++ b/docs/superpowers/plans/2026-05-29-issue-75-writable-paths.md
@@ -791,7 +791,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 Extend `TestRoundtripBlockFormParallel` in `migrate/roundtrip_test.go`: add a `writable_paths` line to the `fast` branch in the `src` string, and add `WritablePaths` to the expected branch. Change the `branch: fast` block to:
 
-```
+```dippin
     branch: fast
       model: claude-haiku-4-5
       provider: anthropic
@@ -1275,7 +1275,7 @@ Expected: FAIL — `read example: open ../examples/agent_writable_paths.dip: no 
 
 Create `examples/agent_writable_paths.dip`:
 
-```
+```dippin
 workflow AgentWritablePaths
   goal: "Demonstrate path-bounded write scope on failure-recorder agents (issue #75)"
   start: Review

--- a/docs/superpowers/plans/2026-06-04-issue-94-budget-attrs.md
+++ b/docs/superpowers/plans/2026-06-04-issue-94-budget-attrs.md
@@ -30,7 +30,7 @@
 
 Edit `parser/testdata/defaults_budget.dip`, adding one line to the `defaults` block (after `max_wall_time: 30m`):
 
-```
+```dippin
   defaults
     model: claude-sonnet-4-6
     max_total_tokens: 500000
@@ -658,7 +658,7 @@ git commit -m "feat: DIP145 lint for negative graph budget defaults (#94)"
 
 Replace the existing `max_turns` table row with:
 
-```
+```text
 | `max_turns` | Integer | 1 | Maximum request-response cycles in the agent's tool-using loop. **Reaching this limit ends the node with outcome `fail`** — it is a hard cap, not a soft budget. The failure routes through the standard failure cascade (fail edge → bounded retry → `fallback_target` → graph `on_failure` → halt). Ensure a failure route exists (see DIP144) or the run halts on exhaustion. |
 ```
 
@@ -691,7 +691,7 @@ priority order below.
 
 In the `defaults` table (around line 113-124), add (the three existing budget fields are currently undocumented here — this fixes that too):
 
-```
+```text
 | `max_total_tokens` | Integer | Hard ceiling on total tokens across the run. `0`/unset = no limit. |
 | `max_cost_cents` | Integer | Hard ceiling on total cost, in **US cents** (e.g. `1000` = $10.00). `0`/unset = no limit. |
 | `max_wall_time` | Duration | Hard ceiling on **wall-clock** run time (e.g. `30m`, `2h`). `0`/unset = no limit. |
@@ -725,7 +725,7 @@ warning[DIP145]: workflow budget default max_cost_cents is -5; budgets cannot be
 
 **Fix:** Use a positive cap, or omit the field / set `0` for no limit. Note `0`
 means *unlimited*, not "zero budget."
-```
+```markdown
 
 - [ ] **Step 6: Cross-link DIP144 → max_turns**
 
@@ -777,7 +777,7 @@ git commit -m "docs: max_turns exhaustion semantics, budget attrs, DIP145, count
 
 Create `examples/budget_guards.dip` — a cost-ceilinged research+build flow with a stall window and a graph `on_failure` escalation, so the budget abort has somewhere to route (and DIP144 stays suppressed). Adjust node/edge syntax to match a known-good existing example (copy the header/shape from `examples/on_failure_route.dip`):
 
-```
+```dippin
 workflow BudgetGuards
   goal: "Research and draft with a cost ceiling and a stall guard"
   start: Research

--- a/docs/superpowers/plans/2026-06-04-on-failure-route-dip144.md
+++ b/docs/superpowers/plans/2026-06-04-on-failure-route-dip144.md
@@ -31,7 +31,7 @@
 
 In `parser/testdata/defaults_complex.dip`, add one line inside the `defaults` block (after `restart_target: A`):
 
-```
+```dippin
     on_failure: A
 ```
 
@@ -835,7 +835,7 @@ Record the counts. Decision rule: leave `stress_*`/adversarial fixtures warning;
 
 Create `examples/on_failure_route.dip`:
 
-```
+```dippin
 workflow OnFailureDemo
   goal: "Demonstrate a graph-level on_failure recovery route"
   start: Plan
@@ -932,4 +932,4 @@ git push -u origin feat/92-on-failure-route
 - [ ] **Step 2: Create the PR** with body covering: the `on_failure` attribute + precedence semantics; the DIP144 lint + its suppression set; the DIP003 node-existence validation + DIP004 reachability seeding; the DOT round-trip decision (tool-safety precedent); the DIP102-suppression descope rationale; the examples blast-radius decision; and the cross-repo split (dippin carries/validates, tracker enforces — note the tracker `upstream` follow-up to be filed, blocking-linked to #295, and the `tracker validate` warning-fatality question). Title: `feat: graph-level on_failure route + DIP144 failure-route lint (Closes #92, Closes #93)`.
 
 - [ ] **Step 3: Do NOT tag a release.** Per the maintainer, tagging (~v0.37.0) requires explicit go-ahead.
-```
+```text

--- a/docs/superpowers/plans/2026-06-05-issue-89-cross-file-tool-access.md
+++ b/docs/superpowers/plans/2026-06-05-issue-89-cross-file-tool-access.md
@@ -169,13 +169,13 @@ In `validator/explanations.go`, in `safetyExplanations()`:
 
 In `validator/explanations.go`, the `DIP143` entry's `Trigger` ends with `Cross-file effective-access enforcement is deferred (#89).` Replace that final sentence with:
 
-```
+```text
 Native `dippin lint` resolves the child and may upgrade this to DIP146 (gap) or silence; DIP143 is the filesystem-free advisory (e.g. the wasm playground) or the fallback when the child cannot be resolved.
 ```
 
 In `validator/lint_subgraph_tool_access.go`, `checkSubgraphBoundary`'s `Help` string currently ends `Cross-file enforcement is tracked as #89.` Replace that trailing sentence with:
 
-```
+```text
 Native `dippin lint` resolves the child (DIP146); this advisory is the filesystem-free check or the fallback when the child cannot be resolved.
 ```
 
@@ -1043,7 +1043,7 @@ result means every resolvable child is fully locked down or had no restriction t
 escape — not that the child's tools are restricted at runtime.
 
 ---
-```
+```markdown
 
 - [ ] **Step 4: `docs/llm-reference.md`**
 
@@ -1056,7 +1056,7 @@ In the `**Subgraph boundary:**` paragraph (line ~106), the final sentence ends `
 
 ```
 ...and native `dippin lint` now resolves the child across the file boundary: [DIP146](https://2389-research.github.io/dippin-lang/validation.html#dip146) (Hint) fires when a resolved child restricts no agent's `tool_access` while a workflow on the path does, superseding DIP143 for boundaries it can resolve ([#89](https://github.com/2389-research/dippin-lang/issues/89)). DIP143 remains the filesystem-free advisory (e.g. the wasm playground) and the fallback when the child can't be resolved.
-```
+```markdown
 
 - [ ] **Step 6: Regenerate the spec and verify**
 

--- a/docs/superpowers/plans/2026-06-10-last-response-truncate.md
+++ b/docs/superpowers/plans/2026-06-10-last-response-truncate.md
@@ -19,7 +19,7 @@
 - Run all builds/tests via `just`, never raw `go`. Key commands: `just test-pkg <pkg>` (one package), `just test` (all), `just lint-go`, `just complexity` (cyclo ≤ 5 / cognit ≤ 7), `just fmt`, `just spec-check`.
 - Work entirely inside the worktree `.claude/worktrees/56-last-response-truncate`. Stage **explicit paths** (never `git add -A`).
 - Commit trailer on every commit:
-  ```
+  ```text
   Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
   ```
 - `0` / unset always means "no truncation" for an agent; `0` on a branch means "inherit the agent's value". The formatter/exporter emit the field only when `> 0`, so a negative value never round-trips — it is a lint concern only.

--- a/docs/superpowers/specs/2026-03-31-structured-output-design.md
+++ b/docs/superpowers/specs/2026-03-31-structured-output-design.md
@@ -65,7 +65,7 @@ case "params":
 
 New helper `writeAgentResponseFields()` slots between model and behavior fields:
 
-```
+```text
 1. Common fields (label, class)
 2. Model fields (model, provider, reasoning_effort, fidelity)
 3. Response fields (response_format, response_schema)  <- NEW

--- a/docs/superpowers/specs/2026-04-06-dippin-spec-command-design.md
+++ b/docs/superpowers/specs/2026-04-06-dippin-spec-command-design.md
@@ -64,7 +64,7 @@ During site build, `docs/generated-spec.md` is copied to `site/static/llms-full.
 
 **New justfile recipes:**
 
-```
+```shell
 # Generate the spec from source docs
 gen-spec:
     ./scripts/gen-spec.sh

--- a/docs/superpowers/specs/2026-04-13-zed-extension-design.md
+++ b/docs/superpowers/specs/2026-04-13-zed-extension-design.md
@@ -18,7 +18,7 @@ The Zed extension is a thin packaging layer:
 
 ## Files
 
-```
+```text
 editors/zed-dippin/
   extension.toml                    # Extension metadata + grammar + LSP declaration
   Cargo.toml                        # Rust crate for WASM compilation

--- a/docs/superpowers/specs/2026-05-19-issue-39-tool-routing-fields-design.md
+++ b/docs/superpowers/specs/2026-05-19-issue-39-tool-routing-fields-design.md
@@ -45,7 +45,7 @@ Three new fields in `applyToolField`:
 
 `writeToolFields` emits new fields when non-default, clustering routing/output-shape fields:
 
-```
+```text
 outputs → marker_grep → route_required → output_limit → timeout → reads → writes → command
 ```
 

--- a/docs/superpowers/specs/2026-05-26-issue-41-design.md
+++ b/docs/superpowers/specs/2026-05-26-issue-41-design.md
@@ -102,7 +102,7 @@ func lintToolAccessValues(res *Result, w *ir.Workflow) {
 
 Diagnostic Help (`validator/explanations.go`):
 
-```
+```text
 DIP139 Trigger: tool_access value is not "none" (case-insensitive) or empty
 DIP139 Fix:     Use `tool_access: none` to disable LLM tools, or omit the field for the full catalog
 DIP139 Example: agent X
@@ -246,7 +246,7 @@ This is enforced in the runtime, not in dippin's validator. The dippin spec does
 
 One file. Lint-clean. Mirrors `examples/tool_safety.dip` syntactic style. Demonstrates the field on a summarizer agent:
 
-```
+```dippin
 workflow AgentToolAccess
   goal: "Demonstrate the tool_access agent-node safety primitive (issue #41)"
   start: Plan

--- a/docs/superpowers/specs/2026-05-27-issue-52-command-file-design.md
+++ b/docs/superpowers/specs/2026-05-27-issue-52-command-file-design.md
@@ -252,7 +252,7 @@ Existing parity tests pass after `CommandFile` is added to `compareToolConfigs`'
 
 ## Example (`examples/external_files.dip` + `examples/external_files/setup.sh`)
 
-```
+```dippin
 workflow ExternalFiles
   goal: "Demonstrate command_file: directive (issue #52)"
   start: Setup

--- a/docs/superpowers/specs/2026-05-27-issue-65-prompt-file-design.md
+++ b/docs/superpowers/specs/2026-05-27-issue-65-prompt-file-design.md
@@ -277,7 +277,7 @@ Existing parity tests pass after `PromptFile` and `SystemPromptFile` are added t
 
 ## Example (`examples/external_prompts.dip` + sibling files)
 
-```
+```dippin
 workflow ExternalPrompts
   goal: "Demonstrate prompt_file:/system_prompt_file: directives (issue #65)"
   start: Reviewer

--- a/docs/superpowers/specs/2026-05-29-issue-75-writable-paths-design.md
+++ b/docs/superpowers/specs/2026-05-29-issue-75-writable-paths-design.md
@@ -338,7 +338,7 @@ New file `validator/lint_writable_paths.go` (keeps DIP139's already-tight functi
 `lint_tool_access.go` undisturbed). Helper ladder (each ≤ cyclo 5 / cognit 7), modeled on
 `lint_style.go`'s `checkNodeFidelityByKind → checkBranchFidelities → checkFidelityValue`:
 
-```
+```text
 lintWritablePaths(w)                      // range nodes -> checkNodeWritablePathsByKind
 checkNodeWritablePathsByKind(n)           // switch AgentConfig / ParallelConfig
 checkBranchWritablePaths(n, branches)     // range branches -> checkWritablePathsObject

--- a/docs/superpowers/specs/2026-06-03-issue-59-design.md
+++ b/docs/superpowers/specs/2026-06-03-issue-59-design.md
@@ -70,7 +70,7 @@ declaring `tool_access: none` is fully safe — the supervisory/steering channel
 (`SteerContext`, `stack.child.*`) is information-flow, a separate concern (#56). It leads with
 the boundary and points the author at the actionable check (security I4, DX M1).
 
-```
+```text
 Message: <kind> %q references subgraph %q, defined in its own file; this workflow's
          tool_access restrictions do not extend across the subgraph boundary
 Help:    audit the agents in %q for their own tool_access — restrictions declared in this
@@ -98,7 +98,7 @@ because it `os.Stat`s the child path). `path/filepath` path-math (`refIsSelf`) i
 only `os` syscalls are not. Decomposed to stay within cyclomatic ≤5 / cognitive ≤7
 (security/arch review: a single type-switch-with-branch-loop would blow the cognitive gate):
 
-```
+```go
 lintSubgraphToolAccess(w)      → if !workflowDeclaresToolAccess(w) { return nil }; loop → checkSubgraphBoundary(n)
 workflowDeclaresToolAccess(w)  → loop → nodeDeclaresToolAccess(n)
 nodeDeclaresToolAccess(n)      → type switch: AgentConfig → toolAccessSet(cfg.ToolAccess)

--- a/docs/superpowers/specs/2026-06-04-issue-94-budget-attrs-design.md
+++ b/docs/superpowers/specs/2026-06-04-issue-94-budget-attrs-design.md
@@ -199,7 +199,7 @@ opposite of intent — the single highest-leverage clarity fix in this issue):
 > **Help:** `use a positive cap (e.g. max_cost_cents: 1000 for $10.00), or omit it / set 0 for no limit`
 
 ### Explanations entry (4-field, test-gated)
-```
+```go
 DIP145: {
     Code:    DIP145,
     Summary: "graph budget default is negative",

--- a/docs/superpowers/specs/2026-07-01-issue-73-file-shipping-pack-design.md
+++ b/docs/superpowers/specs/2026-07-01-issue-73-file-shipping-pack-design.md
@@ -35,7 +35,7 @@ Two distinct categories of files must reach the bundle:
 dippin's deliverable is **structural and tracker-free**: for every file in the
 entry's reachable closure (`.dip` workflows + shipped assets),
 
-```
+```text
 extract(pack(S, --no-inline --include …))/workflows/<rel>  ==  S/<rel>   (byte-for-byte)
 ```
 
@@ -65,7 +65,7 @@ The end-to-end shell-parity check (`tracker run dev_loop.dip` vs
 
 ## CLI surface
 
-```
+```shell
 dippin pack --no-inline [--include <path> ...] -o out.dipx entry.dip
 ```
 
@@ -100,7 +100,7 @@ Assets ship under `workflows/` as **siblings of the `.dip` that references
 them**, reusing the existing `bundlePathFor` mapping (`"workflows/" + rel`,
 `dipx/helpers.go:441-448`) unchanged.
 
-```
+```text
 out.dipx (format_version: 2)
   manifest.json
   workflows/dev_loop.dip              # workflow (entry)

--- a/docs/superpowers/specs/2026-07-07-issue-156-marker-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-07-issue-156-marker-coverage-design.md
@@ -16,7 +16,7 @@ marker-coverage lint at all**.
 
 Example of the hole (silent today):
 
-```
+```dippin
 tool RunTests
   marker_grep: ^(tests-ok|tests-failed)$
 edges
@@ -162,7 +162,7 @@ the helper names above are the pre-planned extractions.
 
 ## Diagnostic shape
 
-```
+```text
 warning[DIP152]: node "RunTests": marker_grep enumerates markers that no edge
   routes and no else default covers: tests-failed
   = help: route each marker (e.g. `RunTests -> <node> on tests-failed`), add an

--- a/docs/superpowers/specs/2026-07-10-issue-175-shared-prompt-fragments-design.md
+++ b/docs/superpowers/specs/2026-07-10-issue-175-shared-prompt-fragments-design.md
@@ -57,7 +57,7 @@ The formatter runs on **unresolved** IR (`dippin fmt` calls `parser.NewParser(..
 
 Effective prompt assembly (each part omitted when empty), per agent:
 
-```
+```text
 body_with_include = join_nonempty("\n\n", [ Prompt, <content of prompt_include> ])
 effective         = join_nonempty("\n\n", [ prefix, body_with_include, suffix ])
 ```

--- a/docs/superpowers/specs/2026-07-13-issue-182-edge-condition-quotes-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-182-edge-condition-quotes-design.md
@@ -67,7 +67,7 @@ A lex-error mechanism, since none exists:
 
 ### Data-flow summary
 
-```
+```text
 source  --lexer(unescape)-->  TokenLiteral.Value (literal content)
         --formatConditionToken(escape)-->  Condition.Raw (escaped, quoted)
         --tryTokenizeQuotedCond(unescape)-->  CondCompare.Value (literal content)   ← round-trips

--- a/docs/superpowers/specs/2026-08-07-pricing-package-and-autosync-design.md
+++ b/docs/superpowers/specs/2026-08-07-pricing-package-and-autosync-design.md
@@ -33,7 +33,7 @@ Two problems, one root cause.
 
 New top-level package `pricing/` that imports **nothing** from dippin (not `ir`, not `cost`). Both `cost` and `validator` import it; tracker can too. Because it is a leaf with no analysis deps, `validator` importing it does **not** violate the "packages import `ir`, not each other" rule (it's a shared leaf like the stdlib).
 
-```
+```text
 pricing/
   prices.json        # the source of truth (embedded)
   pricing.go         # //go:embed, types, Lookup, Cost
@@ -118,7 +118,7 @@ tracker #518's test (catalog constants vs. `PublishedPrice`) moves down into `pr
 
 The honest split: **detection is fully mechanical; authoritative verification is not** (nobody official publishes price as data). So the pipeline automates up to a reviewable diff, and auto-ships only a narrow, high-confidence subset defined by **cross-source agreement**.
 
-```
+```text
 GitHub Action (cron, daily) — no API keys, no HTML scraping
   └─ fetch models.dev + LiteLLM + OpenRouter (JSON)
   └─ normalize IDs (apply the #188 .↔- fold + alias map) and reconcile the 3 sources

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -276,7 +276,7 @@ An omitted field inherits the target agent's value. An inline-form parallel (`->
 
 The `edges` block defines connections between nodes. Every edge is a line of the form:
 
-```
+```dippin
 <FromID> -> <ToID> [on <token> | when <condition>] [label: <text>] [choice: <key>] [weight: <int>] [loop] [override: true]
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ flowchart LR
 
 Test files use `.test.json` extension and are auto-discovered from the workflow path:
 
-```
+```text
 pipeline.dip       → pipeline.test.json
 src/flow.dip       → src/flow.test.json
 ```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -23,7 +23,7 @@ graph LR
 
 Diagnostics are displayed in a rustc-inspired format:
 
-```
+```text
 error[DIP003]: unknown node reference "InterpretX" in edge
   --> pipeline.dip:45:5
   = help: did you mean "Interpret"?
@@ -52,7 +52,7 @@ In JSON output mode (`--format json`), diagnostics are emitted as an array of ob
 
 The workflow must declare a `start:` field pointing to an existing node.
 
-```
+```text
 error[DIP001]: start node does not exist
   --> pipeline.dip:1:1
   = help: add "start: <NodeID>" to the workflow header
@@ -77,7 +77,7 @@ workflow MyPipeline
 
 The workflow must declare an `exit:` field pointing to an existing node.
 
-```
+```text
 error[DIP002]: exit node does not exist
   --> pipeline.dip:1:1
   = help: add "exit: <NodeID>" to the workflow header
@@ -97,7 +97,7 @@ error[DIP002]: exit node does not exist
 
 Every edge's `From` and `To` must reference existing node IDs.
 
-```
+```text
 error[DIP003]: unknown node reference "InterpretX" in edge
   --> pipeline.dip:45:5
   = help: did you mean "Interpret"?
@@ -117,7 +117,7 @@ error[DIP003]: unknown node reference "InterpretX" in edge
 
 Every node must be reachable from the start node via some path of edges.
 
-```
+```text
 error[DIP004]: node unreachable from start
   --> pipeline.dip:20:3
   = help: add an edge leading to this node, or remove it
@@ -135,7 +135,7 @@ error[DIP004]: node unreachable from start
 
 The workflow graph must be a DAG (directed acyclic graph), with the exception of restart edges.
 
-```
+```text
 error[DIP005]: unconditional cycle detected
   --> pipeline.dip:50:5
   = help: remove an edge in this cycle or mark it "restart: true"
@@ -155,7 +155,7 @@ error[DIP005]: unconditional cycle detected
 
 The exit node is the terminal — it must have zero outgoing edges.
 
-```
+```text
 error[DIP006]: exit node has outgoing edges
   --> pipeline.dip:55:5
   = help: remove outgoing edges from the exit node
@@ -173,7 +173,7 @@ error[DIP006]: exit node has outgoing edges
 
 Every `parallel` node must have a matching `fan_in` node with the same set of branch nodes.
 
-```
+```text
 error[DIP007]: parallel fan-out/fan-in mismatch
   --> pipeline.dip:15:3
   = help: add a matching fan_in node
@@ -194,7 +194,7 @@ error[DIP007]: parallel fan-out/fan-in mismatch
 
 Node IDs must be globally unique within a workflow.
 
-```
+```text
 error[DIP008]: duplicate node ID
   --> pipeline.dip:30:3
   = help: rename this node or remove the duplicate
@@ -212,7 +212,7 @@ error[DIP008]: duplicate node ID
 
 No two edges may have the same (from, to, condition) combination.
 
-```
+```text
 error[DIP009]: duplicate edge
   --> pipeline.dip:60:5
   = help: remove the duplicate edge
@@ -256,7 +256,7 @@ lints (DIP103/DIP120/DIP121/DIP122), so one bad condition no longer masks the re
 
 A node where **all** incoming edges have conditions may be unreachable at runtime if no condition matches.
 
-```
+```text
 warning[DIP101]: node "NextPhase" is only reachable through conditional edges and may be skipped at runtime
   --> pipeline.dip:25:3
   = help: add an unconditional edge to this node, or verify all conditions are exhaustive
@@ -278,7 +278,7 @@ Known exhaustive sets: `ctx.outcome` / `outcome` with values `{success, fail}` o
 
 A node with conditional outgoing edges but no unconditional fallback.
 
-```
+```text
 warning[DIP102]: node "Gate" has conditional outgoing edges but no unconditional default edge
   --> pipeline.dip:35:3
   = help: add an unconditional edge as a fallback, or ensure conditions are exhaustive
@@ -306,7 +306,7 @@ warning[DIP102]: node "Gate" has conditional outgoing edges but no unconditional
 
 Multiple edges from the same node test the same variable for the same value.
 
-```
+```text
 warning[DIP103]: overlapping or contradictory conditions
   --> pipeline.dip:45:5
 ```
@@ -323,7 +323,7 @@ warning[DIP103]: overlapping or contradictory conditions
 
 A retry path has no bound and no failure route — no `max_retries`, no `on fail` edge, and no `fallback_target`/`fallback_retry_target`.
 
-```
+```text
 warning[DIP104]: unbounded retry loop (no max_retries or fallback)
   --> pipeline.dip:40:3
 ```
@@ -346,7 +346,7 @@ warning[DIP104]: unbounded retry loop (no max_retries or fallback)
 
 There is no guaranteed path from start to exit through unconditional edges alone.
 
-```
+```text
 warning[DIP105]: no success path from start to exit
   --> pipeline.dip:1:1
 ```
@@ -363,7 +363,7 @@ warning[DIP105]: no success path from start to exit
 
 A prompt template has a `${...}` reference that lacks a known namespace prefix or isn't a valid node-scoped ref.
 
-```
+```text
 warning[DIP106]: unrecognized variable reference ${user}
   --> pipeline.dip:22:5
 ```
@@ -380,7 +380,7 @@ warning[DIP106]: unrecognized variable reference ${user}
 
 A node produces a context key that no downstream node reads.
 
-```
+```text
 warning[DIP107]: unused context key (written but never read)
   --> pipeline.dip:18:5
 ```
@@ -397,7 +397,7 @@ warning[DIP107]: unused context key (written but never read)
 
 The model or provider isn't in the engine's recognized list.
 
-```
+```text
 warning[DIP108]: unknown model/provider combination
   --> pipeline.dip:15:5
 ```
@@ -421,7 +421,7 @@ whichever spelling your executing runtime requires.
 
 Two `subgraph` nodes reference the same `ref:` file, which can collide their context keys.
 
-```
+```text
 warning[DIP109]: duplicate subgraph reference
   --> pipeline.dip:28:5
 ```
@@ -438,7 +438,7 @@ warning[DIP109]: duplicate subgraph reference
 
 An agent node has no prompt text.
 
-```
+```text
 warning[DIP110]: empty prompt on agent node
   --> pipeline.dip:12:3
 ```
@@ -457,7 +457,7 @@ warning[DIP110]: empty prompt on agent node
 
 A tool node has no `timeout` field.
 
-```
+```text
 warning[DIP111]: tool command has no timeout
   --> pipeline.dip:35:3
 ```
@@ -482,7 +482,7 @@ warning[DIP111]: tool command has no timeout
 
 A node declares a `reads` key that no upstream node produces.
 
-```
+```text
 warning[DIP112]: reads key not produced by any upstream writes
   --> pipeline.dip:25:3
 ```
@@ -499,7 +499,7 @@ warning[DIP112]: reads key not produced by any upstream writes
 
 A node or workflow default specifies a `retry_policy` value that is not a recognized policy name.
 
-```
+```text
 warning[DIP113]: node "analyze" has retry_policy "agressive" which is not a recognized policy name
   --> pipeline.dip:15:3
   = help: valid policies: standard, aggressive, patient, linear, none
@@ -525,7 +525,7 @@ warning[DIP113]: node "analyze" has retry_policy "agressive" which is not a reco
 
 A node or workflow default specifies a `fidelity` value that is not a recognized level.
 
-```
+```text
 warning[DIP114]: node "analyze" has fidelity "sumary:high" which is not a recognized level
   --> pipeline.dip:12:3
   = help: valid levels: full, summary:high, summary:medium, summary:low, compact, truncate
@@ -554,7 +554,7 @@ warning[DIP114]: node "analyze" has fidelity "sumary:high" which is not a recogn
 
 A node has `goal_gate: true` but no failure route — no `on fail` edge and no `retry_target`/`fallback_target` — meaning the pipeline has no recovery path if the gate fails.
 
-```
+```text
 warning[DIP115]: node "validate_tests" has goal_gate: true but no retry_target or fallback_target
   --> pipeline.dip:18:3
   = help: add an `on fail` edge, set fallback_target:, or add retry_target with max_retries so the pipeline can recover when the gate fails
@@ -572,7 +572,7 @@ warning[DIP115]: node "validate_tests" has goal_gate: true but no retry_target o
 
 Configuration values for `compaction_threshold` or `on_resume` are outside valid ranges.
 
-```
+```text
 warning[DIP116]: node "Analyze" has compaction_threshold 1.50 outside valid range [0.0, 1.0]
   --> pipeline.dip:15:3
 ```
@@ -592,7 +592,7 @@ warning[DIP116]: node "Analyze" has compaction_threshold 1.50 outside valid rang
 
 A stylesheet rule targets a class that no node declares.
 
-```
+```text
 warning[DIP117]: stylesheet references class "critical" which is not declared on any node
   --> pipeline.dip:80:5
   = help: add class: critical to a node declaration
@@ -608,7 +608,7 @@ warning[DIP117]: stylesheet references class "critical" which is not declared on
 
 A stylesheet rule targets a node ID that doesn't exist.
 
-```
+```text
 warning[DIP118]: stylesheet references node ID "Analize" which does not exist
   --> pipeline.dip:82:5
 ```
@@ -623,7 +623,7 @@ warning[DIP118]: stylesheet references node ID "Analize" which does not exist
 
 A node specifies a `reasoning_effort` value that isn't recognized.
 
-```
+```text
 warning[DIP119]: node "Analyze" has reasoning_effort "extreme" which is not a recognized level
   --> pipeline.dip:12:3
   = help: valid levels: none, minimal, low, medium, high, xhigh, max
@@ -641,7 +641,7 @@ warning[DIP119]: node "Analyze" has reasoning_effort "extreme" which is not a re
 
 A condition references a variable without a namespace prefix.
 
-```
+```text
 warning[DIP120]: condition variable "outcome" should use a namespace prefix (e.g., ctx.outcome)
   --> pipeline.dip:45:5
 ```
@@ -658,7 +658,7 @@ warning[DIP120]: condition variable "outcome" should use a namespace prefix (e.g
 
 An edge condition references a variable that the source node doesn't declare in its `writes`.
 
-```
+```text
 warning[DIP121]: edge Gate → Pass: condition references "ctx.score" but node "Gate" does not declare it in writes
   --> pipeline.dip:45:5
   = help: add writes: score to node "Gate", or use a reserved variable
@@ -678,7 +678,7 @@ warning[DIP121]: edge Gate → Pass: condition references "ctx.score" but node "
 
 An edge condition tests a value that the source tool node doesn't declare in its `outputs`.
 
-```
+```text
 warning[DIP122]: edge RunTest → Pass: condition tests value "retry" but tool "RunTest" does not declare it in outputs
   --> pipeline.dip:50:5
   = help: add "retry" to tool "RunTest" outputs, or check for typos
@@ -696,7 +696,7 @@ warning[DIP122]: edge RunTest → Pass: condition tests value "retry" but tool "
 
 The tool command block has a shell syntax error detectable by `bash -n`.
 
-```
+```text
 warning[DIP123]: tool command has shell syntax error: unexpected EOF while looking for matching `"'
   --> pipeline.dip:45:5
 ```
@@ -713,7 +713,7 @@ warning[DIP123]: tool command has shell syntax error: unexpected EOF while looki
 
 A tool command contains `${ctx.*}` interpolation that won't resolve at shell execution time.
 
-```
+```text
 warning[DIP124]: tool command references ${ctx.api_url} which expands to empty at runtime
   --> pipeline.dip:50:5
 ```
@@ -730,7 +730,7 @@ warning[DIP124]: tool command references ${ctx.api_url} which expands to empty a
 
 The first non-preamble command in the tool block references a binary not found on the current PATH.
 
-```
+```text
 hint[DIP125]: tool command binary "npx" not found on PATH
   --> pipeline.dip:55:5
 ```
@@ -749,7 +749,7 @@ hint[DIP125]: tool command binary "npx" not found on PATH
 
 A subgraph node references a file that does not exist at the declared path.
 
-```
+```text
 warning[DIP126]: subgraph node "Review" references "review_pipeline.dip" which does not exist
   --> pipeline.dip:28:5
   = help: resolved path: /home/user/project/review_pipeline.dip
@@ -767,7 +767,7 @@ warning[DIP126]: subgraph node "Review" references "review_pipeline.dip" which d
 
 A human node has a `mode` value that is not one of the recognized modes.
 
-```
+```text
 warning[DIP127]: node "Gate" has mode "interactive" which is not a recognized human mode
   --> pipeline.dip:12:3
   = help: valid modes: choice, freeform, interview, yes_no
@@ -783,7 +783,7 @@ warning[DIP127]: node "Gate" has mode "interactive" which is not a recognized hu
 
 A human node with `mode: interview` also sets a `default` value. Interview mode collects structured answers — it has no predefined choices to default to.
 
-```
+```text
 warning[DIP128]: node "Ask" is mode interview but has default "yes" which is ignored
   --> pipeline.dip:15:3
   = help: default is only meaningful for choice mode; remove it
@@ -799,7 +799,7 @@ warning[DIP128]: node "Ask" is mode interview but has default "yes" which is ign
 
 A human node with `mode: interview` has multiple labeled outgoing edges. Interview mode does not route by label — it collects answers and follows a single unconditional edge.
 
-```
+```text
 warning[DIP129]: node "Ask" is mode interview but has 2 labeled edges (interview does not route by label)
   --> pipeline.dip:15:3
   = help: interview mode collects answers, not choices; use mode choice for label-based routing
@@ -815,7 +815,7 @@ warning[DIP129]: node "Ask" is mode interview but has 2 labeled edges (interview
 
 An agent node (or any node) specifies a `response_format` value that is not one of the recognized values.
 
-```
+```text
 warning[DIP130]: node "Analyze" has response_format "json" which is not a recognized value
   --> pipeline.dip:12:3
   = help: valid values: json_object, json_schema
@@ -835,7 +835,7 @@ warning[DIP130]: node "Analyze" has response_format "json" which is not a recogn
 
 There is a mismatch between `response_schema` and `response_format: json_schema`.
 
-```
+```text
 warning[DIP131]: node "Analyze" has response_schema but response_format is not json_schema
   --> pipeline.dip:12:3
   = help: set response_format: json_schema to enforce the schema
@@ -859,7 +859,7 @@ hint[DIP131]: node "Analyze" has response_format: json_schema but no response_sc
 
 The content of the `response_schema` block is not valid JSON.
 
-```
+```text
 warning[DIP132]: node "Analyze" has response_schema that is not valid JSON
   --> pipeline.dip:12:3
   = help: response_schema must be a valid JSON Schema object
@@ -877,7 +877,7 @@ warning[DIP132]: node "Analyze" has response_schema that is not valid JSON
 
 An agent node's `params` block contains a key that matches a first-class agent field (e.g., `model`, `provider`).
 
-```
+```text
 hint[DIP133]: node "Analyze" params key "model" shadows the first-class field model
   --> pipeline.dip:12:3
   = help: use the top-level model: field instead of params: model to avoid ambiguity
@@ -1116,7 +1116,7 @@ This is a Hint, not a Warning: the referencing node has no defect. The check is 
 
 An agent node has no declared failure route at any level. If the node fails at runtime, the pipeline has nowhere to go and will halt.
 
-```
+```text
 warning[DIP144]: agent node "Build" has no failure route (no fail edge, no fallback_target, no bounded retry, no graph on_failure)
   --> pipeline.dip:12:3
   = help: add `-> <node> when ctx.outcome = fail`, set fallback_target:, add retry_target with max_retries, or declare a workflow-level on_failure:


### PR DESCRIPTION
## What

Sweep surfaced by PR #85: **267 fenced code blocks across 51 files** in `docs/` were missing a language identifier (markdownlint **MD040**). Each opening fence now carries an appropriate token (`text`/`shell`/`dippin`/`go`/`markdown`/`ebnf`), classified by the block's content.

## Guarantees

- **No technical content altered** — every changed line is a fence delimiter. `git diff --numstat` is exactly **267 insertions / 267 deletions** (one line per fence); every addition is a typed fence, every removal a bare fence (verified programmatically).
- Closing fences left bare; the one 4-backtick fence (wrapping a nested ```json) handled correctly.
- **Docs-only.** No CI gate added, no markdownlint config, no non-doc files, `CHANGELOG.md`/`README.md` (repo root, out of scope) untouched. MD040 only — sibling rules (MD013/MD033) left alone.

## Verification

`markdownlint-cli2` MD040-only re-run over all 101 docs files: **0 issues**.

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788983422&installation_model_id=21126&pr_number=235&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F235&signature=188fb60b5e6dcb37251333aea7e6b2fc24513571efe7c3a4f288e96f3e38d39c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->