### PR TITLE
release: v0.65.0 — export-mermaid + playground v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
-## [Unreleased]
+## [v0.65.0] — 2026-08-11
 
 ### Added
 - **`dippin export-mermaid` — Mermaid flowchart export.** A new exporter (`export.ExportMermaid`) renders a workflow as a [Mermaid](https://mermaid.js.org/) flowchart: node shapes and colors by kind (agent stadium/green, human parallelogram/blue, tool rectangle/orange, subgraph subroutine/purple, conditional rhombus/yellow, parallel·fan_in hexagon/gray), edges labeled by routing condition (`ctx.outcome = success` → `success`), start/exit emphasized, restart edges marked `⟳`. Mermaid renders natively on GitHub and in docs, so this drops a live diagram into a README with one command. Subgraph refs are flattened first.

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,16 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.65.0] — 2026-08-11
+
+### Added
+- **`dippin export-mermaid` — Mermaid flowchart export.** A new exporter (`export.ExportMermaid`) renders a workflow as a [Mermaid](https://mermaid.js.org/) flowchart: node shapes and colors by kind (agent stadium/green, human parallelogram/blue, tool rectangle/orange, subgraph subroutine/purple, conditional rhombus/yellow, parallel·fan_in hexagon/gray), edges labeled by routing condition (`ctx.outcome = success` → `success`), start/exit emphasized, restart edges marked `⟳`. Mermaid renders natively on GitHub and in docs, so this drops a live diagram into a README with one command. Subgraph refs are flattened first.
+- **Playground v2.** The browser playground gains a **Graph** tab (Mermaid render of the workflow), a **Doctor** tab (health card: grade, score, coverage, cost), **live linting** with a diagnostic summary bar, **click-a-diagnostic-to-jump-to-its-line**, an **example gallery** (minimal, review-loop, parallel, conditional, human-gate — each lints clean), and **Copy / Download / Share** (source encoded in the URL for shareable links). The WASM exposes `dippinMermaid` and `dippinDoctor` alongside the existing lint/parse/format.
+
+### Fixed
+- **`dippin new` templates now lint completely clean.** Every scaffold template (`minimal`, `review-loop`, `parallel`, `conditional`, `human-gate`) previously emitted a DIP144 "no failure route" warning (and human-gate two DIP150 hints) on freshly-generated output — an author's first `dippin lint` showed warnings. Each template now declares a graph-level `on_failure` route (and human-gate sets `choice:` on its gate edges), so the generated workflow is clean and demonstrates the failure-route + choice-key features. `manager_loop` still surfaces DIP135 by design (it references an external `child_pipeline.dip` the author must create). Guarded by `TestTemplatesLintClean`.
+- **Playground default example lints clean** (see v0.64.0-era fix, hardened here): the embedded example gallery is guarded by `TestPlaygroundExamplesLintClean`, which lints every example a visitor can load and fails CI on any diagnostic — so a warning-producing demo can no longer ship.
+
 ## [v0.64.0] — 2026-08-11
 
 ### Added


### PR DESCRIPTION
Cuts **v0.65.0**. Renames `[Unreleased]` (export-mermaid, playground v2, clean templates) to `[v0.65.0]`. After merge, tag `v0.65.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789076927&installation_model_id=21126&pr_number=255&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F255&signature=991218dfe7ee76c442a271534bb3955ffa1c8aad073c42ed02b318384da720d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mermaid workflow export is now available.
  - Playground v2 includes Graph and Doctor tabs, live linting, diagnostic navigation, example galleries, sharing, downloads, and expanded WASM exports.
- **Bug Fixes**
  - Generated scaffold templates and Playground examples now pass clean-lint checks.
- **Documentation**
  - Added the v0.65.0 release notes, dated August 11, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->