### PR TITLE
fix(playground): Graph view robustness + stop WASM/JS cache skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to dippin-lang are documented here. Versions follow [semver](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Playground Graph view robustness + WASM cache skew.** The `/dippin.wasm` asset was cached for an hour while the playground JS deploys fresh, so a returning visitor ran new JS against a stale WASM missing the just-added `dippinMermaid` export — `runGraph` threw before replacing the pane, and the Graph view's flex/`white-space:normal` styling collapsed the leftover text into garbage. Fixed three ways: (1) `runGraph` now guards a missing `dippinMermaid` with a clear "hard-reload to refresh the engine" message, clears stale content with a "Rendering graph…" placeholder before rendering, and only applies the graph styling once a real SVG is in hand; (2) `/dippin.wasm` is now served `max-age=0, must-revalidate` so the WASM stays in lockstep with the JS (ETag makes the revalidation a cheap 304 when unchanged); (3) the Mermaid `subgraph` node class was renamed to avoid any collision with Mermaid's reserved `subgraph` keyword.
+
 ## [v0.65.0] — 2026-08-11
 
 ### Added

--- a/export/mermaid.go
+++ b/export/mermaid.go
@@ -109,7 +109,7 @@ func writeMermaidClassDefs(b *strings.Builder) {
 		"classDef agent fill:#e8f5e9,stroke:#43a047,color:#1b5e20;",
 		"classDef human fill:#e3f2fd,stroke:#1e88e5,color:#0d47a1;",
 		"classDef tool fill:#fff3e0,stroke:#fb8c00,color:#e65100;",
-		"classDef subgraph_ fill:#f3e5f5,stroke:#8e24aa,color:#4a148c;",
+		"classDef subgnode fill:#f3e5f5,stroke:#8e24aa,color:#4a148c;",
 		"classDef manager_loop fill:#ede7f6,stroke:#5e35b1,color:#311b92;",
 		"classDef conditional fill:#fffde7,stroke:#fdd835,color:#f57f17;",
 		"classDef fork fill:#eceff1,stroke:#607d8b,color:#263238;",
@@ -139,7 +139,7 @@ var mermaidShapes = map[ir.NodeKind][2]string{
 var mermaidClasses = map[ir.NodeKind]string{
 	ir.NodeAgent:       "agent",
 	ir.NodeHuman:       "human",
-	ir.NodeSubgraph:    "subgraph_",
+	ir.NodeSubgraph:    "subgnode",
 	ir.NodeManagerLoop: "manager_loop",
 	ir.NodeConditional: "conditional",
 	ir.NodeParallel:    "fork",

--- a/netlify.toml
+++ b/netlify.toml
@@ -65,7 +65,11 @@
   for = "/dippin.wasm"
   [headers.values]
     Content-Type = "application/wasm"
-    Cache-Control = "public, max-age=3600"
+    # Revalidate every load (ETag → cheap 304 when unchanged). The WASM is rebuilt
+    # on every deploy and the playground JS deploys alongside it; a long max-age let
+    # a returning visitor run new JS against an hour-stale WASM (missing newly
+    # exported functions), which broke the Graph view. Keep JS and WASM in lockstep.
+    Cache-Control = "public, max-age=0, must-revalidate"
 
 [[headers]]
   for = "/llms.txt"

--- a/site/layouts/_default/playground.html
+++ b/site/layouts/_default/playground.html
@@ -343,7 +343,10 @@ function setTool(tool) {
   document.querySelectorAll(".toolbar button").forEach(b => b.classList.remove("active"));
   const btn = document.getElementById("tab-" + tool);
   if (btn) btn.classList.add("active");
-  outputEl.classList.toggle("graph", tool === "graph");
+  // Only the Graph view renders an SVG; runGraph re-adds .graph on success. Every
+  // other tool (and any graph failure) shows text, which must NOT be whitespace-
+  // collapsed by the .graph flex/normal styling.
+  outputEl.classList.remove("graph");
   runActive();
 }
 
@@ -378,13 +381,19 @@ function runParse() {
 
 let graphGen = 0;
 function graphIsCurrent(gen) { return gen === graphGen && activeTool === "graph"; }
+function graphText(msg) { outputEl.classList.remove("graph"); outputEl.textContent = msg; }
 function runGraph() {
+  // A stale WASM (e.g. a returning visitor whose cached dippin.wasm predates this
+  // export) won't have dippinMermaid — show a clear message, never leave the
+  // previous tool's output on screen (which the .graph styling would garble).
+  if (typeof dippinMermaid !== "function") { graphText("Graph needs a newer engine — hard-reload the page (Cmd/Ctrl+Shift+R) to refresh the WebAssembly module."); return; }
   const res = dippinMermaid(getSource());
   try { const p = JSON.parse(res); if (p.error) { outputEl.classList.remove("graph"); outputEl.innerHTML = '<span class="hl-fail">parse error: ' + escapeHtml(p.error) + '</span>'; return; } } catch (e) {}
+  graphText("Rendering graph…"); // clear stale content while mermaid loads/renders
   const gen = ++graphGen; // invalidate any in-flight load/render from an earlier edit
   loadMermaid()
     .then(() => graphIsCurrent(gen) ? mermaid.render("mmd-" + gen, res) : null)
-    .then(out => { if (out && graphIsCurrent(gen)) outputEl.innerHTML = out.svg; })
+    .then(out => { if (out && graphIsCurrent(gen)) { outputEl.classList.add("graph"); outputEl.innerHTML = out.svg; } })
     .catch(err => {
       // handles both a mermaid.js load failure and a render error
       if (!graphIsCurrent(gen)) return;


### PR DESCRIPTION
**The bug:** the live Graph tab showed garbage (whitespace-collapsed source) for returning visitors. Root cause: `/dippin.wasm` was cached `max-age=3600` while the playground JS deploys fresh — so new JS called `dippinMermaid` on an hour-stale WASM that didn't have it. `runGraph` threw before replacing the output pane, and the `.graph` flex/`white-space:normal` styling collapsed the leftover source into that mess.

**Fixes:**
1. **`runGraph` robustness** — guards a missing `dippinMermaid` with a clear "hard-reload to refresh the engine" message; clears stale content with a "Rendering graph…" placeholder before rendering; only applies the `.graph` styling once a real SVG exists (`setTool` no longer pre-applies it, so a text fallback is never collapsed).
2. **WASM/JS cache lockstep** — `/dippin.wasm` → `max-age=0, must-revalidate` so the WASM always tracks the JS it deploys with (ETag → cheap 304 when unchanged). Prevents the new-JS-vs-old-WASM skew on every future deploy.
3. **Mermaid class rename** — `subgraph_` → `subgnode`, avoiding any clash with Mermaid's reserved `subgraph` keyword.

Merging redeploys the live playground. (Immediate relief for anyone hitting it now: a hard refresh loads the current WASM.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789077511&installation_model_id=21126&pr_number=256&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F256&signature=f222bd9c2178185256bf526650811af4439d814d149eaf8f3d5882c2e7369f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->