### PR TITLE
feat(dip2): `inputs:` subgraph call-site binding (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **dip-2 `inputs:` subgraph call-site binding** ([#227](https://github.com/2389-research/dippin-lang/issues/227)). A `subgraph` node's call-site binding — how a parent supplies values to a child — is now spelled **`inputs:`** in `dip 2` (the dip-1 spelling `params:` is unchanged), completing the call-site half of the inputs epic (#190). This gives the child's declared `inputs` signature a caller: a key matching an input the child declares seeds its `${inputs.*}` namespace; any other key seeds the legacy `${params.*}`. Semantics mirror the retry-channel rename (Option A): `dip 2` rejects `params:` on a subgraph (pointing to `inputs:`), and `dippin fmt --migrate` relabels it losslessly. The existing [DIP160](https://2389-research.github.io/dippin-lang/validation.html#dip160) cross-file "omits a required child input" check works against either spelling. Unblocks the engine runtime half (tracker#556) — the runtime seeds `inputs.*` from the call site.
+
 ## [v0.62.2] — 2026-08-10
 
 ### Changed

--- a/cmd/dippin/crossfile_inputs.go
+++ b/cmd/dippin/crossfile_inputs.go
@@ -70,6 +70,6 @@ func missingRequiredInputDiag(n *ir.Node, ref, name string) validator.Diagnostic
 		Message: fmt.Sprintf("subgraph %q omits required input %q of %q — the child starts with it unset",
 			n.ID, name, ref),
 		Location: n.Source,
-		Help:     fmt.Sprintf("add %q to this subgraph's params:, or give the child input a default", name),
+		Help:     fmt.Sprintf("add %q to this subgraph's input binding (`inputs:` in dip 2, `params:` in dip 1), or give the child input a default", name),
 	}
 }

--- a/cmd/dippin/generated-spec.md
+++ b/cmd/dippin/generated-spec.md
@@ -63,7 +63,7 @@ workflow <Name>
 | `tool` | `command` (or `command_file`) | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes), `command_file` (path to external script, relative to .dip dir) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
