### PR TITLE
fix(playground): default example lints clean + guardrail against a dirty demo

### DIFF
--- a/site/layouts/_default/playground.html
+++ b/site/layouts/_default/playground.html
@@ -47,6 +47,9 @@
   start: Greeter
   exit: Done
 
+  defaults
+    on_failure: Done
+
   agent Greeter
     model: claude-sonnet-4-6
     provider: anthropic

--- a/validator/lint_examples_test.go
+++ b/validator/lint_examples_test.go
@@ -3,8 +3,10 @@ package validator_test
 import (
 	"bytes"
 	"context"
+	"html"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/2389-research/dippin-lang/dipx"
@@ -55,6 +57,54 @@ func TestLintExamples(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPlaygroundDefaultLintsClean guards the website playground's default
+// example (embedded in site/layouts/_default/playground.html): the flagship demo
+// a visitor sees first MUST lint completely clean — zero diagnostics of any
+// severity — through the same passes the WASM playground runs (Validate + Lint).
+// Without this, a lint that newly fires (or an example edit) silently ships a
+// warning-producing demo, which is how the DIP144 "Greeter has no failure route"
+// regression reached the live playground.
+func TestPlaygroundDefaultLintsClean(t *testing.T) {
+	const playgroundHTML = "../site/layouts/_default/playground.html"
+	raw, err := os.ReadFile(playgroundHTML)
+	if err != nil {
+		t.Fatalf("read %s: %v", playgroundHTML, err)
+	}
+	src := extractPlaygroundSource(t, string(raw))
+
+	w, err := parser.NewParser(src, "playground.dip").Parse()
+	if err != nil {
+		t.Fatalf("playground default does not parse: %v\n---\n%s", err, src)
+	}
+	var diags []validator.Diagnostic
+	diags = append(diags, validator.Validate(w).Diagnostics...)
+	diags = append(diags, validator.Lint(w).Diagnostics...)
+	for _, d := range diags {
+		t.Errorf("playground default is not clean: %s[%s] %s (add a fix to the example in %s, or the demo teaches the warning)",
+			d.Severity, d.Code, d.Message, playgroundHTML)
+	}
+}
+
+// extractPlaygroundSource pulls the .dip source out of the playground editor
+// textarea (`<textarea id="editor" ...>SOURCE</textarea>`) and HTML-unescapes it.
+func extractPlaygroundSource(t *testing.T, htmlDoc string) string {
+	t.Helper()
+	i := strings.Index(htmlDoc, `id="editor"`)
+	if i < 0 {
+		t.Fatal(`playground.html: no <textarea id="editor">`)
+	}
+	open := strings.IndexByte(htmlDoc[i:], '>')
+	if open < 0 {
+		t.Fatal("playground.html: unterminated textarea open tag")
+	}
+	start := i + open + 1
+	end := strings.Index(htmlDoc[start:], "</textarea>")
+	if end < 0 {
+		t.Fatal("playground.html: no closing </textarea>")
+	}
+	return html.UnescapeString(htmlDoc[start : start+end])
 }
 
 // TestPackExamples round-trips every example .dip through dipx.Pack →


### PR DESCRIPTION
## The break
The playground's default "Hello" example is `agent Greeter -> Done` with **no failure route**, so **DIP144** ("agent has no failure route") correctly fired on the flagship demo. The WASM is rebuilt from current dippin on every Netlify deploy, so the warning shipped live. (DIP144 is working as designed — `hasFailEdge` deliberately excludes unconditional edges — the *demo* just wasn't a good citizen.)

## Fix
Added a `defaults: on_failure: Done` block so the example lints **completely clean** and now demonstrates the graph-level failure route (a real feature, good for a demo).

## Guardrail — "can't ship broken"
`TestPlaygroundDefaultLintsClean` (in `validator/lint_examples_test.go`) extracts the editor `<textarea>` from `site/layouts/_default/playground.html` and asserts the default source produces **zero diagnostics** through `Validate + Lint` — the same passes the WASM playground runs. A lint that newly fires, or an example edit that introduces a warning, now **fails CI** instead of silently shipping a warning-producing demo.

Merging redeploys the live playground (Netlify builds from `main`); no release tag needed.

Part 1 of the playground work — the "much nicer / more features" enhancement follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789072792&installation_model_id=21126&pr_number=253&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F253&signature=e2c7d0d4f7ecec5a7da9adae94b4176de83466e00c35023525461d09f5a5298d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the playground’s default workflow to mark failed steps as complete.

* **Bug Fixes**
  * Improved validation of the playground’s default example to ensure it parses and lints without errors.
  * Added clearer handling for missing or malformed workflow content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->