### PR TITLE
release: v0.60.0 — drift suppress-list (#211) + doctor cross-file DIP146 (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.60.0] — 2026-08-10
 
 ### Added
 - **pricing-sync drift suppress-list** ([#211](https://github.com/2389-research/dippin-lang/issues/211)). The daily drift Action re-opened the same issue (#201, #206) for the same persistently-deferred candidates — models.dev's intro-vs-durable price for `claude-sonnet-5`, JS-gated Mistral/Cohere pages, and unreliable `deprecated` flags on active OpenAI/Gemini models. `cmd/pricing-sync` now carries a checked-in `drift_suppressions.json` (keyed on `provider`/`model`/`kind` + the dispositioned `aggregator_value`, with a `reason` and a `review_by` date). `sync` filters a suppressed candidate **unless** the aggregator's reported value has changed from the dispositioned one, or the `review_by` date has passed — either re-surfaces it for fresh review. So the daily Action only opens/updates an issue on a genuinely new or changed candidate. Seeded with the nine entries stable across #201 and #206.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,14 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.60.0] — 2026-08-10
+
+### Added
+- **pricing-sync drift suppress-list** ([#211](https://github.com/2389-research/dippin-lang/issues/211)). The daily drift Action re-opened the same issue (#201, #206) for the same persistently-deferred candidates — models.dev's intro-vs-durable price for `claude-sonnet-5`, JS-gated Mistral/Cohere pages, and unreliable `deprecated` flags on active OpenAI/Gemini models. `cmd/pricing-sync` now carries a checked-in `drift_suppressions.json` (keyed on `provider`/`model`/`kind` + the dispositioned `aggregator_value`, with a `reason` and a `review_by` date). `sync` filters a suppressed candidate **unless** the aggregator's reported value has changed from the dispositioned one, or the `review_by` date has passed — either re-surfaces it for fresh review. So the daily Action only opens/updates an issue on a genuinely new or changed candidate. Seeded with the nine entries stable across #201 and #206.
+
+### Fixed
+- **`dippin doctor` now applies the cross-file DIP146 pass / DIP143 supersession** ([#101](https://github.com/2389-research/dippin-lang/issues/101), deferred from #89). Doctor's lint summary previously computed lint inside the `doctor` package and never saw the CLI-layer cross-file resolution, so a fully-restricted (or agent-less) resolved child left a stale DIP143 hint in the health card that `lint`/`check`/`watch` had already superseded. Doctor now receives the cross-file-adjusted diagnostics via a new `doctor.DiagnoseFromDiagnostics` seam (the CLI owns the native pass; `doctor` still imports no CLI code), so its hint count matches the other commands. Only the tool_access pass is threaded in — DIP160 cross-file input arity is a Warning and folding it into the score is a separate change. Score/Grade are unaffected (they react only to errors and warnings).
+
 ## [v0.59.1] — 2026-08-10
 
 ### Fixed


### PR DESCRIPTION
Cuts **v0.60.0**. Renames `[Unreleased]` (#211 + #101) to `[v0.60.0]`. After merge, tag `v0.60.0` to trigger GoReleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788983467&installation_model_id=21126&pr_number=236&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F236&signature=deac83bc93071bcfcb3116fee50495bf2ada6c3724eceba216299cac49dd61f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->