### PR TITLE
release: v0.61.0 — provider cache-read rates (#232) + docs MD040 sweep (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.61.0] — 2026-08-10
 
 ### Added
 - **Cache-read rates for DeepSeek, Z.AI/GLM, xAI/Grok, and Moonshot/Kimi** ([#232](https://github.com/2389-research/dippin-lang/issues/232)). These providers publish a per-model cached-input (cache-hit) price, so the catalog now carries the absolute `cached_input_per_m`, verified 2026-08-10 against each official page: **DeepSeek** (`deepseek-v4-flash` $0.0028, `deepseek-v4-pro` $0.003625/MTok), **Z.AI/GLM** (11 models, e.g. `glm-5.2` $0.26, `glm-4.5` $0.11), **xAI/Grok** (`grok-4.5` $0.30, `grok-4.3` + `grok-4.20-0309-*` $0.20 — base tier), and **Moonshot/Kimi** (`kimi-k3` $0.30). `pricing.Cost` now bills cache reads for these at the published rate instead of $0. The rest stay 0 (consumer overlays until verified): **MiniMax** (no token cache price on its official page), **Mistral**/**Cohere** (pricing pages JS-gated, not machine-verifiable), **Qwen** (unpriced). Pairs with tracker#558.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.61.0] — 2026-08-10
+
+### Added
+- **Cache-read rates for DeepSeek, Z.AI/GLM, xAI/Grok, and Moonshot/Kimi** ([#232](https://github.com/2389-research/dippin-lang/issues/232)). These providers publish a per-model cached-input (cache-hit) price, so the catalog now carries the absolute `cached_input_per_m`, verified 2026-08-10 against each official page: **DeepSeek** (`deepseek-v4-flash` $0.0028, `deepseek-v4-pro` $0.003625/MTok), **Z.AI/GLM** (11 models, e.g. `glm-5.2` $0.26, `glm-4.5` $0.11), **xAI/Grok** (`grok-4.5` $0.30, `grok-4.3` + `grok-4.20-0309-*` $0.20 — base tier), and **Moonshot/Kimi** (`kimi-k3` $0.30). `pricing.Cost` now bills cache reads for these at the published rate instead of $0. The rest stay 0 (consumer overlays until verified): **MiniMax** (no token cache price on its official page), **Mistral**/**Cohere** (pricing pages JS-gated, not machine-verifiable), **Qwen** (unpriced). Pairs with tracker#558.
+
 ## [v0.60.0] — 2026-08-10
 
 ### Added


### PR DESCRIPTION
Cuts **v0.61.0**. Renames `[Unreleased]` (#232) to `[v0.61.0]`. After merge, tag `v0.61.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788985538&installation_model_id=21126&pr_number=238&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F238&signature=12ce2279725b05aa13723522be70068a961a0505c88929234bac69842ee6ed54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published the v0.61.0 release notes dated August 10, 2026.
  * Documented verified cache-read pricing for DeepSeek, Z.AI/GLM, xAI/Grok, and Moonshot/Kimi.

* **Bug Fixes**
  * Cache-read usage is now billed using published rates for supported providers.
  * Providers without verified pricing continue to report cache-read costs as zero until verification is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->