### PR TITLE
docs(pricing-integration): bump recommended pin to v0.64.0

### DIFF
--- a/docs/pricing-integration.md
+++ b/docs/pricing-integration.md
@@ -11,15 +11,16 @@ table, tracker #518) but applies to any consumer.
 ## Version to pin
 
 - **Floor:** `v0.53.0` — the release that introduced the `pricing` package.
-- **Recommended:** the latest tag (currently **`v0.62.1`**). Everything since the
+- **Recommended:** the latest tag (currently **`v0.64.0`**). Everything since the
   floor is additive to the catalog data and the `ModelPrice` shape; the
   `Lookup`/`Cost` API a consumer calls is unchanged. Notable additions: cache
   read/write rates (`v0.57.0`+, see below), `ModelPrice.Deprecated` (`v0.59.0`),
-  per-family OpenAI cache multipliers (`v0.59.1`), and the drift suppress-list
-  tooling.
+  per-family OpenAI cache multipliers (`v0.59.1`), tail-provider cache rates
+  (`v0.61.0`) and Mistral/Cohere verified-no-discount (`v0.62.1`), and the drift
+  suppress-list tooling.
 
 ```sh
-go get github.com/2389-research/dippin-lang@v0.62.1
+go get github.com/2389-research/dippin-lang@v0.64.0
 ```
 
 Consumers **pin a specific tag** — never `@latest` — per dippin's release model.


### PR DESCRIPTION
Post-v0.64.0 currency check across docs/website/dev-tooling. Everything is already current except one stale version pin — v0.63.0 (#227) and v0.64.0 (#247–249) each swept their own surfaces in their PRs, and dev tooling needs nothing (no new keywords; tree-sitter/Zed use generic field rules).

**The one stale item:** `docs/pricing-integration.md` recommended pin was `v0.62.1` → now **`v0.64.0`**.

**Verified already-current (no change):** diagnostic-code counts (70 / DIP101–DIP160), the committed `generated-spec.md`, the #227 `inputs:`/#248 passthrough/#249 separator docs, VSCode/tree-sitter/Zed syntax packages. (`docs/generated-spec.md` showing an old count is a **gitignored** local build artifact, not in the repo.)

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789070600&installation_model_id=21126&pr_number=252&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F252&signature=553dbc4e4d501433f5e1eb8ca53e91471d834a8d5a3982b16f8f6cb1b1fb1ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pricing integration guidance to recommend package version v0.64.0.
  * Added notes covering tail-provider cache rates and Mistral/Cohere verification.
  * Updated the installation command accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->