### PR TITLE
fix(fmt): retain leading file-comment block (#259 MVP)

### DIFF
--- a/formatter/format.go
+++ b/formatter/format.go
@@ -22,6 +22,7 @@ func Format(w *ir.Workflow) string {
 		dip2 = true
 	}
 	wr := &writer{dip2: dip2}
+	writeHeaderComment(wr, w)
 	writeWorkflowHeader(wr, w)
 	writeWorkflowSections(wr, w)
 	return wr.String()
@@ -135,6 +136,19 @@ func (wr *writer) String() string {
 }
 
 // --- Section emitters ---
+
+// writeHeaderComment emits the retained leading file-level comment block verbatim
+// at the very top of the output, followed by a blank line separating it from the
+// `dip N` / `workflow` header. No-op (byte-identical output) when empty (#259).
+func writeHeaderComment(wr *writer, w *ir.Workflow) {
+	if len(w.HeaderComment) == 0 {
+		return
+	}
+	for _, l := range w.HeaderComment {
+		wr.line("%s", l)
+	}
+	wr.blank()
+}
 
 func writeWorkflowHeader(wr *writer, w *ir.Workflow) {
 	if v, err := strconv.Atoi(w.Version); err == nil && v > 1 {

--- a/formatter/format_header_comment_test.go
+++ b/formatter/format_header_comment_test.go
@@ -1,0 +1,89 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/parser"
+)
+
+// TestFormatHeaderCommentRoundtrip verifies the leading file-level comment block
+// (e.g. an `# ABOUTME:` header) survives parse -> Format verbatim at the top (#259).
+func TestFormatHeaderCommentRoundtrip(t *testing.T) {
+	input := `# ABOUTME: This workflow ships a feature end to end.
+# ABOUTME: Requires the anthropic + openai providers.
+#
+# Provider deps: anthropic, openai
+
+workflow WithHeader
+  start: Begin
+  exit: Begin
+
+  agent Begin
+    prompt: "Go."
+`
+	w, err := parser.NewParser(input, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	want := []string{
+		"# ABOUTME: This workflow ships a feature end to end.",
+		"# ABOUTME: Requires the anthropic + openai providers.",
+		"#",
+		"# Provider deps: anthropic, openai",
+	}
+	if len(w.HeaderComment) != len(want) {
+		t.Fatalf("HeaderComment = %#v, want %#v", w.HeaderComment, want)
+	}
+	for i := range want {
+		if w.HeaderComment[i] != want[i] {
+			t.Errorf("HeaderComment[%d] = %q, want %q", i, w.HeaderComment[i], want[i])
+		}
+	}
+
+	formatted := Format(w)
+	header := strings.Join(want, "\n") + "\n\n"
+	if !strings.HasPrefix(formatted, header) {
+		t.Errorf("formatted output does not begin with the verbatim header block\ngot:\n%s", formatted)
+	}
+	if !strings.Contains(formatted, "workflow WithHeader") {
+		t.Errorf("formatted output missing workflow line\ngot:\n%s", formatted)
+	}
+
+	// Round-trips: reparsing and reformatting is stable.
+	w2, err := parser.NewParser(formatted, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("second parse failed: %v\nformatted:\n%s", err, formatted)
+	}
+	if reformatted := Format(w2); formatted != reformatted {
+		t.Errorf("formatter not idempotent with header comment\nfirst:\n%s\nsecond:\n%s", formatted, reformatted)
+	}
+}
+
+// TestFormatNoHeaderCommentByteIdentical guards against a spurious leading blank
+// line when the file has no leading comment (#259).
+func TestFormatNoHeaderCommentByteIdentical(t *testing.T) {
+	input := `workflow NoHeader
+  start: Begin
+  exit: Begin
+
+  agent Begin
+    prompt: "Go."
+`
+	w, err := parser.NewParser(input, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(w.HeaderComment) != 0 {
+		t.Fatalf("HeaderComment = %#v, want empty", w.HeaderComment)
+	}
+
+	formatted := Format(w)
+	if strings.HasPrefix(formatted, "\n") {
+		t.Errorf("formatted output starts with a spurious blank line\ngot:\n%q", formatted)
+	}
+	if !strings.HasPrefix(formatted, "workflow NoHeader") {
+		t.Errorf("formatted output should start with the workflow line\ngot:\n%s", formatted)
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -34,6 +34,15 @@ type Workflow struct {
 	ElseTargetSource SourceLocation   // Source location of the `else` entry, for diagnostics
 	Stylesheet       []StylesheetRule // Theme/styling rules
 	SourceMap        *SourceMap       // File/line mapping for diagnostics
+	// HeaderComment holds the leading file-level comment block: the contiguous
+	// run of `#` comment lines at the very top of the source, before the `dip N`
+	// pragma or `workflow` declaration. Each entry is a raw line verbatim
+	// (leading `#` included), with surrounding blank lines dropped but interior
+	// blank lines preserved. Empty when the file has no leading comment. The
+	// formatter re-emits these so `dippin fmt` no longer erases `# ABOUTME:` /
+	// provider-dependency headers (#259). Inline/trailing/between-node comments
+	// are not yet retained.
+	HeaderComment []string
 }
 
 // StylesheetRule pairs a selector with a set of properties.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -22,9 +22,55 @@ func NewParser(input string, filename string) *Parser {
 		filename: filename,
 		version:  1,
 		workflow: &ir.Workflow{
-			SourceMap: &ir.SourceMap{},
+			SourceMap:     &ir.SourceMap{},
+			HeaderComment: leadingCommentBlock(strings.Split(input, "\n")),
 		},
 	}
+}
+
+// leadingCommentBlock returns the file-level comment lines at the very top of the
+// source: the contiguous run of blank/comment lines before the first code line
+// (the `dip N` pragma or `workflow` declaration), with surrounding blank lines
+// dropped but interior blank lines preserved. Each returned line keeps its
+// leading `#` verbatim. Returns nil when there is no leading comment (#259).
+func leadingCommentBlock(lines []string) []string {
+	end := 0
+	for end < len(lines) && isBlankOrComment(strings.TrimRight(lines[end], "\r")) {
+		end++
+	}
+	return trimBlankEdges(lines[:end])
+}
+
+// trimBlankEdges drops leading and trailing blank-only lines from a block,
+// returning the interior verbatim (trailing \r stripped) or nil if all-blank.
+func trimBlankEdges(block []string) []string {
+	lo, hi := blankTrimRange(block)
+	if lo == hi {
+		return nil
+	}
+	out := make([]string, hi-lo)
+	for i := lo; i < hi; i++ {
+		out[i-lo] = strings.TrimRight(block[i], "\r")
+	}
+	return out
+}
+
+// blankTrimRange returns the [lo, hi) slice bounds of block with leading and
+// trailing blank-only lines excluded.
+func blankTrimRange(block []string) (int, int) {
+	lo, hi := 0, len(block)
+	for lo < hi && isBlankLine(block[lo]) {
+		lo++
+	}
+	for hi > lo && isBlankLine(block[hi-1]) {
+		hi--
+	}
+	return lo, hi
+}
+
+// isBlankLine reports whether a line is empty or whitespace-only.
+func isBlankLine(line string) bool {
+	return len(strings.TrimSpace(line)) == 0
 }
 
 func (p *Parser) Parse() (*ir.Workflow, error) {


### PR DESCRIPTION
Fixes the highest-value slice of #259: `dippin fmt` no longer erases the leading `# ABOUTME:` / provider-dependency header block.

## Root cause + fix
The lexer strips comments at tokenization, so they never reach the IR and the formatter has nothing to re-emit. This captures the **contiguous leading blank/comment block** from the raw source into a new `ir.Workflow.HeaderComment []string`, and the formatter re-emits it verbatim above the `dip N`/`workflow` header. Empty header ⇒ byte-identical output (guards a spurious-blank-line regression).

## Scope
**Leading file-comment block only** — this covers the real-world driver (the pipelines repo's ABOUTME/provider headers) and makes `fmt` safe for header-commented files. **Inline / trailing / between-node comment retention is left for a follow-up** (a larger parser change, since the lexer discards all comments) — so #259 stays partially open.

Guarded by new round-trip + idempotency + no-header tests. Full suite green. Part of the v0.67.0 sequence (with #264 Phase 2).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789162332&installation_model_id=21126&pr_number=280&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F280&signature=923770f6caacff8f4ce79b4d3fd5c158805357b89eb0bcd26b08578edec43fee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved leading file comments when parsing and reformatting workflows.
  * Retained comment content and spacing while keeping inline and trailing comments unchanged.
* **Bug Fixes**
  * Prevented unwanted leading blank lines in files without header comments.
  * Ensured formatting remains stable across repeated parse-and-format cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->