### PR TITLE
release: v0.62.0 — shared defaults system_prompt_file (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.62.0] — 2026-08-10
 
 ### Added
 - **Shared `system_prompt_file` default** ([#72](https://github.com/2389-research/dippin-lang/issues/72)). The `defaults` block now accepts `system_prompt_file:` — a shared system prompt (persona/role) authored once in an external file. It is a **fallback default**: an agent that declares no `system_prompt`/`system_prompt_file` of its own inherits it, and any agent that sets its own fully overrides it (node wins, like `model`/`provider`). File form only — an inline `system_prompt:` under `defaults` remains an unknown-field error; there is no `system_prompt: none` opt-out. Resolved with the same containment/symlink/size envelope as every other file directive, and packed (inline or `--no-inline`) like the existing `prompt_prefix_file` cascade. Complements #175 (which cascades the prompt *body*); this covers the system-prompt half of #72. Design: `docs/superpowers/specs/2026-08-10-issue-72-defaults-system-prompt-design.md`.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.62.0] — 2026-08-10
+
+### Added
+- **Shared `system_prompt_file` default** ([#72](https://github.com/2389-research/dippin-lang/issues/72)). The `defaults` block now accepts `system_prompt_file:` — a shared system prompt (persona/role) authored once in an external file. It is a **fallback default**: an agent that declares no `system_prompt`/`system_prompt_file` of its own inherits it, and any agent that sets its own fully overrides it (node wins, like `model`/`provider`). File form only — an inline `system_prompt:` under `defaults` remains an unknown-field error; there is no `system_prompt: none` opt-out. Resolved with the same containment/symlink/size envelope as every other file directive, and packed (inline or `--no-inline`) like the existing `prompt_prefix_file` cascade. Complements #175 (which cascades the prompt *body*); this covers the system-prompt half of #72. Design: `docs/superpowers/specs/2026-08-10-issue-72-defaults-system-prompt-design.md`.
+
 ## [v0.61.0] — 2026-08-10
 
 ### Added


### PR DESCRIPTION
Cuts **v0.62.0**. Renames `[Unreleased]` (#72) to `[v0.62.0]`. After merge, tag `v0.62.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788987298&installation_model_id=21126&pr_number=240&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F240&signature=337a7ee4820731a88412e70a1ae8f6cf84fe0389454da0bf3151260e551a63a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the v0.62.0 release entry dated August 10, 2026.
  * Documented shared system prompt file defaults, agent-specific overrides, validation requirements, security constraints, and packaging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->