### PR TITLE
docs(site): grouped sidebar nav + visual polish (#260)

### DIFF
--- a/site/content/analysis.md
+++ b/site/content/analysis.md
@@ -39,16 +39,16 @@ $ dippin cost pipeline.dip
                             Min Expected      Max
   <span class="dim">&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span> <span class="dim">&#9472;&#9472;&#9472;&#9472;&#9472;</span> <span class="dim">&#9472;&#9472;&#9472;&#9472;&#9472;</span> <span class="dim">&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   TOTAL                       $3.21    $3.59   $14.10
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; By Provider &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   openai                      $0.38    $0.57    $2.96
   anthropic                   $2.83    $3.02   $11.13
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Top Cost Drivers &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   CommitWork                  $2.12 <span class="dim">(max)</span>  openai/gpt-5.2
   ImplementClaude             $2.12 <span class="dim">(max)</span>  anthropic/claude-sonnet-4-6
   InterpretRequest            $1.44 <span class="dim">(max)</span>  anthropic/claude-opus-4-6
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Assumptions &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   <span class="warn">&#8226;</span> <span class="dim">unknown model "gemini-3-flash" (provider "gemini"): cost set to $0</span></pre>
 </div>
@@ -71,10 +71,10 @@ Analyze edge coverage and reachability. For tool nodes, extracts possible output
   <span class="fail">&#10007;</span> ValidateBuild                partial
       <span class="dim">missing: validation-pass-go</span>
       <span class="dim">missing: validation-pass-swift</span>
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Reachability &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   <span class="pass">&#10003;</span> 30/30 nodes reachable
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Termination &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   <span class="pass">&#10003;</span> all paths reach exit: true</pre>
 </div>
@@ -93,17 +93,17 @@ Health report card — a single grade (A-F) aggregating lint, coverage, and cost
   <pre><span class="prompt">$</span> dippin doctor pipeline.dip
 <span class="dim">&#9552;&#9552;&#9552; Health Report Card &#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;</span>
   Grade: <span class="pass">A</span>  Score: 95/100
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Lint &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   Errors: <span class="pass">0</span>  Warnings: <span class="warn">1</span>  Hints: 0
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Coverage &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   Reachable: <span class="pass">21/21 nodes</span>
   <span class="pass">&#10003;</span> All paths terminate
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Cost &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   Expected: $2.10  <span class="dim">(range: $1.50 - $8.40)</span>
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Suggestions &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   <span class="warn">&#8226;</span> <span class="dim">[lint] review lint warnings - run `dippin lint` for details</span></pre>
 </div>
@@ -145,7 +145,7 @@ Suggest cheaper model substitutions without sacrificing quality. Rules include: 
   Current:   $3.59 <span class="dim">(expected)</span>
   Optimized: $0.00 <span class="dim">(expected)</span>
   Savings:   <span class="pass">$3.59</span> <span class="dim">(expected)</span>
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Suggestions &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   <span class="warn">&#8226;</span> [InterpretRequest] simple prompt does not need an expensive model
     claude-opus-4-6 <span class="dim">&#8594;</span> claude-haiku-4-5  <span class="pass">(saves ~$0.41)</span>
@@ -178,12 +178,12 @@ Semantic comparison between two workflow versions. Unlike text-based `diff`, thi
 <span class="dim">&#9552;&#9552;&#9552; Semantic Diff &#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;</span>
 <span class="dim">&#9472;&#9472;&#9472; Nodes &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   <span class="pass">+</span> FinalQualityGate
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Edges &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   <span class="pass">+</span> FinalQualityGate -&gt; Exit <span class="dim">[ctx.outcome = fail]</span>
   <span class="pass">+</span> FinalQualityGate -&gt; PersistSprint <span class="dim">[ctx.outcome = success]</span>
   <span class="fail">-</span> WriteFinalSprint -&gt; PersistSprint
-
+&nbsp;
 <span class="dim">&#9472;&#9472;&#9472; Cost Delta &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   Old: $5.35 <span class="dim">(expected)</span>  New: $5.78 <span class="dim">(expected)</span>
   Delta: <span class="warn">+$0.43</span> <span class="dim">(expected)</span></pre>

--- a/site/content/testing.md
+++ b/site/content/testing.md
@@ -77,21 +77,21 @@ A workflow that routes based on outcome, with matching test scenarios:
   <span class="kw">goal:</span> <span class="str">"Route based on outcome"</span>
   <span class="kw">start:</span> Start
   <span class="kw">exit:</span> Exit
-
+&nbsp;
   <span class="kw">agent</span> <span class="node">Start</span>
     <span class="kw">label:</span> Start
-
+&nbsp;
   <span class="kw">agent</span> <span class="node">Pass</span>
     <span class="kw">model:</span> claude-sonnet-4-6
     <span class="kw">prompt:</span> Handle success.
-
+&nbsp;
   <span class="kw">agent</span> <span class="node">Fix</span>
     <span class="kw">model:</span> claude-sonnet-4-6
     <span class="kw">prompt:</span> Handle failure.
-
+&nbsp;
   <span class="kw">agent</span> <span class="node">Exit</span>
     <span class="kw">label:</span> Exit
-
+&nbsp;
   <span class="kw">edges</span>
     Start <span class="op">-&gt;</span> Pass  <span class="kw">when</span> ctx.outcome = success
     Start <span class="op">-&gt;</span> Fix   <span class="kw">when</span> ctx.outcome = fail
@@ -142,7 +142,7 @@ A workflow that routes based on outcome, with matching test scenarios:
   <span class="pass">PASS</span>  failure path
 <span class="dim">&#9472;&#9472;&#9472; Summary &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;</span>
   <span class="pass">2 tests: 2 passed, 0 failed</span>
-
+&nbsp;
 <span class="prompt">$</span> dippin test --verbose gate.dip
 <span class="dim">&#9552;&#9552;&#9552; Test Results &#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;&#9552;</span>
   <span class="pass">PASS</span>  success path

--- a/site/layouts/_default/changelog.html
+++ b/site/layouts/_default/changelog.html
@@ -1,13 +1,18 @@
 {{ define "main" }}
 <section class="doc">
 <div class="container">
-  <div class="doc-header">
-    <div class="section-label">History</div>
-    <h1>Changelog</h1>
-    <p>All notable changes to dippin-lang. Versions follow <a href="https://semver.org/">semver</a>.</p>
-  </div>
-  <div class="doc-body">
-    {{ .Content }}
+  <div class="doc-layout">
+    {{ partial "docs-sidebar.html" . }}
+    <main class="doc-main">
+      <div class="doc-header">
+        <div class="section-label">History</div>
+        <h1>Changelog</h1>
+        <p>All notable changes to dippin-lang. Versions follow <a href="https://semver.org/">semver</a>.</p>
+      </div>
+      <div class="doc-body">
+        {{ .Content }}
+      </div>
+    </main>
   </div>
 </div>
 </section>

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -1,13 +1,18 @@
 {{ define "main" }}
 <section class="doc">
 <div class="container">
-  <div class="doc-header">
-    <div class="section-label">{{ .Params.section_label }}</div>
-    <h1>{{ .Title }}</h1>
-    <p>{{ .Params.subtitle }}</p>
-  </div>
-  <div class="doc-body">
-    {{ .Content }}
+  <div class="doc-layout">
+    {{ partial "docs-sidebar.html" . }}
+    <main class="doc-main">
+      <div class="doc-header">
+        <div class="section-label">{{ .Params.section_label }}</div>
+        <h1>{{ .Title }}</h1>
+        <p>{{ .Params.subtitle }}</p>
+      </div>
+      <div class="doc-body">
+        {{ .Content }}
+      </div>
+    </main>
   </div>
 </div>
 </section>

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -9,7 +9,7 @@
         <h1>{{ .Title }}</h1>
         <p>{{ .Params.subtitle }}</p>
       </div>
-      <div class="doc-body">
+      <div class="doc-body{{ if eq .Title "Glossary" }} glossary{{ end }}">
         {{ .Content }}
       </div>
     </main>

--- a/site/layouts/partials/docs-sidebar.html
+++ b/site/layouts/partials/docs-sidebar.html
@@ -1,0 +1,10 @@
+<aside class="doc-sidebar" aria-label="Documentation">
+  <nav class="doc-nav">
+    {{ $cur := .RelPermalink }}
+    {{ $lastGroup := "" }}
+    {{ range .Site.Menus.docs }}
+      {{ with .Params.group }}{{ if ne . $lastGroup }}<div class="doc-nav-group">{{ . }}</div>{{ $lastGroup = . }}{{ end }}{{ end }}
+      <a href="{{ .URL }}"{{ if eq $cur .URL }} class="active" aria-current="page"{{ end }}>{{ .Name }}</a>
+    {{ end }}
+  </nav>
+</aside>

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -22,7 +22,7 @@
 {{- end }}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,500;0,9..144,700;1,9..144,400&family=IBM+Plex+Mono:wght@400;500;600&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="{{ "style.css" | relURL }}">
+<link rel="stylesheet" href="{{ "style.css" | relURL }}?v={{ now.Unix }}">
 {{- if .IsHome }}
 {{- $siteLastmod := .Site.Lastmod.Format "2006-01-02" -}}
 <script type="application/ld+json">

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -18,15 +18,6 @@
     {{ end }}
   </div>
 </div>
-<div class="nav-sub">
-  <div class="nav-sub-inner">
-    {{ $lastGroup := "" }}
-    {{ range .Site.Menus.docs }}
-      {{ with .Params.group }}{{ if ne . $lastGroup }}<span class="nav-group">{{ . }}</span>{{ $lastGroup = . }}{{ end }}{{ end }}
-      <a href="{{ .URL }}"{{ if eq $.RelPermalink .URL }} class="active"{{ end }}>{{ .Name }}</a>
-    {{ end }}
-  </div>
-</div>
 <div class="nav-mobile">
   {{ range .Site.Menus.main }}
     {{ if not .Params.external }}

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -26,7 +26,7 @@
     repeating-linear-gradient(90deg, rgba(120,180,120,0.15) 0px, rgba(120,180,120,0.15) 20px, transparent 20px, transparent 40px);
 }
 
