### PR TITLE
release: v0.62.2 — docs/website/syntax currency sweep (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [v0.62.2] — 2026-08-10
+
+### Changed
+- **Documentation, website, and syntax-package currency sweep** ([#243](https://github.com/2389-research/dippin-lang/pull/243)). Aligned every author-facing surface with the current state: diagnostic-code counts now read **70** everywhere (the agent-facing `skill.md`/`llms-full.txt`/embedded spec were missing the DIP155–DIP160 rows), the pricing-integration guide was rewritten (current version pin, `ModelPrice.Deprecated`, real populated cache-pricing state instead of the old "not populated / $0" section), and stale blog counts were corrected. **VSCode** syntax highlighting gained 13 missing field keywords (`timeout_action`, `questions_key`, `answers_key`, `outputs`, `params`, `on_resume`, `on_failure`, `tool_commands_allow`, `tool_denylist_add`, `max_total_tokens`, `max_cost_cents`, `max_wall_time`, `stall_timeout`) + the `stylesheet` section; **tree-sitter** highlighting gained the `inputs` section keyword. The `fmt --migrate` flag help now reads "lossless version bump" rather than "edges own destinations" (Option A keeps the retry channel on the node). No runtime behavior change.
+
 ## [v0.62.1] — 2026-08-10
 
 ### Changed

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.62.2] — 2026-08-10
+
+### Changed
+- **Documentation, website, and syntax-package currency sweep** ([#243](https://github.com/2389-research/dippin-lang/pull/243)). Aligned every author-facing surface with the current state: diagnostic-code counts now read **70** everywhere (the agent-facing `skill.md`/`llms-full.txt`/embedded spec were missing the DIP155–DIP160 rows), the pricing-integration guide was rewritten (current version pin, `ModelPrice.Deprecated`, real populated cache-pricing state instead of the old "not populated / $0" section), and stale blog counts were corrected. **VSCode** syntax highlighting gained 13 missing field keywords (`timeout_action`, `questions_key`, `answers_key`, `outputs`, `params`, `on_resume`, `on_failure`, `tool_commands_allow`, `tool_denylist_add`, `max_total_tokens`, `max_cost_cents`, `max_wall_time`, `stall_timeout`) + the `stylesheet` section; **tree-sitter** highlighting gained the `inputs` section keyword. The `fmt --migrate` flag help now reads "lossless version bump" rather than "edges own destinations" (Option A keeps the retry channel on the node). No runtime behavior change.
+
 ## [v0.62.1] — 2026-08-10
 
 ### Changed


### PR DESCRIPTION
Cuts **v0.62.2**. Adds the changelog entry for the #243 currency sweep. After merge, tag `v0.62.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788991863&installation_model_id=21126&pr_number=244&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F244&signature=887571c6d5dd330006f2391a4c40ea6fa2cf56163b21d9a95d4d41ee36c13df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the v0.62.2 changelog entry.
  - Standardized documented diagnostic counts at 70.
  - Updated pricing guidance and corrected outdated blog information.
  - Added missing VSCode and tree-sitter syntax keywords.
  - Corrected the `fmt --migrate` help text.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->