### PR TITLE
release: v0.62.1 — Mistral/Cohere verified no cached-input discount (#232 tail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.62.1] — 2026-08-10
 
 ### Changed
 - **Mistral and Cohere marked as verified no cached-input discount** ([#232](https://github.com/2389-research/dippin-lang/issues/232) tail). Their official pricing pages publish no cached-input rate, so their `cache_read_mult` is now a **verified `1.0`** — a cache read bills at the full input rate. This is deliberately distinct from an unverified `0` (which prices cache reads at $0 and signals "a consumer may overlay a default"): `1.0` says "we checked, there is no discount." A consumer can now stop overlaying a default cache rate for Mistral/Cohere and trust the catalog. Only **MiniMax** (official page is audio-only) and **Qwen** (unpriced/console-gated) remain unverified (cache fields `0`). Closes the pricing half of #232 / tracker#558 for all but those two.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.62.1] — 2026-08-10
+
+### Changed
+- **Mistral and Cohere marked as verified no cached-input discount** ([#232](https://github.com/2389-research/dippin-lang/issues/232) tail). Their official pricing pages publish no cached-input rate, so their `cache_read_mult` is now a **verified `1.0`** — a cache read bills at the full input rate. This is deliberately distinct from an unverified `0` (which prices cache reads at $0 and signals "a consumer may overlay a default"): `1.0` says "we checked, there is no discount." A consumer can now stop overlaying a default cache rate for Mistral/Cohere and trust the catalog. Only **MiniMax** (official page is audio-only) and **Qwen** (unpriced/console-gated) remain unverified (cache fields `0`). Closes the pricing half of #232 / tracker#558 for all but those two.
+
 ## [v0.62.0] — 2026-08-10
 
 ### Added


### PR DESCRIPTION
Cuts **v0.62.1**. Renames `[Unreleased]` (#232 tail) to `[v0.62.1]`. After merge, tag `v0.62.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788990063&installation_model_id=21126&pr_number=242&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F242&signature=977fb5bb509987637c5a162685cbf69310a08faef74f48337cb9f376eec02305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->