### PR TITLE
release: v0.63.0 — dip-2 inputs: subgraph call-site binding (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.63.0] — 2026-08-10
 
 ### Added
 - **dip-2 `inputs:` subgraph call-site binding** ([#227](https://github.com/2389-research/dippin-lang/issues/227)). A `subgraph` node's call-site binding — how a parent supplies values to a child — is now spelled **`inputs:`** in `dip 2` (the dip-1 spelling `params:` is unchanged), completing the call-site half of the inputs epic (#190). This gives the child's declared `inputs` signature a caller: a key matching an input the child declares seeds its `${inputs.*}` namespace; any other key seeds the legacy `${params.*}`. Semantics mirror the retry-channel rename (Option A): `dip 2` rejects `params:` on a subgraph (pointing to `inputs:`), and `dippin fmt --migrate` relabels it losslessly. The existing [DIP160](https://2389-research.github.io/dippin-lang/validation.html#dip160) cross-file "omits a required child input" check works against either spelling. Unblocks the engine runtime half (tracker#556) — the runtime seeds `inputs.*` from the call site.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,11 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.63.0] — 2026-08-10
+
+### Added
+- **dip-2 `inputs:` subgraph call-site binding** ([#227](https://github.com/2389-research/dippin-lang/issues/227)). A `subgraph` node's call-site binding — how a parent supplies values to a child — is now spelled **`inputs:`** in `dip 2` (the dip-1 spelling `params:` is unchanged), completing the call-site half of the inputs epic (#190). This gives the child's declared `inputs` signature a caller: a key matching an input the child declares seeds its `${inputs.*}` namespace; any other key seeds the legacy `${params.*}`. Semantics mirror the retry-channel rename (Option A): `dip 2` rejects `params:` on a subgraph (pointing to `inputs:`), and `dippin fmt --migrate` relabels it losslessly. The existing [DIP160](https://2389-research.github.io/dippin-lang/validation.html#dip160) cross-file "omits a required child input" check works against either spelling. Unblocks the engine runtime half (tracker#556) — the runtime seeds `inputs.*` from the call site.
+
 ## [v0.62.2] — 2026-08-10
 
 ### Changed


### PR DESCRIPTION
Cuts **v0.63.0**. Renames `[Unreleased]` (#227) to `[v0.63.0]`. After merge, tag `v0.63.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788995633&installation_model_id=21126&pr_number=246&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F246&signature=a8e37f565b445c698f43934c060e3731c8174a7f1d82ff3da969578801a11a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog for the v0.63.0 release.
  * Documented `dip 2` subgraph call-site bindings using `inputs:`.
  * Clarified that `params:` remains the dip-1 spelling and is rejected by `dip 2` subgraphs.
  * Documented lossless migration behavior and accepted spellings for required-input checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->