### PR TITLE
release: v0.64.0 — dipx.OpenReader + cascade passthrough fix (#247, #248, #249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.64.0] — 2026-08-11
 
 ### Added
 - **`dipx.OpenReader(ctx, r io.ReaderAt, size int64)` for in-memory bundles** ([#247](https://github.com/2389-research/dippin-lang/issues/247)). An embedded consumer that bakes a `.dipx` into its binary via `go:embed` can now load it straight from bytes — same strict admission, hash verification, and ref-walking as `Open`, but with no temp-file bridge (and no `0600` window). Errors carry no bundle path (there is none on an in-memory source).

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,17 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.64.0] — 2026-08-11
+
+### Added
+- **`dipx.OpenReader(ctx, r io.ReaderAt, size int64)` for in-memory bundles** ([#247](https://github.com/2389-research/dippin-lang/issues/247)). An embedded consumer that bakes a `.dipx` into its binary via `go:embed` can now load it straight from bytes — same strict admission, hash verification, and ref-walking as `Open`, but with no temp-file bridge (and no `0600` window). Errors carry no bundle path (there is none on an in-memory source).
+
+### Fixed
+- **The defaults prompt cascade no longer synthesizes a prompt on body-less passthrough nodes** ([#248](https://github.com/2389-research/dippin-lang/issues/248)). A `defaults` `prompt_prefix`/`prompt_suffix` cascade (#175) applied to *every* agent, including the body-less `agent` nodes a workflow declares as `start:`/`exit:` passthroughs — synthesizing a prompt for them out of the prefix/suffix alone. A runtime that keys passthrough on "no prompt attribute" would then execute a real LLM call at the top and tail of every run. The cascade now **skips any agent with no prompt of its own and no `prompt_include`** (nothing to wrap), so passthrough nodes stay body-less. Nodes with a body (or an include) are unaffected.
+
+### Documentation
+- **Prompt-cascade join separator documented** ([#249](https://github.com/2389-research/dippin-lang/issues/249)). The resolve-time `prefix → body → include → suffix` composition joins non-empty parts with a fixed **blank line (`\n\n`)**. This is now stated in the defaults-cascade docs, with a note that hoisting an identical leading line into a `prompt_prefix_file:` fragment is byte-lossless only when the original body had a blank line after that line.
+
 ## [v0.63.0] — 2026-08-10
 
 ### Added


### PR DESCRIPTION
Cuts **v0.64.0**. Renames `[Unreleased]` (#247/#248/#249) to `[v0.64.0]`. After merge, tag `v0.64.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789067397&installation_model_id=21126&pr_number=251&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F251&signature=366ceb5a6d4e194846aa16ce1ed03e1024cc53d767c8d3e935699c3698fcabbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading in-memory bundles with `dipx.OpenReader`.
* **Bug Fixes**
  * Prevented default prompt cascades from being applied to body-less passthrough agents.
* **Documentation**
  * Documented the blank-line separator used in prompt cascades.
  * Published the v0.64.0 release notes dated August 11, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->