### PR TITLE
release: v0.68.0 — verified display_name in the model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ## [Unreleased]
 
+## [v0.68.0] — 2026-08-21
+
+### Added
+- **Verified `display_name` in the model catalog** ([#285](https://github.com/2389-research/dippin-lang/issues/285)). Each catalog entry can now carry the model's human-facing product name exactly as the provider writes it (`GPT-4o`, `Command R+`, `GLM-4.5-AirX`), verified against the same official page the entry cites in `source`. Populated for **97/111** models across all 11 providers; the rest have no confirmable name on a current official page and are left `unknown` (absent, never guessed). Plumbs through `pricing.ModelPrice.DisplayName`, published in `/models.schema.json`, documented on the Models & Pricing page. This lets a consumer label a model without title-casing the id (which loses branding) or hand-maintaining a parallel name table — closing the last gap that blocked retiring a downstream identity catalog.
+
+### Changed
+- Refreshed stale pricing verifications and suppressed a Gemini 3.6 Flash intro-rate drift ([#284](https://github.com/2389-research/dippin-lang/issues/284)).
+
 ## [v0.67.0] — 2026-08-12
 
 ### Added

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -4,6 +4,14 @@ description: "Version history and release notes for dippin-lang."
 navActive: "changelog"
 layout: "changelog"
 ---
+## [v0.68.0] — 2026-08-21
+
+### Added
+- **Verified `display_name` in the model catalog** ([#285](https://github.com/2389-research/dippin-lang/issues/285)). Each catalog entry can now carry the model's human-facing product name exactly as the provider writes it (`GPT-4o`, `Command R+`, `GLM-4.5-AirX`), verified against the same official page the entry cites in `source`. Populated for **97/111** models across all 11 providers; the rest have no confirmable name on a current official page and are left `unknown` (absent, never guessed). Plumbs through `pricing.ModelPrice.DisplayName`, published in `/models.schema.json`, documented on the Models & Pricing page. This lets a consumer label a model without title-casing the id (which loses branding) or hand-maintaining a parallel name table — closing the last gap that blocked retiring a downstream identity catalog.
+
+### Changed
+- Refreshed stale pricing verifications and suppressed a Gemini 3.6 Flash intro-rate drift ([#284](https://github.com/2389-research/dippin-lang/issues/284)).
+
 ## [v0.67.0] — 2026-08-12
 
 ### Added


### PR DESCRIPTION
CHANGELOG + generated site changelog for **v0.68.0**. Bundles what merged since v0.67.0:

- **#285** — verified `display_name` on catalog entries (97/111 populated, all 11 providers), unblocks the display-name half of tracker#570.
- **#284** — refreshed stale pricing verifications + Gemini 3.6 Flash intro-rate drift suppression.

Tag is pushed after this merges; GoReleaser builds binaries + Homebrew and Netlify redeploys (republishing `/prices.json`, `/models.json`, `/models.schema.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789932011&installation_model_id=21126&pr_number=287&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F287&signature=af300c6d29d41730166d1057a978b297d2c362ce19f849ee3bddb497bed95005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->