### PR TITLE
feat(site): publish pricing catalog as public JSON at /prices.json (#266)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,7 @@
     ./scripts/gen-spec.sh && \
     cp docs/generated-spec.md site/static/llms-full.txt && \
     cp AGENTS.md site/static/AGENTS.md && \
+    cp pricing/prices.json site/static/prices.json && \
     cd site && hugo --minify
   """
   publish = "site/public"
@@ -28,6 +29,7 @@
     ./scripts/gen-spec.sh && \
     cp docs/generated-spec.md site/static/llms-full.txt && \
     cp AGENTS.md site/static/AGENTS.md && \
+    cp pricing/prices.json site/static/prices.json && \
     cd site && hugo --minify --baseURL $URL
   """
 
@@ -40,6 +42,7 @@
     ./scripts/gen-spec.sh && \
     cp docs/generated-spec.md site/static/llms-full.txt && \
     cp AGENTS.md site/static/AGENTS.md && \
+    cp pricing/prices.json site/static/prices.json && \
     cd site && hugo --minify --baseURL $DEPLOY_PRIME_URL
   """
 
@@ -70,6 +73,15 @@
     # a returning visitor run new JS against an hour-stale WASM (missing newly
     # exported functions), which broke the Graph view. Keep JS and WASM in lockstep.
     Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/prices.json"
+  [headers.values]
+    Content-Type = "application/json; charset=utf-8"
+    # Public, consumable model/pricing catalog (single source of truth:
+    # pricing/prices.json, copied fresh each build). Allow cross-origin fetch.
+    Access-Control-Allow-Origin = "*"
+    Cache-Control = "public, max-age=300, must-revalidate"
 
 [[headers]]
   for = "/llms.txt"

--- a/site/content/models.md
+++ b/site/content/models.md
@@ -89,3 +89,15 @@ Two flags mark entries that behave differently from an ordinary priced model:
 ## Estimating Cost
 
 Because pricing lives in the same embedded catalog the validator uses, `dippin cost` can estimate a workflow's per-run token spend directly from the model each agent names — no separate price table to configure. For the cost command, its assumptions, and the related coverage and optimization tools, see [Analysis Tools](/analysis/).
+
+## Use the catalog in your own tools
+
+The full catalog is published as consumable JSON at **[`/prices.json`](/prices.json)** — the exact file dippin embeds, refreshed on every deploy, and served with `Access-Control-Allow-Origin: *` so you can fetch it straight from a browser. Each entry carries `provider`, `model`, `input_per_m` / `output_per_m` (USD per million tokens), optional cache fields (`cache_read_mult` / `cache_write_mult`, or an absolute `cached_input_per_m`), the `priced` / `deprecated` flags, and provenance (`source` URL + `as_of` date). A top-level `provider_aliases` map resolves shorthand names (e.g. `xai` → `grok`) to canonical providers.
+
+```sh
+curl -s https://dippin.org/prices.json | jq '.models[] | select(.provider == "anthropic")'
+```
+
+## Report a correction
+
+Every price is verified against the provider's **official** pricing page — each entry records the `source` URL and the `as_of` date it was last checked. Prices are never taken from model memory or third-party aggregators as ground truth, so a correction needs a first-party citation. If you spot a stale or wrong number, open an issue or a PR against [`pricing/prices.json`](https://github.com/2389-research/dippin-lang/blob/main/pricing/prices.json), **including the official source URL and the date you checked**.


### PR DESCRIPTION
Publishes dippin's verified model/pricing catalog as consumable open JSON.

- **Serve it:** the Netlify build copies `pricing/prices.json` → `site/static/prices.json` in all 3 contexts (fresh from the source of truth every deploy — no committed duplicate, no drift; same pattern as the wasm/llms-full.txt generation). Verify on the deploy-preview at `/prices.json`.
- **Consumable:** served `application/json` with `Access-Control-Allow-Origin: *` for cross-origin `fetch()`.
- **Documented + correction workflow:** the Models & Pricing page gets a *Use the catalog in your own tools* section (field schema + `curl … | jq` example) and a *Report a correction* section (open an issue/PR with the official source URL + date).

Closes #266. A formal JSON Schema at `/prices.schema.json` can be a later add if consumers want it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789146928&installation_model_id=21126&pr_number=273&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F273&signature=4699be1d01229d87cec702a811be79336161df2c33825695d0f6c14352be2f3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->