### PR TITLE
release: v0.67.0 — model family aliases + DIP162 + fmt header retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ## [Unreleased]
 
+## [v0.67.0] — 2026-08-12
+
+### Added
+- **Model family aliases — `[provider/]family@selector`** ([#264](https://github.com/2389-research/dippin-lang/issues/264), Phase 2). An `agent`'s `model:` may now be a family alias (`opus@latest`, `anthropic/opus@stable`) with selector `latest` / `stable` / `sota`, instead of a concrete id that silently rots when a provider retires a model. `dippin fmt` **pins** a resolvable alias in place to its concrete catalog id (author-time, one-way) — and a provider-prefixed cross-provider alias also reconciles the node's `provider:` field, so pinning never turns a lint-clean file into a warning. `dippin cost` prices an un-pinned alias on its resolved id. Resolution excludes deprecated / preview / unpriced members, so an alias can never land on a retired or unpriced model. Builds on the `pricing.ResolveAlias` foundation from v0.66.0; adds the shared `pricing.ResolveModelRef` resolver.
+- **DIP162 — Unresolvable Model Alias.** Warns when a `family@selector` alias resolves to no eligible model (unknown family, invalid selector, or every member deprecated/preview). A resolvable alias is valid — no DIP108, no DIP162.
+
+### Changed
+- **`dippin fmt` retains a file's leading comment block** ([#259](https://github.com/2389-research/dippin-lang/issues/259)). A `.dip` file's leading blank/comment header — license banners, `ABOUTME:` lines — is now captured and re-emitted by `fmt` instead of being silently dropped. (Interior/inline comment retention remains future work; the lexer strips comments at tokenize time.)
+- Diagnostic-code count is now **72** (DIP101–DIP162) across all doc and site surfaces.
+
 ## [v0.66.2] — 2026-08-12
 
 ### Added

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,16 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.67.0] — 2026-08-12
+
+### Added
+- **Model family aliases — `[provider/]family@selector`** ([#264](https://github.com/2389-research/dippin-lang/issues/264), Phase 2). An `agent`'s `model:` may now be a family alias (`opus@latest`, `anthropic/opus@stable`) with selector `latest` / `stable` / `sota`, instead of a concrete id that silently rots when a provider retires a model. `dippin fmt` **pins** a resolvable alias in place to its concrete catalog id (author-time, one-way) — and a provider-prefixed cross-provider alias also reconciles the node's `provider:` field, so pinning never turns a lint-clean file into a warning. `dippin cost` prices an un-pinned alias on its resolved id. Resolution excludes deprecated / preview / unpriced members, so an alias can never land on a retired or unpriced model. Builds on the `pricing.ResolveAlias` foundation from v0.66.0; adds the shared `pricing.ResolveModelRef` resolver.
+- **DIP162 — Unresolvable Model Alias.** Warns when a `family@selector` alias resolves to no eligible model (unknown family, invalid selector, or every member deprecated/preview). A resolvable alias is valid — no DIP108, no DIP162.
+
+### Changed
+- **`dippin fmt` retains a file's leading comment block** ([#259](https://github.com/2389-research/dippin-lang/issues/259)). A `.dip` file's leading blank/comment header — license banners, `ABOUTME:` lines — is now captured and re-emitted by `fmt` instead of being silently dropped. (Interior/inline comment retention remains future work; the lexer strips comments at tokenize time.)
+- Diagnostic-code count is now **72** (DIP101–DIP162) across all doc and site surfaces.
+
 ## [v0.66.2] — 2026-08-12
 
 ### Added


### PR DESCRIPTION
CHANGELOG + generated site changelog for **v0.67.0**. Bundles what merged since v0.66.2:

- **#264 Phase 2** — `[provider/]family@selector` model aliases, `dippin fmt` pin-resolution (with cross-provider `provider:` reconciliation), `dippin cost` alias pricing, **DIP162** unresolvable-alias lint.
- **#259** — `dippin fmt` retains a file's leading comment block.
- Diagnostic-code count swept to **72 (DIP101–DIP162)** across all surfaces.

Tag is pushed after this merges; GoReleaser builds binaries + Homebrew and Netlify redeploys (republishing `/prices.json`, `/models.json`, `/models.schema.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789164484&installation_model_id=21126&pr_number=282&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F282&signature=1e9b36c872452c45388419db53e5fce259356eafb02cd93779fac8a43b979b50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->