### PR TITLE
feat(#285): verified display_name in the model catalog

### DIFF
--- a/pricing/load.go
+++ b/pricing/load.go
@@ -24,6 +24,9 @@ type fileEntry struct {
 	ContextWindow int      `json:"context_window,omitempty"`
 	MaxOutput     int      `json:"max_output,omitempty"`
 	Capabilities  []string `json:"capabilities,omitempty"`
+	// Human-facing product name, verified from source (#285); optional (absent =
+	// unknown, consumer derives or overlays).
+	DisplayName string `json:"display_name,omitempty"`
 }
 
 type priceFile struct {
@@ -80,6 +83,7 @@ func (idx *catalogIndex) add(e fileEntry) {
 		ContextWindow:   e.ContextWindow,
 		MaxOutput:       e.MaxOutput,
 		Capabilities:    e.Capabilities,
+		DisplayName:     e.DisplayName,
 	}
 	idx.put(e.Provider, e.Model, p)
 	for _, a := range e.Aliases {

--- a/pricing/prices.json
+++ b/pricing/prices.json
@@ -8,6 +8,7 @@
     {
       "provider": "anthropic",
       "model": "claude-fable-5",
+      "display_name": "Claude Fable 5",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -21,6 +22,7 @@
     {
       "provider": "anthropic",
       "model": "claude-haiku-3-5",
+      "display_name": "Claude Haiku 3.5",
       "family": "haiku",
       "rank": 35,
       "maturity": "stable",
@@ -35,6 +37,7 @@
     {
       "provider": "anthropic",
       "model": "claude-haiku-4-5",
+      "display_name": "Claude Haiku 4.5",
       "context_window": 200000,
       "max_output": 64000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -51,6 +54,7 @@
     {
       "provider": "anthropic",
       "model": "claude-mythos-5",
+      "display_name": "Claude Mythos 5",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -64,6 +68,7 @@
     {
       "provider": "anthropic",
       "model": "claude-mythos-preview",
+      "display_name": "Claude Mythos Preview",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -74,6 +79,7 @@
     {
       "provider": "anthropic",
       "model": "claude-opus-4-0",
+      "display_name": "Claude Opus 4",
       "family": "opus",
       "rank": 40,
       "maturity": "stable",
@@ -88,6 +94,7 @@
     {
       "provider": "anthropic",
       "model": "claude-opus-4-1",
+      "display_name": "Claude Opus 4.1",
       "family": "opus",
       "rank": 41,
       "maturity": "stable",
@@ -102,6 +109,7 @@
     {
       "provider": "anthropic",
       "model": "claude-opus-4-5",
+      "display_name": "Claude Opus 4.5",
       "context_window": 200000,
       "max_output": 64000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -118,6 +126,7 @@
     {
       "provider": "anthropic",
       "model": "claude-opus-4-6",
+      "display_name": "Claude Opus 4.6",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -134,6 +143,7 @@
     {
       "provider": "anthropic",
       "model": "claude-opus-4-7",
+      "display_name": "Claude Opus 4.7",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -150,6 +160,7 @@
     {
       "provider": "anthropic",
       "model": "claude-opus-4-8",
+      "display_name": "Claude Opus 4.8",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -166,6 +177,7 @@
     {
       "provider": "anthropic",
       "model": "claude-opus-5",
+      "display_name": "Claude Opus 5",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -182,6 +194,7 @@
     {
       "provider": "anthropic",
       "model": "claude-sonnet-4-0",
+      "display_name": "Claude Sonnet 4",
       "family": "sonnet",
       "rank": 40,
       "maturity": "stable",
@@ -196,6 +209,7 @@
     {
       "provider": "anthropic",
       "model": "claude-sonnet-4-5",
+      "display_name": "Claude Sonnet 4.5",
       "context_window": 200000,
       "max_output": 64000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -212,6 +226,7 @@
     {
       "provider": "anthropic",
       "model": "claude-sonnet-4-6",
+      "display_name": "Claude Sonnet 4.6",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -228,6 +243,7 @@
     {
       "provider": "anthropic",
       "model": "claude-sonnet-5",
+      "display_name": "Claude Sonnet 5",
       "context_window": 1000000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -244,6 +260,7 @@
     {
       "provider": "cohere",
       "model": "command-a-03-2025",
+      "display_name": "Command A",
       "context_window": 256000,
       "max_output": 8000,
       "capabilities": ["tools"],
@@ -256,6 +273,7 @@
     {
       "provider": "cohere",
       "model": "command-r",
+      "display_name": "Command R",
       "context_window": 128000,
       "max_output": 4000,
       "capabilities": ["tools"],
@@ -269,6 +287,7 @@
     {
       "provider": "cohere",
       "model": "command-r-08-2024",
+      "display_name": "Command R",
       "context_window": 128000,
       "max_output": 4000,
       "capabilities": ["tools"],
@@ -281,6 +300,7 @@
     {
       "provider": "cohere",
       "model": "command-r-plus",
+      "display_name": "Command R+",
       "context_window": 128000,
       "max_output": 4000,
       "capabilities": ["tools"],
@@ -294,6 +314,7 @@
     {
       "provider": "cohere",
       "model": "command-r-plus-08-2024",
+      "display_name": "Command R+",
       "context_window": 128000,
       "max_output": 4000,
       "capabilities": ["tools"],
@@ -306,6 +327,7 @@
     {
       "provider": "cohere",
       "model": "command-r7b",
+      "display_name": "Command R7B",
       "input_per_m": 0.0375,
       "output_per_m": 0.15,
       "source": "https://docs.cohere.com/docs/models",
@@ -315,6 +337,7 @@
     {
       "provider": "cohere",
       "model": "command-r7b-12-2024",
+      "display_name": "Command R7B",
       "context_window": 128000,
       "max_output": 4000,
       "capabilities": ["tools"],
@@ -343,6 +366,7 @@
     {
       "provider": "deepseek",
       "model": "deepseek-v4-flash",
+      "display_name": "DeepSeek-V4-Flash-0731",
       "context_window": 1000000,
       "max_output": 384000,
       "capabilities": ["tools", "reasoning"],
@@ -355,6 +379,7 @@
     {
       "provider": "deepseek",
       "model": "deepseek-v4-pro",
+      "display_name": "DeepSeek-V4-Pro-0813",
       "context_window": 1000000,
       "max_output": 384000,
       "capabilities": ["tools", "reasoning"],
@@ -367,6 +392,7 @@
     {
       "provider": "deepseek",
       "model": "deepseek-v4-pro-0813",
+      "display_name": "DeepSeek-V4-Pro-0813",
       "context_window": 1000000,
       "max_output": 384000,
       "capabilities": ["tools", "reasoning"],
@@ -379,6 +405,7 @@
     {
       "provider": "gemini",
       "model": "gemini-2.0-flash",
+      "display_name": "Gemini 2.0 Flash",
       "context_window": 1048576,
       "max_output": 8192,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -392,6 +419,7 @@
     {
       "provider": "gemini",
       "model": "gemini-2.5-flash",
+      "display_name": "Gemini 2.5 Flash",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -404,6 +432,7 @@
     {
       "provider": "gemini",
       "model": "gemini-2.5-flash-lite",
+      "display_name": "Gemini 2.5 Flash-Lite",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -416,6 +445,7 @@
     {
       "provider": "gemini",
       "model": "gemini-2.5-pro",
+      "display_name": "Gemini 2.5 Pro",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -428,6 +458,7 @@
     {
       "provider": "gemini",
       "model": "gemini-3-flash-preview",
+      "display_name": "Gemini 3 Flash",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -440,6 +471,7 @@
     {
       "provider": "gemini",
       "model": "gemini-3.1-flash-lite",
+      "display_name": "Gemini 3.1 Flash-Lite",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -465,6 +497,7 @@
     {
       "provider": "gemini",
       "model": "gemini-3.1-pro-preview",
+      "display_name": "Gemini 3.1 Pro",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -486,6 +519,7 @@
     {
       "provider": "gemini",
       "model": "gemini-3.5-flash",
+      "display_name": "Gemini 3.5 Flash",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -498,6 +532,7 @@
     {
       "provider": "gemini",
       "model": "gemini-3.5-flash-lite",
+      "display_name": "Gemini 3.5 Flash-Lite",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -510,6 +545,7 @@
     {
       "provider": "gemini",
       "model": "gemini-3.6-flash",
+      "display_name": "Gemini 3.6 Flash",
       "context_window": 1048576,
       "max_output": 65536,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -571,6 +607,7 @@
     {
       "provider": "grok",
       "model": "grok-4.3",
+      "display_name": "Grok 4.3",
       "context_window": 1000000,
       "capabilities": ["tools", "vision", "reasoning"],
       "input_per_m": 1.25,
@@ -582,6 +619,7 @@
     {
       "provider": "grok",
       "model": "grok-4.5",
+      "display_name": "Grok 4.5",
       "context_window": 500000,
       "capabilities": ["tools", "vision", "reasoning"],
       "input_per_m": 2,
@@ -593,6 +631,7 @@
     {
       "provider": "grok",
       "model": "grok-4.6",
+      "display_name": "Grok 4.6",
       "context_window": 500000,
       "capabilities": ["tools", "vision", "reasoning"],
       "input_per_m": 2,
@@ -615,6 +654,7 @@
     {
       "provider": "minimax",
       "model": "MiniMax-M2",
+      "display_name": "MiniMax-M2",
       "context_window": 204800,
       "capabilities": ["tools", "reasoning"],
       "input_per_m": 0.3,
@@ -625,6 +665,7 @@
     {
       "provider": "minimax",
       "model": "MiniMax-M2.1",
+      "display_name": "MiniMax-M2.1",
       "context_window": 204800,
       "capabilities": ["tools", "reasoning"],
       "input_per_m": 0.3,
@@ -635,6 +676,7 @@
     {
       "provider": "minimax",
       "model": "MiniMax-M2.5",
+      "display_name": "MiniMax-M2.5",
       "context_window": 204800,
       "capabilities": ["tools", "reasoning"],
       "input_per_m": 0.3,
@@ -645,6 +687,7 @@
     {
       "provider": "minimax",
       "model": "MiniMax-M2.7",
+      "display_name": "MiniMax-M2.7",
       "context_window": 204800,
       "capabilities": ["tools", "reasoning"],
       "input_per_m": 0.3,
@@ -655,6 +698,7 @@
     {
       "provider": "minimax",
       "model": "MiniMax-M2.7-highspeed",
+      "display_name": "MiniMax-M2.7-highspeed",
       "context_window": 204800,
       "capabilities": ["tools", "reasoning"],
       "input_per_m": 0.6,
@@ -665,6 +709,7 @@
     {
       "provider": "minimax",
       "model": "MiniMax-M3",
+      "display_name": "MiniMax-M3",
       "context_window": 1000000,
       "capabilities": ["tools", "vision", "reasoning"],
       "input_per_m": 0.3,
@@ -675,6 +720,7 @@
     {
       "provider": "mistral",
       "model": "codestral",
+      "display_name": "Codestral",
       "capabilities": ["tools"],
       "input_per_m": 0.3,
       "output_per_m": 0.9,
@@ -685,6 +731,7 @@
     {
       "provider": "mistral",
       "model": "magistral-medium",
+      "display_name": "Magistral Medium",
       "capabilities": ["tools", "reasoning"],
       "input_per_m": 2,
       "output_per_m": 5,
@@ -695,6 +742,7 @@
     {
       "provider": "mistral",
       "model": "ministral-3-14b-2512",
+      "display_name": "Ministral 3 14B",
       "capabilities": ["tools", "vision"],
       "input_per_m": 0.2,
       "output_per_m": 0.2,
@@ -705,6 +753,7 @@
     {
       "provider": "mistral",
       "model": "ministral-3-3b-2512",
+      "display_name": "Ministral 3 3B",
       "capabilities": ["tools", "vision"],
       "input_per_m": 0.1,
       "output_per_m": 0.1,
@@ -715,6 +764,7 @@
     {
       "provider": "mistral",
       "model": "ministral-3-8b-2512",
+      "display_name": "Ministral 3 8B",
       "capabilities": ["tools", "vision"],
       "input_per_m": 0.15,
       "output_per_m": 0.15,
@@ -725,6 +775,7 @@
     {
       "provider": "mistral",
       "model": "ministral-8b",
+      "display_name": "Ministral 8B",
       "deprecated": true,
       "input_per_m": 0.1,
       "output_per_m": 0.1,
@@ -735,6 +786,7 @@
     {
       "provider": "mistral",
       "model": "mistral-large-3",
+      "display_name": "Mistral Large 3",
       "capabilities": ["tools", "vision"],
       "input_per_m": 0.5,
       "output_per_m": 1.5,
@@ -745,6 +797,7 @@
     {
       "provider": "mistral",
       "model": "mistral-medium-3",
+      "display_name": "Mistral Medium 3",
       "input_per_m": 0.4,
       "output_per_m": 2,
       "source": "https://docs.mistral.ai/getting-started/models/models_overview/",
@@ -754,6 +807,7 @@
     {
       "provider": "mistral",
       "model": "mistral-medium-3-1-2508",
+      "display_name": "Mistral Medium 3.1",
       "capabilities": ["tools", "vision"],
       "deprecated": true,
       "input_per_m": 0.4,
@@ -765,6 +819,7 @@
     {
       "provider": "mistral",
       "model": "mistral-medium-3-5-2604",
+      "display_name": "Mistral Medium 3.5",
       "capabilities": ["tools", "vision", "reasoning"],
       "input_per_m": 1.5,
       "output_per_m": 7.5,
@@ -775,6 +830,7 @@
     {
       "provider": "mistral",
       "model": "mistral-nemo",
+      "display_name": "Mistral Nemo 12B",
       "deprecated": true,
       "input_per_m": 0.02,
       "output_per_m": 0.04,
@@ -795,6 +851,7 @@
     {
       "provider": "mistral",
       "model": "mistral-small-2603",
+      "display_name": "Mistral Small 4",
       "capabilities": ["tools", "reasoning"],
       "input_per_m": 0.1,
       "output_per_m": 0.3,
@@ -805,6 +862,7 @@
     {
       "provider": "moonshot",
       "model": "kimi-k3",
+      "display_name": "Kimi K3",
       "context_window": 1000000,
       "capabilities": ["tools", "vision", "reasoning"],
       "input_per_m": 3,
@@ -816,6 +874,7 @@
     {
       "provider": "openai",
       "model": "gpt-4.1",
+      "display_name": "GPT-4.1",
       "context_window": 1047576,
       "max_output": 32768,
       "capabilities": ["tools", "vision"],
@@ -828,6 +887,7 @@
     {
       "provider": "openai",
       "model": "gpt-4.1-mini",
+      "display_name": "GPT-4.1 mini",
       "context_window": 1047576,
       "max_output": 32768,
       "capabilities": ["tools", "vision"],
@@ -840,6 +900,7 @@
     {
       "provider": "openai",
       "model": "gpt-4.1-nano",
+      "display_name": "GPT-4.1 nano",
       "context_window": 1047576,
       "max_output": 32768,
       "capabilities": ["tools", "vision"],
@@ -852,6 +913,7 @@
     {
       "provider": "openai",
       "model": "gpt-4o",
+      "display_name": "GPT-4o",
       "context_window": 128000,
       "max_output": 16384,
       "capabilities": ["tools", "vision"],
@@ -864,6 +926,7 @@
     {
       "provider": "openai",
       "model": "gpt-4o-mini",
+      "display_name": "GPT-4o mini",
       "context_window": 128000,
       "max_output": 16384,
       "capabilities": ["tools", "vision"],
@@ -876,6 +939,7 @@
     {
       "provider": "openai",
       "model": "gpt-5",
+      "display_name": "GPT-5",
       "context_window": 272000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -888,6 +952,7 @@
     {
       "provider": "openai",
       "model": "gpt-5-mini",
+      "display_name": "GPT-5 mini",
       "context_window": 272000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -900,6 +965,7 @@
     {
       "provider": "openai",
       "model": "gpt-5-nano",
+      "display_name": "GPT-5 nano",
       "context_window": 272000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -912,6 +978,7 @@
     {
       "provider": "openai",
       "model": "gpt-5-pro",
+      "display_name": "GPT-5 Pro",
       "context_window": 400000,
       "max_output": 272000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -924,6 +991,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.1",
+      "display_name": "GPT-5.1",
       "context_window": 400000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -936,6 +1004,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.2",
+      "display_name": "GPT-5.2",
       "context_window": 400000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -951,6 +1020,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.2-pro",
+      "display_name": "GPT-5.2 Pro",
       "context_window": 400000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -963,6 +1033,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.3-codex",
+      "display_name": "GPT-5.3-Codex",
       "context_window": 272000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -975,6 +1046,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.4",
+      "display_name": "GPT-5.4",
       "context_window": 1050000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -987,6 +1059,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.4-mini",
+      "display_name": "GPT-5.4 mini",
       "context_window": 272000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -999,6 +1072,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.4-nano",
+      "display_name": "GPT-5.4 nano",
       "context_window": 272000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1011,6 +1085,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.4-pro",
+      "display_name": "GPT-5.4 Pro",
       "context_window": 1050000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1023,6 +1098,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.5",
+      "display_name": "GPT-5.5",
       "context_window": 1050000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1035,6 +1111,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.5-pro",
+      "display_name": "GPT-5.5 Pro",
       "context_window": 1050000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1047,6 +1124,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.6-luna",
+      "display_name": "GPT-5.6 Luna",
       "context_window": 922000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1059,6 +1137,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.6-sol",
+      "display_name": "GPT-5.6 Sol",
       "context_window": 922000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1071,6 +1150,7 @@
     {
       "provider": "openai",
       "model": "gpt-5.6-terra",
+      "display_name": "GPT-5.6 Terra",
       "context_window": 922000,
       "max_output": 128000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1083,6 +1163,7 @@
     {
       "provider": "openai",
       "model": "o3",
+      "display_name": "o3",
       "context_window": 200000,
       "max_output": 100000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1095,6 +1176,7 @@
     {
       "provider": "openai",
       "model": "o3-mini",
+      "display_name": "o3-mini",
       "context_window": 200000,
       "max_output": 100000,
       "capabilities": ["tools", "reasoning"],
@@ -1107,6 +1189,7 @@
     {
       "provider": "openai",
       "model": "o3-pro",
+      "display_name": "o3-pro",
       "context_window": 200000,
       "max_output": 100000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1119,6 +1202,7 @@
     {
       "provider": "openai",
       "model": "o4-mini",
+      "display_name": "o4-mini",
       "context_window": 200000,
       "max_output": 100000,
       "capabilities": ["tools", "vision", "reasoning"],
@@ -1161,6 +1245,7 @@
     {
       "provider": "zai",
       "model": "glm-4.5",
+      "display_name": "GLM-4.5",
       "context_window": 131072,
       "max_output": 98304,
       "capabilities": ["tools", "reasoning"],
@@ -1173,6 +1258,7 @@
     {
       "provider": "zai",
       "model": "glm-4.5-air",
+      "display_name": "GLM-4.5-Air",
       "context_window": 131072,
       "max_output": 98304,
       "capabilities": ["tools", "reasoning"],
@@ -1185,6 +1271,7 @@
     {
       "provider": "zai",
       "model": "glm-4.5-airx",
+      "display_name": "GLM-4.5-AirX",
       "context_window": 131072,
       "max_output": 98304,
       "capabilities": ["tools", "reasoning"],
@@ -1197,6 +1284,7 @@
     {
       "provider": "zai",
       "model": "glm-4.5-flash",
+      "display_name": "GLM-4.5-Flash",
       "context_window": 131072,
       "max_output": 98304,
       "capabilities": ["tools", "reasoning"],
@@ -1207,6 +1295,7 @@
     {
       "provider": "zai",
       "model": "glm-4.5-x",
+      "display_name": "GLM-4.5-X",
       "context_window": 131072,
       "max_output": 98304,
       "capabilities": ["tools", "reasoning"],
@@ -1219,6 +1308,7 @@
     {
       "provider": "zai",
       "model": "glm-4.6",
+      "display_name": "GLM-4.6",
       "context_window": 204800,
       "max_output": 131072,
       "capabilities": ["tools", "reasoning"],
@@ -1231,6 +1321,7 @@
     {
       "provider": "zai",
       "model": "glm-4.7",
+      "display_name": "GLM-4.7",
       "context_window": 204800,
       "max_output": 131072,
       "capabilities": ["tools", "reasoning"],
@@ -1243,6 +1334,7 @@
     {
       "provider": "zai",
       "model": "glm-4.7-flash",
+      "display_name": "GLM-4.7-Flash",
       "context_window": 204800,
       "max_output": 131072,
       "capabilities": ["tools", "reasoning"],
@@ -1253,6 +1345,7 @@
     {
       "provider": "zai",
       "model": "glm-4.7-flashx",
+      "display_name": "GLM-4.7-FlashX",
       "context_window": 204800,
       "max_output": 131072,
       "capabilities": ["tools", "reasoning"],
@@ -1265,6 +1358,7 @@
     {
       "provider": "zai",
       "model": "glm-5",
+      "display_name": "GLM-5",
       "context_window": 204800,
       "max_output": 131072,
       "capabilities": ["tools", "reasoning"],
@@ -1277,6 +1371,7 @@
     {
       "provider": "zai",
       "model": "glm-5-turbo",
+      "display_name": "GLM-5-Turbo",
       "context_window": 204800,
       "max_output": 131072,
       "capabilities": ["tools", "reasoning"],
@@ -1289,6 +1384,7 @@
     {
       "provider": "zai",
       "model": "glm-5.1",
+      "display_name": "GLM-5.1",
       "context_window": 204800,
       "max_output": 131072,
       "capabilities": ["tools", "reasoning"],
@@ -1301,6 +1397,7 @@
     {
       "provider": "zai",
       "model": "glm-5.2",
+      "display_name": "GLM-5.2",
       "context_window": 1048576,
       "max_output": 131072,
       "capabilities": ["tools", "reasoning"],

--- a/pricing/prices_test.go
+++ b/pricing/prices_test.go
@@ -26,6 +26,32 @@ func TestCatalogProvenance(t *testing.T) {
 	}
 }
 
+// TestDisplayNameLoads verifies the optional display_name field (#285) plumbs
+// through the loader to ModelPrice, and that a verified name carries its exact
+// provider branding.
+func TestDisplayNameLoads(t *testing.T) {
+	cases := map[string]string{
+		"claude-opus-4-8": "Claude Opus 4.8",
+		"gpt-4o":          "GPT-4o",
+		"command-r-plus":  "Command R+",
+		"glm-4.5-airx":    "GLM-4.5-AirX",
+	}
+	for model, want := range cases {
+		p, ok := Lookup(model)
+		if !ok {
+			t.Errorf("%s not found", model)
+			continue
+		}
+		if p.DisplayName != want {
+			t.Errorf("%s DisplayName = %q, want %q", model, p.DisplayName, want)
+		}
+	}
+	// A model without a verified name leaves DisplayName empty (unknown, not "").
+	if p, ok := Lookup("qwen3.7-max"); ok && p.DisplayName != "" {
+		t.Errorf("unverified qwen3.7-max should have empty DisplayName, got %q", p.DisplayName)
+	}
+}
+
 func TestLookupExactAndFold(t *testing.T) {
 	// Exact.
 	if _, ok := Lookup("claude-opus-5"); !ok {

--- a/pricing/pricing.go
+++ b/pricing/pricing.go
@@ -47,6 +47,10 @@ type ModelPrice struct {
 	ContextWindow int      // max input context window in tokens
 	MaxOutput     int      // max output tokens per response
 	Capabilities  []string // e.g. "tools", "vision", "reasoning"
+
+	// Human-facing product name (optional; #285), verified from Source. Empty =
+	// unknown; a consumer derives from the id or overlays its own.
+	DisplayName string // e.g. "Claude Opus 4.8", "GPT-4o", "Command R+"
 }
 
 // Usage is a neutral token-count struct so the one Cost implementation serves

--- a/site/content/models.md
+++ b/site/content/models.md
@@ -38,6 +38,7 @@ Each entry describes one model and its published price:
 | --- | --- |
 | `provider` | Canonical provider name |
 | `model` | Model identifier |
+| `display_name` | Optional human-facing product name, verified from `source` (e.g. `GPT-4o`, `Command R+`) — absent means unknown |
 | `input_per_m` | Input price per million tokens |
 | `output_per_m` | Output price per million tokens |
 | `source` | URL of the official provider page the price was read from |
@@ -94,6 +95,7 @@ Beyond price, an entry can carry optional metadata so a consumer can derive its 
 
 - **`family` / `rank` / `maturity`** — the family a model belongs to (e.g. `opus`), its ordering within that family (`rank`, higher = newer), and `stable`/`preview`. This lets a consumer resolve a *family reference* to a concrete model without string-parsing irregular IDs — newest-in-family, one release back, and so on. Resolution deliberately excludes deprecated, unpriced, and preview models, so it can never land on a retired or unpriced model. Go consumers can call `pricing.ResolveAlias(provider, family, selector)` (`latest`/`sota` = newest eligible, `stable` = one release back); a JSON consumer resolves from these fields directly.
 - **`context_window` / `max_output` / `capabilities`** — max input context tokens, max output tokens, and capability tags (`tools`, `vision`, `reasoning`). Absent means **unknown**, never a claim of zero. Populated in verified per-provider batches.
+- **`display_name`** — the model's human-facing product name as the provider writes it (`GPT-4o`, `Command R+`, `GLM-4.5-AirX`), verified against the same official page in `source` — so a UI can label a model without title-casing the id (which loses branding) or hand-maintaining a parallel name table. Absent means **unknown**; a consumer derives from the id or overlays its own.
 
 ### Model families / aliases
 
@@ -125,7 +127,7 @@ Because pricing lives in the same embedded catalog the validator uses, `dippin c
 
 ## Use the catalog in your own tools
 
-The full catalog is published as consumable JSON at **[`/prices.json`](/prices.json)** (also aliased as **[`/models.json`](/models.json)** — the catalog carries more than prices) — the exact file dippin embeds, refreshed on every deploy, and served with `Access-Control-Allow-Origin: *` so you can fetch it straight from a browser. A JSON Schema for the shape is published at **[`/models.schema.json`](/models.schema.json)**. Each entry carries `provider`, `model`, `input_per_m` / `output_per_m` (USD per million tokens), optional cache fields (`cache_read_mult` / `cache_write_mult`, or an absolute `cached_input_per_m`), the `priced` / `deprecated` flags, optional drift metadata (`family` / `rank` / `maturity`) and capability metadata (`context_window` / `max_output` / `capabilities`), and provenance (`source` URL + `as_of` date). A top-level `provider_aliases` map resolves shorthand names (e.g. `xai` → `grok`) to canonical providers.
+The full catalog is published as consumable JSON at **[`/prices.json`](/prices.json)** (also aliased as **[`/models.json`](/models.json)** — the catalog carries more than prices) — the exact file dippin embeds, refreshed on every deploy, and served with `Access-Control-Allow-Origin: *` so you can fetch it straight from a browser. A JSON Schema for the shape is published at **[`/models.schema.json`](/models.schema.json)**. Each entry carries `provider`, `model`, an optional human-facing `display_name`, `input_per_m` / `output_per_m` (USD per million tokens), optional cache fields (`cache_read_mult` / `cache_write_mult`, or an absolute `cached_input_per_m`), the `priced` / `deprecated` flags, optional drift metadata (`family` / `rank` / `maturity`) and capability metadata (`context_window` / `max_output` / `capabilities`), and provenance (`source` URL + `as_of` date). A top-level `provider_aliases` map resolves shorthand names (e.g. `xai` → `grok`) to canonical providers.
 
 ```sh
 curl -s https://dippin.org/prices.json | jq '.models[] | select(.provider == "anthropic")'

--- a/site/static/models.schema.json
+++ b/site/static/models.schema.json
@@ -24,6 +24,7 @@
       "properties": {
         "provider": { "type": "string", "description": "Canonical provider name." },
         "model": { "type": "string", "description": "Model identifier. Dotted and dashed forms are equivalent." },
+        "display_name": { "type": "string", "description": "Human-facing product name, verified from source (e.g. 'Claude Opus 4.8', 'GPT-4o', 'Command R+'). Absent = unknown; derive from the id or overlay." },
         "aliases": { "type": "array", "items": { "type": "string" }, "description": "Alternate model spellings that resolve to this entry." },
         "input_per_m": { "type": "number", "description": "Input price, USD per 1M tokens." },
         "output_per_m": { "type": "number", "description": "Output price, USD per 1M tokens." },


### PR DESCRIPTION
Closes #285. Adds an optional **`display_name`** field to each catalog entry — the model's human-facing product name as the provider writes it (`GPT-4o`, `Command R+`, `GLM-4.5-AirX`), verified against the same official page the entry already cites in `source`. Absent = **unknown** (consumer derives from the id or overlays its own), consistent with the capability fields.

## Why
tracker#570's `ListModels()` still walks a hand-maintained identity catalog largely for display names. dippin had no source for them (id + alternate *spellings* only). #267 delivered capability metadata but never names — the dependency was mis-attributed to it. This is the field that actually unblocks it.

## Coverage
Populated **97/111** models across all 11 providers, verified per-provider against official docs. The **14** left unknown have no confirmable name on a current official page — honest gaps, not guesses:
- grok: `grok-4-1-fast-*`, `grok-4.20-*` snapshots, `grok-build-0.1`
- deepseek: `deepseek-chat` / `deepseek-reasoner` (rolling aliases, delisted)
- gemini: `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview-customtools`
- mistral: bare `mistral-small`
- qwen: all three (official pages expose only lowercase ids)

## Shape
Plumbs `fileEntry → pricing.ModelPrice`, published in `/models.schema.json`, documented on the Models & Pricing page. Diff is **purely additive** (97 insertions, 0 deletions in `prices.json`). New test asserts the field loads with exact branding and stays empty when unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789931862&installation_model_id=21126&pr_number=286&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F286&signature=5d6b04499b39c85ee53f0aeb5f619178fb0fef3fc276d59409a830786eb1553c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional human-readable display names for verified models across the pricing catalog.
  * Display names are available through model pricing data and the public model catalog.

* **Documentation**
  * Documented the `display_name` field, including its verification and fallback behavior.
  * Updated the public catalog schema to include the optional field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->