### PR TITLE
pricing: add grok-4.6 + deepseek-v4-pro-0813 (released today)

### DIFF
--- a/pricing/prices.json
+++ b/pricing/prices.json
@@ -264,6 +264,15 @@
       "cached_input_per_m": 0.003625
     },
     {
+      "provider": "deepseek",
+      "model": "deepseek-v4-pro-0813",
+      "input_per_m": 0.435,
+      "output_per_m": 0.87,
+      "source": "https://api-docs.deepseek.com/quick_start/pricing",
+      "as_of": "2026-08-12",
+      "cached_input_per_m": 0.003625
+    },
+    {
       "provider": "gemini",
       "model": "gemini-2.0-flash",
       "input_per_m": 0.1,
@@ -430,6 +439,15 @@
       "source": "https://docs.x.ai/docs/models",
       "as_of": "2026-08-10",
       "cached_input_per_m": 0.3
+    },
+    {
+      "provider": "grok",
+      "model": "grok-4.6",
+      "input_per_m": 2,
+      "output_per_m": 6,
+      "source": "https://docs.x.ai/docs/models",
+      "as_of": "2026-08-12",
+      "cached_input_per_m": 0.5
     },
     {
       "provider": "grok",


### PR DESCRIPTION
Two models that landed **2026-08-12**, both verified against official pages:

- **grok-4.6** — $2 in / $6 out / **$0.50/M cached** (base <200k tier), per [docs.x.ai/docs/models](https://docs.x.ai/docs/models). x.ai's newest, billed like grok-4.5 but with a higher cache rate.
- **deepseek-v4-pro-0813** — the GA snapshot (Aug 12) of `deepseek-v4-pro`, priced identically ($0.435 / $0.87 + $0.003625/M cached) per the [official DeepSeek pricing page](https://api-docs.deepseek.com/quick_start/pricing). Adds the pinned dated id so a workflow referencing the snapshot doesn't trip a spurious DIP108.

(OpenRouter surfaced both, but prices are sourced from the providers' official pages, not the aggregator.) Catalog: 109 → 111 models.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789147498&installation_model_id=21126&pr_number=275&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F275&signature=7eac123f158955a634ee874732130b8f2dbb43f79014d29b744eaa3f241c6c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->