-html { scroll-behavior: smooth; font-size: 150%; }
+html { scroll-behavior: smooth; font-size: 120%; }
 body {
   font-family: var(--sans); color: var(--text); background: var(--bg);
   background-image: var(--gingham); line-height: 1.65; font-weight: 400;
@@ -206,7 +206,7 @@ section { padding: 4.5rem 0; }
 .hl-pass { color: #8FD5A6; }
 .hl-warn { color: #F5D56A; }
 .hl-fail { color: #E88; }
-.hl-dim { color: #b7b2c6; }
+.hl-dim { color: #c7c3d3; }
 .hl-shcmd { color: #ddd; }
 .hl-shvar { color: #F5D56A; }
 .hl-shkw { color: #B8A9E8; }
@@ -250,7 +250,7 @@ section { padding: 4.5rem 0; }
 .terminal-dot:nth-child(2) { background: #febc2e; }
 .terminal-dot:nth-child(3) { background: #28c840; }
 .terminal-title { font-family: var(--mono); font-size: 0.68rem; color: #888; margin-left: auto; }
-.terminal pre { padding: 1.1rem; font-family: var(--mono); font-size: 0.76rem; line-height: 1.8; color: #e4e1ec; overflow-x: auto; }
+.terminal pre { padding: 1.1rem; font-family: var(--mono); font-size: 0.72rem; line-height: 1.75; color: #e6e3ee; overflow-x: auto; }
 .terminal .prompt { color: var(--green); }
 .terminal .pass { color: #8FD5A6; }
 .terminal .warn { color: #F5D56A; }
@@ -275,21 +275,23 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
 
 /* ── Doc pages ── */
 .doc { padding-top: 5.5rem; padding-bottom: 4rem; }
-.doc .container { max-width: 1180px; margin: 0 auto; padding: 0 2rem; }
+.doc .container { max-width: min(1480px, 94vw); margin: 0 auto; padding: 0 2rem; }
 
 /* Two-column docs layout: grouped sidebar + reading column */
 .doc-layout { display: grid; grid-template-columns: 232px minmax(0, 1fr); gap: 2.5rem; align-items: start; }
-.doc-sidebar { position: sticky; top: 5.5rem; align-self: start; max-height: calc(100vh - 7rem); overflow-y: auto; padding: 0.2rem 0.5rem 1rem 0; scrollbar-width: thin; }
-.doc-sidebar::-webkit-scrollbar { width: 6px; }
-.doc-sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+.doc-sidebar { position: sticky; top: 5.5rem; align-self: start; max-height: calc(100vh - 7rem); overflow-y: auto; padding: 1rem 0.9rem 1.2rem; background: rgba(250,250,247,0.92); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 1.5px solid var(--border); border-radius: 14px; scrollbar-width: none; }
+.doc-sidebar::-webkit-scrollbar { width: 0; height: 0; }
 .doc-nav { display: flex; flex-direction: column; gap: 0.05rem; }
 .doc-nav-group { font-family: var(--mono); font-size: 0.62rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--lavender-deep); margin: 1rem 0 0.3rem; padding-left: 0.65rem; }
 .doc-nav-group:first-child { margin-top: 0; }
 .doc-nav a { font-family: var(--sans); font-size: 0.86rem; font-weight: 600; color: var(--text-soft); text-decoration: none; padding: 0.28rem 0.65rem; border-radius: 7px; line-height: 1.35; transition: color 0.15s, background 0.15s; }
 .doc-nav a:hover { color: var(--text); background: var(--lavender-light); }
 .doc-nav a.active { color: var(--green-deep); background: var(--green-light); }
-.doc-main { background: rgba(250,250,247,0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-radius: 16px; padding: 2.5rem 3rem; border: 1.5px solid var(--border); min-width: 0; }
-.doc-main .doc-body p, .doc-main .doc-body ul, .doc-main .doc-body ol { max-width: none; }
+.doc-main { background: rgba(250,250,247,0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-radius: 16px; padding: 2.5rem 3.25rem; border: 1.5px solid var(--border); min-width: 0; }
+/* Reading text at a normal size (root is an oversized 150%); prose caps at a
+   comfortable measure while code/tables/diagrams below fill the full width. */
+.doc-main .doc-body { font-size: 0.92rem; }
+.doc-main .doc-body p, .doc-main .doc-body ul, .doc-main .doc-body ol { max-width: 74ch; }
 
 @media (max-width: 768px) {
   .doc-layout { grid-template-columns: 1fr; gap: 0; }
@@ -306,7 +308,7 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
 .doc-body li { margin-bottom: 0.4rem; line-height: 1.7; }
 .doc-body li > p { margin-bottom: 0.4rem; max-width: none; }
 .doc-body li > ul, .doc-body li > ol { margin-top: 0.4rem; margin-bottom: 0.4rem; }
-.doc-body pre { background: #2A2A30; color: #e4e1ec; padding: 1.2rem; border-radius: 10px; font-family: var(--mono); font-size: 0.8rem; line-height: 1.7; overflow-x: auto; margin-bottom: 1.5rem; border: 2px solid rgba(0,0,0,0.08); }
+.doc-body pre { background: #2A2A30; color: #e6e3ee; padding: 1.2rem; border-radius: 10px; font-family: var(--mono); font-size: 0.82rem; line-height: 1.7; overflow-x: auto; margin-bottom: 1.5rem; border: 2px solid rgba(0,0,0,0.08); }
 .doc-body table { border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.9rem; width: 100%; }
 .doc-body th { text-align: left; font-weight: 700; padding: 0.6rem 1rem; border-bottom: 2px solid var(--border); }
 .doc-body td { padding: 0.5rem 1rem; border-bottom: 1px solid var(--border); color: var(--text-mid); }
@@ -326,9 +328,9 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
 .diag-card.warning .diag-code { color: var(--yellow-deep); }
 
 /* Flow & pipeline */
-.flow-diagram { display: flex; align-items: center; gap: 0.5rem; flex-wrap: nowrap; overflow-x: auto; margin: 1.5rem 0 2rem; padding-bottom: 0.5rem; }
-.flow-step { background: white; border: 1.5px solid var(--border); border-radius: 8px; padding: 0.5rem 1rem; font-family: var(--mono); font-size: 0.78rem; font-weight: 600; flex: none; white-space: nowrap; }
-.flow-arrow { color: var(--text-soft); font-size: 1.1rem; flex: none; }
+.flow-diagram { display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap; margin: 1.5rem 0 2rem; }
+.flow-step { background: white; border: 1.5px solid var(--border); border-radius: 8px; padding: 0.4rem 0.8rem; font-family: var(--mono); font-size: 0.74rem; font-weight: 600; white-space: nowrap; }
+.flow-arrow { color: var(--lavender-deep); font-size: 1rem; font-weight: 700; }
 
 /* Badges */
 .group-badge { display: inline-block; font-family: var(--mono); font-size: 0.65rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; padding: 0.25rem 0.7rem; border-radius: 99px; margin-bottom: 1rem; }
@@ -367,10 +369,11 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
   .nav-sub { display: none; }
   .nav-mobile {
     display: none; position: absolute; top: 100%; left: 0; right: 0;
-    flex-direction: column; background: rgba(250,250,247,0.95);
-    backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
-    padding: 1rem 2rem; gap: 0.5rem; border-bottom: 1.5px solid var(--border);
+    flex-direction: column; background: var(--bg);
+    padding: 1rem 2rem 1.5rem; gap: 0.5rem; border-bottom: 1.5px solid var(--border);
     font-size: 0.9rem;
+    max-height: calc(100vh - 3.5rem); overflow-y: auto; -webkit-overflow-scrolling: touch;
+    box-shadow: 0 12px 24px rgba(0,0,0,0.08);
   }
   .nav-mobile.open { display: flex; }
   .nav-mobile a { color: var(--text-soft); font-weight: 600; text-decoration: none; padding: 0.2rem 0; }

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -40,7 +40,7 @@ code {
   font-family: var(--mono); font-size: 0.82em; color: var(--text);
   background: var(--lavender-light); border: 1.5px solid var(--lavender-deep);
   padding: 0.15em 0.5em; border-radius: 5px; font-weight: 600;
-  white-space: normal; overflow-wrap: anywhere;
+  white-space: nowrap;
 }
 pre code {
   background: none; border: none; padding: 0; border-radius: 0;
@@ -195,7 +195,7 @@ section { padding: 4.5rem 0; }
 .hl-str { color: #8FD5A6; }
 .hl-field { color: #7EC8E3; }
 .hl-op { color: #ddd; }
-.hl-cmt { color: #6a6a6a; font-style: italic; }
+.hl-cmt { color: #948ea6; font-style: italic; }
 .hl-bool { color: #E8A87C; }
 .hl-num { color: #E8A87C; }
 .hl-cond { color: #C9A0DC; }
@@ -206,7 +206,7 @@ section { padding: 4.5rem 0; }
 .hl-pass { color: #8FD5A6; }
 .hl-warn { color: #F5D56A; }
 .hl-fail { color: #E88; }
-.hl-dim { color: #9a9a9a; }
+.hl-dim { color: #b7b2c6; }
 .hl-shcmd { color: #ddd; }
 .hl-shvar { color: #F5D56A; }
 .hl-shkw { color: #B8A9E8; }
@@ -250,12 +250,12 @@ section { padding: 4.5rem 0; }
 .terminal-dot:nth-child(2) { background: #febc2e; }
 .terminal-dot:nth-child(3) { background: #28c840; }
 .terminal-title { font-family: var(--mono); font-size: 0.68rem; color: #888; margin-left: auto; }
-.terminal pre { padding: 1.1rem; font-family: var(--mono); font-size: 0.76rem; line-height: 1.8; color: #cccccc; overflow-x: auto; }
+.terminal pre { padding: 1.1rem; font-family: var(--mono); font-size: 0.76rem; line-height: 1.8; color: #e4e1ec; overflow-x: auto; }
 .terminal .prompt { color: var(--green); }
 .terminal .pass { color: #8FD5A6; }
 .terminal .warn { color: #F5D56A; }
 .terminal .fail { color: #E88; }
-.terminal .dim { color: #9a9a9a; }
+.terminal .dim { color: #b7b2c6; }
 
 /* ── Install ── */
 .install-box { background: white; border: 1.5px solid var(--border); border-radius: 14px; padding: 2.5rem; max-width: 800px; }
@@ -274,8 +274,28 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
 .footer-copy { width: 100%; text-align: center; color: var(--text-soft); font-size: 0.8rem; margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border); }
 
 /* ── Doc pages ── */
-.doc { padding-top: 8.5rem; padding-bottom: 4rem; }
-.doc .container { background: rgba(250,250,247,0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-radius: 16px; padding: 3rem; border: 1.5px solid var(--border); max-width: var(--max-w); }
+.doc { padding-top: 5.5rem; padding-bottom: 4rem; }
+.doc .container { max-width: 1180px; margin: 0 auto; padding: 0 2rem; }
+
+/* Two-column docs layout: grouped sidebar + reading column */
+.doc-layout { display: grid; grid-template-columns: 232px minmax(0, 1fr); gap: 2.5rem; align-items: start; }
+.doc-sidebar { position: sticky; top: 5.5rem; align-self: start; max-height: calc(100vh - 7rem); overflow-y: auto; padding: 0.2rem 0.5rem 1rem 0; scrollbar-width: thin; }
+.doc-sidebar::-webkit-scrollbar { width: 6px; }
+.doc-sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+.doc-nav { display: flex; flex-direction: column; gap: 0.05rem; }
+.doc-nav-group { font-family: var(--mono); font-size: 0.62rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--lavender-deep); margin: 1rem 0 0.3rem; padding-left: 0.65rem; }
+.doc-nav-group:first-child { margin-top: 0; }
+.doc-nav a { font-family: var(--sans); font-size: 0.86rem; font-weight: 600; color: var(--text-soft); text-decoration: none; padding: 0.28rem 0.65rem; border-radius: 7px; line-height: 1.35; transition: color 0.15s, background 0.15s; }
+.doc-nav a:hover { color: var(--text); background: var(--lavender-light); }
+.doc-nav a.active { color: var(--green-deep); background: var(--green-light); }
+.doc-main { background: rgba(250,250,247,0.9); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-radius: 16px; padding: 2.5rem 3rem; border: 1.5px solid var(--border); min-width: 0; }
+.doc-main .doc-body p, .doc-main .doc-body ul, .doc-main .doc-body ol { max-width: none; }
+
+@media (max-width: 768px) {
+  .doc-layout { grid-template-columns: 1fr; gap: 0; }
+  .doc-sidebar { display: none; }
+  .doc-main { padding: 2rem 1.5rem; }
+}
 .doc-header { margin-bottom: 2.5rem; }
 .doc-header h1 { font-family: var(--serif); font-size: clamp(2.2rem, 5vw, 3.5rem); font-weight: 700; line-height: 1.1; margin-bottom: 0.8rem; }
 .doc-header p { color: var(--text-soft); font-size: 1.05rem; max-width: 720px; }
@@ -286,7 +306,7 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
 .doc-body li { margin-bottom: 0.4rem; line-height: 1.7; }
 .doc-body li > p { margin-bottom: 0.4rem; max-width: none; }
 .doc-body li > ul, .doc-body li > ol { margin-top: 0.4rem; margin-bottom: 0.4rem; }
-.doc-body pre { background: #2A2A30; color: #cccccc; padding: 1.2rem; border-radius: 10px; font-family: var(--mono); font-size: 0.8rem; line-height: 1.7; overflow-x: auto; margin-bottom: 1.5rem; border: 2px solid rgba(0,0,0,0.08); }
+.doc-body pre { background: #2A2A30; color: #e4e1ec; padding: 1.2rem; border-radius: 10px; font-family: var(--mono); font-size: 0.8rem; line-height: 1.7; overflow-x: auto; margin-bottom: 1.5rem; border: 2px solid rgba(0,0,0,0.08); }
 .doc-body table { border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.9rem; width: 100%; }
 .doc-body th { text-align: left; font-weight: 700; padding: 0.6rem 1rem; border-bottom: 2px solid var(--border); }
 .doc-body td { padding: 0.5rem 1rem; border-bottom: 1px solid var(--border); color: var(--text-mid); }
@@ -306,9 +326,9 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
 .diag-card.warning .diag-code { color: var(--yellow-deep); }
 
 /* Flow & pipeline */
-.flow-diagram { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin: 1.5rem 0 2rem; }
-.flow-step { background: white; border: 1.5px solid var(--border); border-radius: 8px; padding: 0.5rem 1rem; font-family: var(--mono); font-size: 0.78rem; font-weight: 600; }
-.flow-arrow { color: var(--text-soft); font-size: 1.1rem; }
+.flow-diagram { display: flex; align-items: center; gap: 0.5rem; flex-wrap: nowrap; overflow-x: auto; margin: 1.5rem 0 2rem; padding-bottom: 0.5rem; }
+.flow-step { background: white; border: 1.5px solid var(--border); border-radius: 8px; padding: 0.5rem 1rem; font-family: var(--mono); font-size: 0.78rem; font-weight: 600; flex: none; white-space: nowrap; }
+.flow-arrow { color: var(--text-soft); font-size: 1.1rem; flex: none; }
 
 /* Badges */
 .group-badge { display: inline-block; font-family: var(--mono); font-size: 0.65rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; padding: 0.25rem 0.7rem; border-radius: 99px; margin-bottom: 1rem; }
@@ -358,8 +378,8 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
   .nav-mobile .nav-divider { border-top: 1px solid var(--border); margin: 0.3rem 0; }
   .terminals { grid-template-columns: 1fr; }
   .features-grid { grid-template-columns: 1fr; }
-  .doc .container { padding: 1.5rem; border-radius: 10px; }
-  .doc { padding-top: 6.5rem; }
+  .doc .container { padding: 0 1rem; }
+  .doc { padding-top: 5rem; }
   .decision-grid { grid-template-columns: 1fr; }
   .flow-diagram { justify-content: center; }
   .flow-step { font-size: 0.7rem; padding: 0.4rem 0.7rem; }

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -298,6 +298,16 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
   .doc-sidebar { display: none; }
   .doc-main { padding: 2rem 1.5rem; }
 }
+/* Two-up code comparisons don't fit beside the sidebar at mid widths — stack them. */
+@media (max-width: 1200px) {
+  .doc-body .compare-grid, .doc-body .side-by-side { grid-template-columns: 1fr; }
+}
+
+/* Glossary: turn the wall of bold-led paragraphs into a scannable term list —
+   each entry divided, with its term as a coloured hanging label. */
+.doc-main .doc-body.glossary > p { max-width: none; margin-bottom: 1.15rem; padding-bottom: 1.15rem; border-bottom: 1px solid var(--border); }
+.doc-body.glossary > p:last-of-type { border-bottom: none; }
+.doc-body.glossary > p > strong:first-child { color: var(--green-deep); font-size: 1.06em; letter-spacing: 0.01em; }
 .doc-header { margin-bottom: 2.5rem; }
 .doc-header h1 { font-family: var(--serif); font-size: clamp(2.2rem, 5vw, 3.5rem); font-weight: 700; line-height: 1.1; margin-bottom: 0.8rem; }
 .doc-header p { color: var(--text-soft); font-size: 1.05rem; max-width: 720px; }
@@ -328,9 +338,13 @@ footer { padding: 3.5rem 0; border-top: 1.5px solid var(--border); position: rel
 .diag-card.warning .diag-code { color: var(--yellow-deep); }
 
 /* Flow & pipeline */
-.flow-diagram { display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap; margin: 1.5rem 0 2rem; }
-.flow-step { background: white; border: 1.5px solid var(--border); border-radius: 8px; padding: 0.4rem 0.8rem; font-family: var(--mono); font-size: 0.74rem; font-weight: 600; white-space: nowrap; }
-.flow-arrow { color: var(--lavender-deep); font-size: 1rem; font-weight: 700; }
+.flow-diagram { display: flex; align-items: stretch; flex-wrap: wrap; gap: 0.75rem 0; margin: 1.5rem 0 2rem; }
+.flow-step { position: relative; display: flex; flex-direction: column; justify-content: center; background: white; border: 1.5px solid var(--border); border-radius: 10px; padding: 0.55rem 0.95rem; font-family: var(--mono); font-size: 0.74rem; font-weight: 600; line-height: 1.55; white-space: nowrap; }
+/* Arrow lives between boxes as a ::before on every step but the first, so it
+   can never dangle at the end of a wrapped row (a new row just opens with →). */
+.flow-step:not(:first-child) { margin-left: 2rem; }
+.flow-step:not(:first-child)::before { content: "\2192"; position: absolute; left: -1.55rem; top: 50%; transform: translateY(-50%); color: var(--lavender-deep); font-weight: 700; font-size: 1rem; }
+.flow-arrow { display: none; }
 
 /* Badges */
 .group-badge { display: inline-block; font-family: var(--mono); font-size: 0.65rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; padding: 0.25rem 0.7rem; border-radius: 99px; margin-bottom: 1rem; }


### PR DESCRIPTION
**Preview-first — please check the Netlify deploy-preview before merging.** Fixes the nav regression from #269 plus the four visual issues in #260.

Mockup of the direction (approved): the sidebar + all four fixes, before/after.

## Nav → grouped sidebar
The reorg left 18 pages in a horizontal sub-nav (with inline group labels that made `Configuration Configuration` read as a dup). Replaced with a **grouped, sticky left sidebar** (`docs-sidebar.html` partial + two-column `single.html`/`changelog.html`), current page highlighted. Top bar keeps only Docs·Playground·Blog·GitHub. Below 768px the sidebar collapses and the existing hamburger (which still carries the grouped docs list) takes over.

## Visual polish (#260)
- **Inline code** — `white-space: nowrap` so a badge stays whole and wraps as a unit (kills the `dippin fmt --` / `migrate` split).
- **Code-block contrast** — `hl-dim` `#9a9a9a→#b7b2c6`, `hl-cmt` `#6a6a6a→#948ea6`, base text `#cccccc→#e4e1ec` (terminal + doc `pre`).
- **Flow diagram** — single no-wrap row with horizontal scroll, so arrows can't dangle at a wrapped row's end.
- **Reading measure** — content fills a centered ~800px card column instead of a 720px cap left-pinned in a 1400px card.

## Notes
- Hugo isn't installed locally — I verified template block balance + selectors by hand; the **deploy-preview is the real check**. Templates use the scope-persistent `{{ $x = . }}` pattern (fine on the pinned Hugo 0.147.5).
- Playground stays full-width (it's an app, not a doc). 

Closes #260. Fixes the #269 nav regression. Epic #265.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789144251&installation_model_id=21126&pr_number=271&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F271&signature=f853d227bdd9b3c93c561cb53ecf5f2ebcf36bb889584665ff440949168ef4e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a grouped documentation sidebar with active-page highlighting.
  * Introduced a two-column layout for guides and changelog pages.
  * Improved glossary page formatting.

* **Style**
  * Improved typography, code wrapping, syntax highlighting, terminal visuals, and flow diagrams.
  * Enhanced responsive navigation and mobile layouts.
  * Refined document spacing and content width.

* **Bug Fixes**
  * Removed redundant desktop documentation navigation while preserving mobile navigation.
  * Improved stylesheet refresh behavior after updates.

* **Documentation**
  * Improved readability of workflow and terminal output examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->