-| `subgraph` | `ref` | `params` |
+| `subgraph` | `ref` | `params` (dip 1) / `inputs` (dip 2, #227) |
 
 All kinds also accept: `label`, `reads`, `writes`, `retry_policy`, `max_retries`, `base_delay`, `retry_target`, and the retry-exhaustion route — spelled `fallback_target` in `dip 1`, `fallback_retry_target` in `dip 2` (`dippin fmt --migrate` relabels it). These are the engine's retry channel, read from the node, not the `edges` block.
 
@@ -439,7 +439,7 @@ Both inline (`parallel P -> A, B`) and block form (`parallel P` with `branch:` l
 | Field | Type | Notes |
 |-------|------|-------|
 | `ref` | string | Path to .dip file (DIP126 if missing) |
-| `params` | key: value | Passed to child via `${params.key}` |
+| `params` / `inputs` | key: value | Call-site binding (`params:` dip 1, `inputs:` dip 2). A key matching a declared child input seeds `${inputs.key}`; others seed `${params.key}` |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -731,7 +731,7 @@ The primary loop for authoring .dip files:
 | DIP157 | `${inputs.x}` appears inside a tool `command:`, which never interpolates it — the literal reaches the shell (Error) | Read a `file`/`secret` input via its staged path, not `${inputs.x}` in the command |
 | DIP158 | An input constraint is invalid or inapplicable — enum default ∉ options, min > max, bad pattern regex, or a constraint on a type that lacks it (Error) | Fix the constraint or move it to an applicable type |
 | DIP159 | A declared input is never referenced — a dead input (Warning). `file`/`secret` inputs are exempt (consumed out-of-band by staged path) | Reference the input, or remove it |
-| DIP160 | A `subgraph` node's `params:` omits an input the referenced child declares `required: true` — a cross-file check (Warning) | Add the missing input to the node's `params:` |
+| DIP160 | A `subgraph` node's call-site binding omits an input the referenced child declares `required: true` — a cross-file check (Warning) | Add the missing input to the node's binding (`inputs:` dip 2 / `params:` dip 1) |
 
 ## Best Practices
 

--- a/docs/GRAMMAR.ebnf
+++ b/docs/GRAMMAR.ebnf
@@ -166,7 +166,8 @@ tool_field ::= "command" ":" field_value
 subgraph_node ::= "subgraph" IDENTIFIER NEWLINE INDENT ( subgraph_field | common_field )* OUTDENT
 
 subgraph_field ::= "ref" ":" field_value
-                 | "params" ":" params_block
+                 | "params" ":" params_block             /* dip 1 call-site binding */
+                 | "inputs" ":" params_block              /* dip 2 spelling of the same binding (#227) */
 
 params_block ::= NEWLINE INDENT ( IDENTIFIER ":" field_value )* OUTDENT
 

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -61,7 +61,7 @@ workflow <Name>
 | `tool` | `command` (or `command_file`) | `timeout` (e.g. 30s, 5m), `outputs` (CSV), `marker_grep` (regex), `route_required` (bool), `output_limit` (bytes), `command_file` (path to external script, relative to .dip dir) |
 | `parallel` | `-> Target1, Target2` (inline) | — |
 | `fan_in` | `<- Source1, Source2` (inline) | — |
-| `subgraph` | `ref` | `params` |
+| `subgraph` | `ref` | `params` (dip 1) / `inputs` (dip 2, #227) |
 
 All kinds also accept: `label`, `reads`, `writes`, `retry_policy`, `max_retries`, `base_delay`, `retry_target`, and the retry-exhaustion route — spelled `fallback_target` in `dip 1`, `fallback_retry_target` in `dip 2` (`dippin fmt --migrate` relabels it). These are the engine's retry channel, read from the node, not the `edges` block.
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -524,22 +524,24 @@ Subgraph nodes embed another workflow as a single step.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `ref` | String | — | Name or file path of the workflow to embed. |
-| `params` | Map | — | Key-value parameter overrides passed to the sub-workflow. Parameters are substituted via the `params.*` namespace in the embedded workflow. |
+| `params` / `inputs` | Map | — | The call-site binding: key-value values passed to the child. Spelled `params:` in `dip 1`, **`inputs:` in `dip 2`** (dip 2 rejects `params:` on a subgraph; `dippin fmt --migrate` relabels it). A key that matches an input the child declares in its `inputs` block seeds the child's `${inputs.*}`; any other key seeds `${params.*}` (the legacy undeclared namespace). [DIP160](validation.md#dip160) warns cross-file when a required child input is omitted. |
 
 ### Parameter Passing
 
-Parameters let you customize a reusable workflow at invocation time:
+The call-site binding lets you customize a reusable workflow at invocation time. Use `inputs:` under `dip 2`, `params:` under `dip 1`:
 
 ```dippin
+dip 2
+
 # In the parent workflow:
   subgraph SecurityScan
     ref: security/scan_pipeline
-    params:
-      severity: critical
+    inputs:
+      severity: critical   # -> child ${inputs.severity} if declared, else ${params.severity}
       fail_fast: true
 ```
 
-The embedded workflow can reference these via `${params.severity}`.
+The embedded workflow reads a declared value as `${inputs.severity}` and an undeclared one as `${params.severity}`. (Under `dip 1` the block is spelled `params:` and reads back as `${params.*}` unless the runtime binds declared inputs.)
 
 ### Reusable Interview Loop
 

--- a/docs/subgraph-composition.md
+++ b/docs/subgraph-composition.md
@@ -27,10 +27,11 @@ subgraph Interview
     focus: "resources, auth, consumers, scale"
 ```
 
-`ref` points to the workflow file. `params` passes key-value pairs
-into it. Inside `interview_loop.dip`, those values are available as
-`${params.topic}` and `${params.focus}` — the same interpolation
-syntax used for context variables, but in a dedicated namespace that
+`ref` points to the workflow file. The call-site binding — spelled `params:`
+in `dip 1` and `inputs:` in `dip 2` (#227) — passes key-value pairs
+into it. Inside `interview_loop.dip`, a value bound to a declared input is read
+as `${inputs.topic}`; an undeclared one is read as `${params.topic}` — the same
+interpolation syntax used for context variables, but in a dedicated namespace that
 keeps parent and child workflows from stepping on each other.
 
 The referenced workflow is a complete, self-contained `.dip` file.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1546,9 +1546,10 @@ declaration.
 
 **Severity**: Warning
 
-A `subgraph` node's `params:` block does not provide a value for an input the
-referenced child workflow declares as `required: true`, so the child would start
-with that input unset. This is a **cross-file** check: the CLI (`validate`,
+A `subgraph` node's call-site binding — spelled `inputs:` in `dip 2`, `params:`
+in `dip 1` (#227) — does not provide a value for an input the referenced child
+workflow declares as `required: true`, so the child would start with that input
+unset. This is a **cross-file** check: the CLI (`validate`,
 `check`, `watch`) resolves and parses the referenced child to read its `inputs`
 block. It is skipped for `.dipx` bundles (whose refs are in-bundle paths) and
 when the child file cannot be read or parsed — matching the DIP146 cross-file
@@ -1558,8 +1559,8 @@ pass.
 warning[DIP160]: subgraph "Interview" omits required input "topic" of "interview_loop.dip" — the child starts with it unset
 ```
 
-**Fix:** Add the missing key to the subgraph node's `params:`, or give the child
-input a `default:` so it is no longer required.
+**Fix:** Add the missing key to the subgraph node's binding (`inputs:` in dip 2,
+`params:` in dip 1), or give the child input a `default:` so it is no longer required.
 
 ---
 

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -736,7 +736,17 @@ func writeSubgraphFields(wr *writer, n *ir.Node, cfg ir.SubgraphConfig) {
 	if cfg.Ref != "" {
 		wr.line("ref: %s", quoteValue(cfg.Ref))
 	}
-	writeSortedMapBlock(wr, "params", cfg.Params)
+	writeSortedMapBlock(wr, subgraphBindingLabel(wr), cfg.Params)
+}
+
+// subgraphBindingLabel is the subgraph call-site binding keyword: `inputs` in
+// dip 2, `params` in dip 1 (#227). Only the subgraph binding is renamed —
+// parallel/fan_in/manager_loop `params:` are opaque runtime pass-through.
+func subgraphBindingLabel(wr *writer) string {
+	if wr.dip2 {
+		return "inputs"
+	}
+	return "params"
 }
 
 // writeSortedMapBlock emits a named block containing sorted "key: value"

--- a/formatter/format_subgraph_inputs_test.go
+++ b/formatter/format_subgraph_inputs_test.go
@@ -1,0 +1,57 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/parser"
+)
+
+func subgraphWF(version string) *ir.Workflow {
+	return &ir.Workflow{
+		Name: "P", Version: version, Start: "S", Exit: "S",
+		Nodes: []*ir.Node{{
+			ID: "S", Kind: ir.NodeSubgraph,
+			Config: ir.SubgraphConfig{Ref: "child.dip", Params: map[string]string{"topic": "hi"}},
+		}},
+	}
+}
+
+// TestFormatSubgraph_Dip1EmitsParams: a v1 workflow formats the binding as params:.
+func TestFormatSubgraph_Dip1EmitsParams(t *testing.T) {
+	out := Format(subgraphWF("1"))
+	if !strings.Contains(out, "params:") || strings.Contains(out, "inputs:") {
+		t.Errorf("dip 1 should emit params:, not inputs:\n%s", out)
+	}
+}
+
+// TestFormatSubgraph_Dip2EmitsInputs: a dip-2 workflow formats the binding as
+// inputs: and round-trips (#227).
+func TestFormatSubgraph_Dip2EmitsInputs(t *testing.T) {
+	out := Format(subgraphWF("2"))
+	if !strings.Contains(out, "inputs:") || strings.Contains(out, "params:") {
+		t.Errorf("dip 2 should emit inputs:, not params:\n%s", out)
+	}
+	w2, err := parser.NewParser(out, "p.dip").Parse()
+	if err != nil {
+		t.Fatalf("re-parse: %v\n%s", err, out)
+	}
+	if w2.Nodes[0].Config.(ir.SubgraphConfig).Params["topic"] != "hi" {
+		t.Errorf("round-trip lost the binding:\n%s", out)
+	}
+}
+
+// TestMigrateSubgraph_ParamsRelabeledToInputs: fmt --migrate (version bump +
+// format) relabels a v1 subgraph params: to the dip-2 inputs: spelling (#227),
+// losslessly.
+func TestMigrateSubgraph_ParamsRelabeledToInputs(t *testing.T) {
+	w := subgraphWF("1")
+	if notes := MigrateToV2(w); len(notes) != 0 {
+		t.Fatalf("lossless migration, want no notes, got %v", notes)
+	}
+	out := Format(w)
+	if !strings.Contains(out, "inputs:") || strings.Contains(out, "params:") {
+		t.Errorf("migrated dip-2 output should spell the binding inputs:\n%s", out)
+	}
+}

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -607,14 +607,34 @@ func (p *Parser) applyToolParsedField(cfg *ir.ToolConfig, key, val string, loc i
 
 // applySubgraphField applies subgraph-specific configuration fields.
 func (p *Parser) applySubgraphField(cfg *ir.SubgraphConfig, key, val string, loc ir.SourceLocation) {
+	if p.rejectV2SubgraphParams(key, loc) {
+		return // handled (rejected) — dip 2 spells the call-site binding `inputs:`
+	}
 	switch key {
 	case "ref":
 		cfg.Ref = val
-	case "params":
+	case "params", "inputs":
+		// The subgraph call-site binding (#227). `params` is the dip-1 spelling;
+		// `inputs` the dip-2 spelling (dip 2 rejects `params` upstream). Both map
+		// to SubgraphConfig.Params; the runtime seeds the child's declared
+		// `inputs.*` from keys matching its inputs and `params.*` from the rest.
 		cfg.Params = p.parseParamsBlock(val)
 	default:
 		p.emitUnknownFieldHint("subgraph", key, loc)
 	}
+}
+
+// rejectV2SubgraphParams rejects `params:` on a subgraph node under dip 2, where
+// the call-site input binding is spelled `inputs:` (#227). Returns true when the
+// field was rejected (handled).
+func (p *Parser) rejectV2SubgraphParams(key string, loc ir.SourceLocation) bool {
+	if p.version >= 2 && key == "params" {
+		p.diagnostics = append(p.diagnostics, fmt.Sprintf(
+			"%q is not a subgraph field in dip 2 — use `inputs:` to bind the child's declared inputs (run `dippin fmt --migrate`) at %d:%d",
+			key, loc.Line, loc.Column))
+		return true
+	}
+	return false
 }
 
 // applyManagerLoopField applies manager_loop-specific configuration fields.

--- a/parser/parse_subgraph_inputs_test.go
+++ b/parser/parse_subgraph_inputs_test.go
@@ -1,0 +1,60 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// subgraphSrc builds a workflow with a subgraph node whose call-site binding
+// uses the given keyword (`params` or `inputs`), optionally under a dip-N header.
+func subgraphSrc(header, keyword string) string {
+	return header + `workflow P
+  start: S
+  exit: S
+  subgraph S
+    ref: child.dip
+    ` + keyword + `:
+      topic: hi
+`
+}
+
+func subgraphParams(t *testing.T, w *ir.Workflow) map[string]string {
+	t.Helper()
+	return w.Nodes[0].Config.(ir.SubgraphConfig).Params
+}
+
+// TestSubgraph_Dip1AcceptsParams: dip 1 keeps the `params:` call-site binding.
+func TestSubgraph_Dip1AcceptsParams(t *testing.T) {
+	w, err := NewParser(subgraphSrc("", "params"), "p.dip").Parse()
+	if err != nil {
+		t.Fatalf("dip 1 must accept subgraph params: %v", err)
+	}
+	if subgraphParams(t, w)["topic"] != "hi" {
+		t.Errorf("params[topic] = %q, want hi", subgraphParams(t, w)["topic"])
+	}
+}
+
+// TestSubgraph_Dip2AcceptsInputs: dip 2 spells the binding `inputs:` (#227).
+func TestSubgraph_Dip2AcceptsInputs(t *testing.T) {
+	w, err := NewParser(subgraphSrc("dip 2\n\n", "inputs"), "p.dip").Parse()
+	if err != nil {
+		t.Fatalf("dip 2 must accept subgraph inputs: %v", err)
+	}
+	if subgraphParams(t, w)["topic"] != "hi" {
+		t.Errorf("inputs[topic] = %q, want hi", subgraphParams(t, w)["topic"])
+	}
+}
+
+// TestSubgraph_Dip2RejectsParams: dip 2 rejects `params:` on a subgraph and
+// points at `inputs:`.
+func TestSubgraph_Dip2RejectsParams(t *testing.T) {
+	_, err := NewParser(subgraphSrc("dip 2\n\n", "params"), "p.dip").Parse()
+	if err == nil {
+		t.Fatal("dip 2 must reject subgraph params:")
+	}
+	if !strings.Contains(err.Error(), "inputs:") {
+		t.Errorf("rejection should point to inputs:, got %v", err)
+	}
+}

--- a/site/content/language.md
+++ b/site/content/language.md
@@ -127,7 +127,7 @@ Vars are exported as graph-level DOT attributes so they round-trip through `dipp
 
 ## Inputs Block
 
-The optional `inputs` block declares the workflow's callee-side signature — the named values a caller (a human at the entry point, or a parent workflow via a `subgraph` node's `params:`) must or may supply at run start:
+The optional `inputs` block declares the workflow's callee-side signature — the named values a caller (a human at the entry point, or a parent workflow via a `subgraph` node's call-site binding — `inputs:` in `dip 2`, `params:` in `dip 1`) must or may supply at run start:
 
 ```
   inputs

--- a/site/static/llms-full.txt
+++ b/site/static/llms-full.txt
@@ -426,7 +426,7 @@ Both inline (`parallel P -> A, B`) and block form (`parallel P` with `branch:` l
 | Field | Type | Notes |
 |-------|------|-------|
 | `ref` | string | Path to .dip file (DIP126 if missing) |
-| `params` | key: value | Passed to child via `${params.key}` |
+| `params` / `inputs` | key: value | Call-site binding (`params:` dip 1, `inputs:` dip 2). A key matching a declared child input seeds `${inputs.key}`; others seed `${params.key}` |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -718,7 +718,7 @@ The primary loop for authoring .dip files:
 | DIP157 | `${inputs.x}` appears inside a tool `command:`, which never interpolates it — the literal reaches the shell (Error) | Read a `file`/`secret` input via its staged path, not `${inputs.x}` in the command |
 | DIP158 | An input constraint is invalid or inapplicable — enum default ∉ options, min > max, bad pattern regex, or a constraint on a type that lacks it (Error) | Fix the constraint or move it to an applicable type |
 | DIP159 | A declared input is never referenced — a dead input (Warning). `file`/`secret` inputs are exempt (consumed out-of-band by staged path) | Reference the input, or remove it |
-| DIP160 | A `subgraph` node's `params:` omits an input the referenced child declares `required: true` — a cross-file check (Warning) | Add the missing input to the node's `params:` |
+| DIP160 | A `subgraph` node's call-site binding omits an input the referenced child declares `required: true` — a cross-file check (Warning) | Add the missing input to the node's binding (`inputs:` dip 2 / `params:` dip 1) |
 
 ## Best Practices
 

--- a/site/static/skill.md
+++ b/site/static/skill.md
@@ -246,7 +246,7 @@ Both inline (`parallel P -> A, B`) and block form (`parallel P` with `branch:` l
 | Field | Type | Notes |
 |-------|------|-------|
 | `ref` | string | Path to .dip file (DIP126 if missing) |
-| `params` | key: value | Passed to child via `${params.key}` |
+| `params` / `inputs` | key: value | Call-site binding (`params:` dip 1, `inputs:` dip 2). A key matching a declared child input seeds `${inputs.key}`; others seed `${params.key}` |
 | `reads` | CSV | Context keys read |
 | `writes` | CSV | Context keys written |
 
@@ -538,7 +538,7 @@ The primary loop for authoring .dip files:
 | DIP157 | `${inputs.x}` appears inside a tool `command:`, which never interpolates it — the literal reaches the shell (Error) | Read a `file`/`secret` input via its staged path, not `${inputs.x}` in the command |
 | DIP158 | An input constraint is invalid or inapplicable — enum default ∉ options, min > max, bad pattern regex, or a constraint on a type that lacks it (Error) | Fix the constraint or move it to an applicable type |
 | DIP159 | A declared input is never referenced — a dead input (Warning). `file`/`secret` inputs are exempt (consumed out-of-band by staged path) | Reference the input, or remove it |
-| DIP160 | A `subgraph` node's `params:` omits an input the referenced child declares `required: true` — a cross-file check (Warning) | Add the missing input to the node's `params:` |
+| DIP160 | A `subgraph` node's call-site binding omits an input the referenced child declares `required: true` — a cross-file check (Warning) | Add the missing input to the node's binding (`inputs:` dip 2 / `params:` dip 1) |
 
 ## Best Practices
 

--- a/validator/explanations.go
+++ b/validator/explanations.go
@@ -206,9 +206,9 @@ func inputsExplanations() map[string]Explanation {
 		DIP160: {
 			Code:    DIP160,
 			Summary: "subgraph params omits a required input of the referenced child",
-			Trigger: "A subgraph node's params: block does not provide a value for an input the referenced child workflow declares as required: true. The child would start with that input unset. This is a cross-file check run by the CLI (validate/check/watch), not the in-file linter, so it is skipped for .dipx bundles and when the child file cannot be read or parsed.",
-			Fix:     "Add the missing key to the subgraph node's params:, or give the child input a default so it is no longer required.",
-			Example: "subgraph Scan\n  ref: child.dip\n  params:\n    severity: high   # DIP160 if child.dip declares a required input that params omits",
+			Trigger: "A subgraph node's call-site input binding (spelled `inputs:` in dip 2, `params:` in dip 1) does not provide a value for an input the referenced child workflow declares as required: true. The child would start with that input unset. This is a cross-file check run by the CLI (validate/check/watch), not the in-file linter, so it is skipped for .dipx bundles and when the child file cannot be read or parsed.",
+			Fix:     "Add the missing key to the subgraph node's input binding (`inputs:` in dip 2, `params:` in dip 1), or give the child input a default so it is no longer required.",
+			Example: "subgraph Scan\n  ref: child.dip\n  params:\n    severity: high   # dip 1; DIP160 if child.dip declares a required input this omits",
 		},
 		DIP158: {
 			Code:    DIP158,


### PR DESCRIPTION
Completes the **call-site half of the inputs epic (#190)** and unblocks the engine runtime half (tracker#556, which was closed "blocked on dippin call-site grammar").

## What

A `subgraph` node's call-site binding — how a parent supplies values to a child — is now spelled **`inputs:`** in `dip 2`; `dip 1` keeps `params:`. This finally gives the child's declared `inputs` signature a caller:
- a key matching an input the child **declares** → seeds the child's `${inputs.*}`
- any other key → seeds the legacy `${params.*}` (undeclared pass-through)

```dippin
dip 2
  subgraph Interview
    ref: interview_loop.dip
    inputs:
      topic: "onboarding"   # -> child ${inputs.topic}
      debug: "1"            # undeclared -> child ${params.debug}
```

## Design — mirrors the retry-channel Option A rename

Chosen per #190's own spec ("rename the call-site keyword `params:` → `inputs:` — dip 2"):
- **parser** — subgraph accepts `inputs:` (both spellings map to `SubgraphConfig.Params`); **dip 2 rejects `params:`** on a subgraph, pointing to `inputs:`.
- **formatter** — emits `inputs:` in dip 2 / `params:` in dip 1 via the existing `writer.dip2` flag; `fmt --migrate` **relabels losslessly**.
- **DIP160** (cross-file required-input arity) works against either spelling; its message + explanation are now version-neutral.
- **Scope:** only the *subgraph* binding is renamed — `parallel`/`fan_in`/`manager_loop` `params:` are opaque runtime pass-through, unchanged.

## Coverage
Tests: dip1-accepts-params, dip2-accepts-inputs, dip2-rejects-params (→ points to `inputs:`), formatter round-trip, migrate relabel. Docs/GRAMMAR/llm-reference/skill/site swept; generated-spec regenerated. Full suite + complexity + validate-examples green. Syntax packages need no change (generic field rule).

Closes #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788994042&installation_model_id=21126&pr_number=245&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F245&signature=1680ca6912ebd677867f758fd285ea7c1509dcfebe9db34bd0442ec515a93dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - DIP 2 subgraph bindings now use `inputs:`, while DIP 1 continues to use `params:`.
  - Declared child inputs are available through `${inputs.*}`; other values retain `${params.*}` compatibility.
  - DIP 2 provides migration guidance when `params:` is used.

- **Bug Fixes**
  - Improved validation and diagnostics for missing child inputs and incorrect binding syntax.

- **Documentation**
  - Updated language references, specifications, grammar, migration guidance, and examples to explain version-specific subgraph bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->