### PR TITLE
fix(pricing-sync): surface new upstream models in the daily drift Action

### DIFF
--- a/.github/workflows/pricing-sync.yml
+++ b/.github/workflows/pricing-sync.yml
@@ -56,8 +56,27 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: New-model report (upstream models missing from the catalog)
+        id: new
+        run: |
+          # The complement of --existing-only. Without this the job could only
+          # ever see price drift on models we already carry, so newly released
+          # models were invisible — the catalog silently fell two Gemini Flash
+          # releases behind while this job reported success every morning.
+          # --new-only filters to text models on priced providers, dropping
+          # non-text modalities, 0/0-priced entries and dated/preview snapshots
+          # of models we already carry.
+          set +e
+          go run ./cmd/pricing-sync sync --new-only --tolerance 0.02 > new.txt 2>&1
+          cat new.txt
+          if grep -qE '^\s+\[' new.txt; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upsert drift issue
-        if: steps.drift.outputs.changed == 'true'
+        if: steps.drift.outputs.changed == 'true' || steps.new.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -65,7 +84,7 @@ jobs:
           # Assemble the issue body from the tool's own output files (trusted;
           # no github.event.* input is used anywhere in this workflow).
           {
-            echo "Automated daily check found **price or deprecation drift** for models already in \`pricing/prices.json\`, and/or entries overdue for re-verification."
+            echo "Automated daily check found **price or deprecation drift**, **new upstream models** missing from \`pricing/prices.json\`, and/or entries overdue for re-verification."
             echo
             echo "> ⚠️ **Human-gated.** Confirm each candidate against the model's official \`source\` URL before editing \`pricing/prices.json\`. models.dev is a detection aid, not an authority — it can reflect introductory or discounted rates (an intro price vs. the durable list price)."
             echo
@@ -74,6 +93,11 @@ jobs:
             echo '### Price / deprecation drift (`sync --existing-only --tolerance 0.02`)'
             echo '```'
             cat drift.txt
+            echo '```'
+            echo
+            echo '### New upstream models (`sync --new-only`)'
+            echo '```'
+            cat new.txt
             echo '```'
             echo
             echo '### Staleness (`check`)'

--- a/.github/workflows/pricing-sync.yml
+++ b/.github/workflows/pricing-sync.yml
@@ -46,8 +46,17 @@ jobs:
           # --existing-only keeps the signal actionable: price and deprecation
           # drift for models we already carry, not the hundreds of upstream
           # image/tts/embedding models we don't price.
-          set +e
-          go run ./cmd/pricing-sync sync --existing-only --tolerance 0.02 > drift.txt 2>&1
+          # Do NOT swallow a nonzero exit. pricing-sync only exits nonzero on a
+          # genuine failure (fetch/parse error, bad suppressions file, bad
+          # flags) — finding candidates is exit 0 unless --fail-on-changes. If
+          # the tool fails, the error text lands in drift.txt, the candidate
+          # grep matches nothing and the job would record changed=false and go
+          # green while detecting nothing. Fail loudly instead.
+          if ! go run ./cmd/pricing-sync sync --existing-only --tolerance 0.02 > drift.txt 2>&1; then
+            cat drift.txt
+            echo "::error::pricing-sync sync --existing-only failed; drift detection did not run"
+            exit 1
+          fi
           cat drift.txt
           # A candidate line is indented and starts with "[".
           if grep -qE '^\s+\[' drift.txt; then
@@ -66,8 +75,14 @@ jobs:
           # --new-only filters to text models on priced providers, dropping
           # non-text modalities, 0/0-priced entries and dated/preview snapshots
           # of models we already carry.
-          set +e
-          go run ./cmd/pricing-sync sync --new-only --tolerance 0.02 > new.txt 2>&1
+          # Same failure-propagation rule as the drift step above: a silent
+          # green run that detects nothing is the exact bug this step exists to
+          # fix, so a tool failure must fail the job.
+          if ! go run ./cmd/pricing-sync sync --new-only --tolerance 0.02 > new.txt 2>&1; then
+            cat new.txt
+            echo "::error::pricing-sync sync --new-only failed; new-model detection did not run"
+            exit 1
+          fi
           cat new.txt
           if grep -qE '^\s+\[' new.txt; then
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/Justfile
+++ b/Justfile
@@ -176,3 +176,8 @@ check-prices:
 # Diff the catalog against models.dev and report candidate changes (report-only)
 sync-prices:
     go run ./cmd/pricing-sync sync
+
+# Report only NEW upstream models missing from the catalog (what the daily
+# Action's new-model section runs). Filtered to actionable text-model adds.
+new-prices:
+    go run ./cmd/pricing-sync sync --new-only --tolerance 0.02

--- a/cmd/pricing-sync/newfilter.go
+++ b/cmd/pricing-sync/newfilter.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/2389-research/dippin-lang/pricing"
+)
+
+// nonTextMarker matches model-ID substrings for modalities the catalog does not
+// price. The catalog prices *text* generation per MTok; image, speech, video,
+// music and embedding models bill in a different unit, so proposing them as
+// catalog adds is pure noise.
+//
+// Deliberately absent: "vision", "vl", "omni". Those are text models with a
+// non-text *input* — they still bill text tokens and belong in the catalog.
+var nonTextMarker = []string{
+	"image", "-tts", "tts-", "embedding", "embed-", "-embed",
+	"realtime", "-live", "live-", "asr", "-ocr", "voxtral",
+	"veo-", "lyria-", "whisper", "-audio", "audio-", "speech",
+	"moderation", "rerank",
+}
+
+// snapshotSuffix strips a trailing dated-snapshot marker so a model can be
+// compared against its undated catalog entry: "-20251001" (YYYYMMDD),
+// "-05-2026" (MM-YYYY), or a trailing "-preview"/"-latest" marker.
+var snapshotSuffix = regexp.MustCompile(`(?:-\d{8}|-\d{2}-\d{4}|-preview|-latest)$`)
+
+// filterNew reduces raw "new" candidates to the actionable signal: text models
+// on providers we actually price, that are not just a redundant naming variant
+// of an entry the catalog already carries.
+//
+// Without this, models.dev's ~170 upstream-only models drown the daily report
+// and the job goes unread — which is how the catalog fell two Gemini Flash
+// releases behind while the Action reported "success" every morning.
+func filterNew(changes []change) []change {
+	unpriced := unpricedProviders()
+	var out []change
+	for _, c := range changes {
+		if c.Kind == "new" && actionableNew(c, unpriced) {
+			out = append(out, c)
+		}
+	}
+	return dedupe(out)
+}
+
+// dedupe collapses rows identical in provider+model+aggregator value. models.dev
+// exposes some providers under several ids that map to one canonical key of
+// ours (zai/zhipuai/z-ai), which otherwise reports the same model twice.
+// Rows that agree on the model but disagree on price are kept — that
+// disagreement is signal, not duplication.
+func dedupe(changes []change) []change {
+	seen := map[change]bool{}
+	var out []change
+	for _, c := range changes {
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	return out
+}
+
+func actionableNew(c change, unpriced map[string]bool) bool {
+	if unpriced[c.Provider] || c.Agg == "0/0" {
+		return false
+	}
+	return isTextModel(c.Model) && !variantOfCataloged(c.Provider, c.Model)
+}
+
+// unpricedProviders lists providers whose every catalog entry is priced:false
+// (e.g. Qwen, whose USD rates are console-gated and unverifiable). Derived from
+// the catalog rather than hardcoded, so it self-corrects once one is priced.
+func unpricedProviders() map[string]bool {
+	out := map[string]bool{}
+	for provider, models := range pricing.Providers() {
+		if !anyPriced(models) {
+			out[provider] = true
+		}
+	}
+	return out
+}
+
+func anyPriced(models map[string]pricing.ModelPrice) bool {
+	for _, p := range models {
+		if p.Priced {
+			return true
+		}
+	}
+	return false
+}
+
+func isTextModel(model string) bool {
+	id := strings.ToLower(model)
+	for _, marker := range nonTextMarker {
+		if strings.Contains(id, marker) {
+			return false
+		}
+	}
+	return true
+}
+
+// variantOfCataloged reports whether the model is a dated snapshot or
+// preview/latest alias of an entry the catalog already carries — covered, not
+// new (e.g. claude-haiku-4-5-20251001 vs. our claude-haiku-4-5).
+func variantOfCataloged(provider, model string) bool {
+	for base := model; ; {
+		trimmed := snapshotSuffix.ReplaceAllString(base, "")
+		if trimmed == base {
+			return false
+		}
+		if _, found := pricing.LookupProvider(provider, trimmed); found {
+			return true
+		}
+		base = trimmed
+	}
+}

--- a/cmd/pricing-sync/newfilter.go
+++ b/cmd/pricing-sync/newfilter.go
@@ -23,8 +23,9 @@ var nonTextMarker = []string{
 
 // snapshotSuffix strips a trailing dated-snapshot marker so a model can be
 // compared against its undated catalog entry: "-20251001" (YYYYMMDD),
-// "-05-2026" (MM-YYYY), or a trailing "-preview"/"-latest" marker.
-var snapshotSuffix = regexp.MustCompile(`(?:-\d{8}|-\d{2}-\d{4}|-preview|-latest)$`)
+// "-2024-08-06" (ISO, OpenAI's convention), "-05-2026" (MM-YYYY), or a trailing
+// "-preview"/"-latest" marker.
+var snapshotSuffix = regexp.MustCompile(`(?:-\d{8}|-\d{4}-\d{2}-\d{2}|-\d{2}-\d{4}|-preview|-latest)$`)
 
 // filterNew reduces raw "new" candidates to the actionable signal: text models
 // on providers we actually price, that are not just a redundant naming variant
@@ -34,10 +35,10 @@ var snapshotSuffix = regexp.MustCompile(`(?:-\d{8}|-\d{2}-\d{4}|-preview|-latest
 // and the job goes unread — which is how the catalog fell two Gemini Flash
 // releases behind while the Action reported "success" every morning.
 func filterNew(changes []change) []change {
-	unpriced := unpricedProviders()
+	priced := pricedProviders()
 	var out []change
 	for _, c := range changes {
-		if c.Kind == "new" && actionableNew(c, unpriced) {
+		if c.Kind == "new" && actionableNew(c, priced) {
 			out = append(out, c)
 		}
 	}
@@ -62,20 +63,26 @@ func dedupe(changes []change) []change {
 	return out
 }
 
-func actionableNew(c change, unpriced map[string]bool) bool {
-	if unpriced[c.Provider] || c.Agg == "0/0" {
+func actionableNew(c change, priced map[string]bool) bool {
+	if !priced[c.Provider] || c.Agg == "0/0" {
 		return false
 	}
 	return isTextModel(c.Model) && !variantOfCataloged(c.Provider, c.Model)
 }
 
-// unpricedProviders lists providers whose every catalog entry is priced:false
-// (e.g. Qwen, whose USD rates are console-gated and unverifiable). Derived from
-// the catalog rather than hardcoded, so it self-corrects once one is priced.
-func unpricedProviders() map[string]bool {
+// pricedProviders is the allowlist of providers carrying at least one priced
+// catalog entry. Derived from the catalog rather than hardcoded, so it
+// self-corrects when a provider gains its first verifiable rate.
+//
+// An allowlist, not a denylist of unpriced providers: this fails closed. It
+// excludes Qwen (every entry priced:false — console-gated, no verifiable USD
+// rate) and also any provider added to aggregatorProvider before it has catalog
+// entries, which under a denylist would flood the daily report with its entire
+// upstream model list.
+func pricedProviders() map[string]bool {
 	out := map[string]bool{}
 	for provider, models := range pricing.Providers() {
-		if !anyPriced(models) {
+		if anyPriced(models) {
 			out[provider] = true
 		}
 	}

--- a/cmd/pricing-sync/newfilter_test.go
+++ b/cmd/pricing-sync/newfilter_test.go
@@ -1,0 +1,176 @@
+package main
+
+import "testing"
+
+func newChange(provider, model string) change {
+	return change{Kind: "new", Provider: provider, Model: model, Agg: "1/5"}
+}
+
+func models(cs []change) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.Model)
+	}
+	return out
+}
+
+func has(cs []change, model string) bool {
+	for _, c := range cs {
+		if c.Model == model {
+			return true
+		}
+	}
+	return false
+}
+
+// A genuinely new text model on a priced provider is the whole point of the
+// report: it must survive every filter.
+func TestFilterNew_KeepsGenuineTextModel(t *testing.T) {
+	got := filterNew([]change{
+		newChange("gemini", "gemini-3.8-flash"),
+		newChange("openai", "gpt-5.6"),
+		newChange("anthropic", "claude-fable-5-1"),
+		newChange("moonshot", "kimi-k2.6"),
+	})
+	if len(got) != 4 {
+		t.Fatalf("kept %v, want all 4 text models", models(got))
+	}
+}
+
+// Non-"new" kinds are price/deprecation drift, reported by the existing path.
+func TestFilterNew_DropsNonNewKinds(t *testing.T) {
+	got := filterNew([]change{
+		{Kind: "price", Provider: "openai", Model: "gpt-5.3"},
+		{Kind: "deprecated", Provider: "openai", Model: "o3-mini"},
+		newChange("openai", "gpt-5.6"),
+	})
+	if len(got) != 1 || got[0].Model != "gpt-5.6" {
+		t.Errorf("kept %v, want only gpt-5.6", models(got))
+	}
+}
+
+// Qwen carries only priced:false entries (console-gated, no verifiable USD
+// rate), so proposing 50 more Qwen adds is noise we can never action.
+func TestFilterNew_DropsUnpricedProviders(t *testing.T) {
+	got := filterNew([]change{
+		newChange("qwen", "qwen3.8-max"),
+		newChange("gemini", "gemini-3.8-flash"),
+	})
+	if len(got) != 1 || got[0].Provider != "gemini" {
+		t.Errorf("kept %v, want only the gemini entry", models(got))
+	}
+}
+
+// The catalog prices text generation. Image/tts/embedding/video/asr models bill
+// in a different unit and are deliberately out of scope.
+func TestFilterNew_DropsNonTextModalities(t *testing.T) {
+	got := filterNew([]change{
+		newChange("gemini", "gemini-3.1-flash-image"),
+		newChange("gemini", "gemini-3.1-flash-tts-preview"),
+		newChange("gemini", "gemini-embedding-2"),
+		newChange("gemini", "veo-3.1-generate-preview"),
+		newChange("gemini", "lyria-3-pro-preview"),
+		newChange("openai", "text-embedding-3-large"),
+		newChange("openai", "gpt-realtime-2.1"),
+		newChange("qwen", "qwen3-asr-flash"),
+		newChange("mistral", "voxtral-mini-tts-latest"),
+		newChange("gemini", "gemini-3.5-live-translate-preview"),
+	})
+	if len(got) != 0 {
+		t.Errorf("kept %v, want none (all non-text modalities)", models(got))
+	}
+}
+
+// A vision- or reasoning-capable *text* model still bills text tokens and
+// belongs in the catalog — the modality filter must not over-reach.
+func TestFilterNew_KeepsVisionCapableTextModels(t *testing.T) {
+	got := filterNew([]change{
+		newChange("deepseek", "deepseek-v4-flash-vision-exp"),
+		newChange("cohere", "command-a-vision-07-2025"),
+	})
+	if len(got) != 2 {
+		t.Errorf("kept %v, want both vision-input text models", models(got))
+	}
+}
+
+// claude-haiku-4-5-20251001 is the dated snapshot of claude-haiku-4-5, which
+// the catalog already carries — covered, not new.
+func TestFilterNew_DropsDatedSnapshotOfCatalogedModel(t *testing.T) {
+	got := filterNew([]change{
+		newChange("anthropic", "claude-haiku-4-5-20251001"),
+		newChange("anthropic", "claude-opus-4-5-20251101"),
+		newChange("anthropic", "claude-sonnet-4-5-20250929"),
+	})
+	if len(got) != 0 {
+		t.Errorf("kept %v, want none (all dated snapshots of cataloged models)", models(got))
+	}
+}
+
+// gemini-2.5-computer-use-preview-10-2025 style: a MM-YYYY suffix is the same
+// snapshot idea. Only drop when the undated base is actually cataloged.
+func TestFilterNew_KeepsDatedSnapshotWhenBaseNotCataloged(t *testing.T) {
+	got := filterNew([]change{newChange("cohere", "command-a-plus-05-2026")})
+	if len(got) != 1 {
+		t.Errorf("kept %v, want the entry (base command-a-plus is not cataloged)", models(got))
+	}
+}
+
+// The catalog carries gemini-3-flash-preview; the aggregator's bare
+// gemini-3-flash would be the same model without the preview marker.
+func TestFilterNew_DropsPreviewVariantOfCatalogedModel(t *testing.T) {
+	got := filterNew([]change{newChange("gemini", "gemini-3.1-flash-lite-preview")})
+	if len(got) != 0 {
+		t.Errorf("kept %v, want none (already cataloged)", models(got))
+	}
+}
+
+// Regression guard against the live catalog: the daily job must surface the
+// Gemini flash releases we are currently two versions behind on.
+func TestFilterNew_SurfacesGeminiFlashGap(t *testing.T) {
+	got := filterNew([]change{
+		newChange("gemini", "gemini-3.7-flash"),
+		newChange("gemini", "gemini-3.8-flash"),
+	})
+	if !has(got, "gemini-3.8-flash") || !has(got, "gemini-3.7-flash") {
+		t.Errorf("kept %v, want both uncataloged flash releases", models(got))
+	}
+}
+
+// The aggregator reports 0/0 when it has no USD rate (open-weight or
+// console-gated models). There is nothing to verify against an official source,
+// so these can never be actioned from this report.
+func TestFilterNew_DropsZeroPricedCandidates(t *testing.T) {
+	got := filterNew([]change{
+		{Kind: "new", Provider: "cohere", Model: "c4ai-aya-expanse-32b", Agg: "0/0"},
+		{Kind: "new", Provider: "gemini", Model: "gemma-4-31b-it", Agg: "0/0"},
+		{Kind: "new", Provider: "mistral", Model: "labs-devstral-small-2512", Agg: "0/0"},
+		newChange("openai", "gpt-5.6"),
+	})
+	if len(got) != 1 || got[0].Model != "gpt-5.6" {
+		t.Errorf("kept %v, want only gpt-5.6", models(got))
+	}
+}
+
+// models.dev exposes Z.AI under both "zai" and "zhipuai"; both map to our "zai"
+// key, so an identical model arrives twice and was reported twice.
+func TestDedupe_CollapsesIdenticalRows(t *testing.T) {
+	got := dedupe([]change{
+		{Kind: "new", Provider: "zai", Model: "glm-5.3", Agg: "1.4/4.4"},
+		{Kind: "new", Provider: "zai", Model: "glm-5.3", Agg: "1.4/4.4"},
+	})
+	if len(got) != 1 {
+		t.Errorf("got %d rows, want 1 after collapsing the duplicate alias", len(got))
+	}
+}
+
+// Conflicting prices for the same model are real signal (the two upstream
+// provider entries disagree) and must NOT be collapsed away.
+func TestDedupe_KeepsConflictingPrices(t *testing.T) {
+	got := dedupe([]change{
+		{Kind: "new", Provider: "zai", Model: "glm-5v-turbo", Agg: "5/22"},
+		{Kind: "new", Provider: "zai", Model: "glm-5v-turbo", Agg: "1.2/4"},
+	})
+	if len(got) != 2 {
+		t.Errorf("got %d rows, want both conflicting prices preserved", len(got))
+	}
+}

--- a/cmd/pricing-sync/newfilter_test.go
+++ b/cmd/pricing-sync/newfilter_test.go
@@ -174,3 +174,30 @@ func TestDedupe_KeepsConflictingPrices(t *testing.T) {
 		t.Errorf("got %d rows, want both conflicting prices preserved", len(got))
 	}
 }
+
+// OpenAI publishes ISO-dated snapshots (gpt-4o-2024-08-06); the catalog carries
+// the undated gpt-4o, so these are covered, not new.
+func TestFilterNew_DropsISODatedSnapshotOfCatalogedModel(t *testing.T) {
+	got := filterNew([]change{
+		newChange("openai", "gpt-4o-2024-05-13"),
+		newChange("openai", "gpt-4o-2024-08-06"),
+		newChange("openai", "gpt-4o-2024-11-20"),
+	})
+	if len(got) != 0 {
+		t.Errorf("kept %v, want none (all ISO-dated snapshots of cataloged gpt-4o)", models(got))
+	}
+}
+
+// Fail closed on an unrecognized provider. Today every aggregator target maps to
+// a catalog provider, so this is unreachable — but if a provider is added to
+// aggregatorProvider before it has catalog entries, a denylist would let its
+// entire model list flood the daily report. An allowlist cannot.
+func TestFilterNew_DropsProviderAbsentFromCatalog(t *testing.T) {
+	got := filterNew([]change{
+		newChange("someNewProvider", "shiny-model-1"),
+		newChange("openai", "gpt-5.6"),
+	})
+	if len(got) != 1 || got[0].Provider != "openai" {
+		t.Errorf("kept %v, want only the cataloged-provider entry", models(got))
+	}
+}

--- a/cmd/pricing-sync/sync.go
+++ b/cmd/pricing-sync/sync.go
@@ -34,16 +34,38 @@ type change struct {
 	Agg string
 }
 
+// syncOptions is the parsed command line for `sync`.
+type syncOptions struct {
+	tol           float64
+	mode          reportMode
+	failOnChanges bool
+}
+
+// parseSyncFlags parses and validates the flag set. Split out of runSync to
+// keep both functions within the repo's complexity ceiling.
+func parseSyncFlags(args []string) (syncOptions, int) {
+	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
+	tol := fs.Float64("tolerance", 0.0, "ignore price deltas at or below this fraction (e.g. 0.05 = 5%)")
+	existingOnly := fs.Bool("existing-only", false, "report only price/deprecation drift for models already in the catalog (drop 'new'); the low-noise daily signal")
+	newOnly := fs.Bool("new-only", false, "report only new upstream models, filtered to actionable text-model adds on priced providers; the complement of --existing-only")
+	failOnChanges := fs.Bool("fail-on-changes", false, "exit non-zero when any candidate is reported (for CI gating)")
+	if err := fs.Parse(args); err != nil {
+		return syncOptions{}, 2
+	}
+	if *existingOnly && *newOnly {
+		fmt.Fprintln(errOut, "pricing-sync: --existing-only and --new-only are mutually exclusive")
+		return syncOptions{}, 2
+	}
+	return syncOptions{tol: *tol, mode: selectMode(*existingOnly, *newOnly), failOnChanges: *failOnChanges}, 0
+}
+
 // runSync fetches machine-readable aggregators, diffs against the embedded
 // catalog, and prints candidate changes. It never writes prices.json — the
 // aggregators drive detection, not authority.
 func runSync(ctx context.Context, args []string) int {
-	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
-	tol := fs.Float64("tolerance", 0.0, "ignore price deltas at or below this fraction (e.g. 0.05 = 5%)")
-	existingOnly := fs.Bool("existing-only", false, "report only price/deprecation drift for models already in the catalog (drop 'new'); the low-noise daily signal")
-	failOnChanges := fs.Bool("fail-on-changes", false, "exit non-zero when any candidate is reported (for CI gating)")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	opts, code := parseSyncFlags(args)
+	if code != 0 {
+		return code
 	}
 	sups, err := loadSuppressions()
 	if err != nil {
@@ -55,17 +77,35 @@ func runSync(ctx context.Context, args []string) int {
 		fmt.Fprintf(errOut, "pricing-sync: fetch failed: %v\n", err)
 		return 1
 	}
-	return reportChanges(cands, *tol, *existingOnly, *failOnChanges, sups, time.Now())
+	return reportChanges(cands, opts.tol, opts.mode, opts.failOnChanges, sups, time.Now())
+}
+
+// reportMode picks which slice of the diff a run reports. The daily Action runs
+// both halves separately so each gets its own section in the drift issue.
+type reportMode int
+
+const (
+	modeAll reportMode = iota
+	modeExistingOnly
+	modeNewOnly
+)
+
+func selectMode(existingOnly, newOnly bool) reportMode {
+	switch {
+	case existingOnly:
+		return modeExistingOnly
+	case newOnly:
+		return modeNewOnly
+	default:
+		return modeAll
+	}
 }
 
 // reportChanges diffs, filters (drop-new + suppress-list), prints, and returns
 // the exit code. Suppressed candidates are dispositioned drift the daily Action
 // should not re-open an issue for (see drift_suppressions.json).
-func reportChanges(cands []candidate, tol float64, existingOnly, failOnChanges bool, sups []suppression, now time.Time) int {
-	changes := diff(cands, tol)
-	if existingOnly {
-		changes = dropNew(changes)
-	}
+func reportChanges(cands []candidate, tol float64, mode reportMode, failOnChanges bool, sups []suppression, now time.Time) int {
+	changes := applyMode(diff(cands, tol), mode)
 	changes, suppressed := applySuppressions(changes, sups, now)
 	printChanges(changes, len(cands))
 	if suppressed > 0 {
@@ -75,6 +115,17 @@ func reportChanges(cands []candidate, tol float64, existingOnly, failOnChanges b
 		return 1
 	}
 	return 0
+}
+
+func applyMode(changes []change, mode reportMode) []change {
+	switch mode {
+	case modeExistingOnly:
+		return dropNew(changes)
+	case modeNewOnly:
+		return filterNew(changes)
+	default:
+		return changes
+	}
 }
 
 // dropNew filters out "new" (upstream-only) candidates, leaving price and

--- a/docs/pricing-integration.md
+++ b/docs/pricing-integration.md
@@ -121,8 +121,12 @@ releases):
 - `just check-prices` — flags catalog entries overdue for re-verification.
 - `just sync-prices` — diffs `prices.json` against models.dev and reports
   candidates (report-only; a human confirms against each official `source`).
+- `just new-prices` — reports only upstream models missing from the catalog,
+  filtered to actionable text-model adds on priced providers.
 - A daily GitHub Action opens a rolling issue when it detects price/deprecation
-  drift for existing models.
+  drift for existing models **or** new upstream models the catalog is missing.
+  Persistent non-candidates (models we deliberately don't carry) are silenced
+  via `cmd/pricing-sync/drift_suppressions.json`.
 
 When dippin cuts a new tag with refreshed prices, tracker bumps its pin to adopt
 it — the same flow tracker already uses for every other dippin feature.


### PR DESCRIPTION
## The bug

The daily **Pricing sync** Action has been green every morning and doing nothing. Run [33654013368](https://github.com/2389-research/dippin-lang/actions/runs/33654013368) (today):

```
pricing: all entries verified within 45 days
pricing-sync: catalog agrees with models.dev across 265 scanned models
```

`.github/workflows/pricing-sync.yml` runs `sync --existing-only`, which routes through `dropNew()` and deletes every `"new"` candidate *before* the report is written. Only price/deprecation drift for models already in `prices.json` survives. The workflow's `changed=true` grep then correctly finds nothing — on a report that was already emptied upstream. A newly released model could never reach the issue-upsert step.

So the catalog fell behind silently. Today's aggregator data has, and the catalog lacks:

| Provider | Missing |
|---|---|
| gemini | `gemini-3.8-flash`, `gemini-3.7-flash` (0.75/3.75) — catalog's newest Flash is **3.6** |
| openai | `gpt-5.6` (4/20), `gpt-5.3-chat-latest`, `gpt-5.3-codex-spark` |
| anthropic | `claude-fable-5-1` (10/50) |
| moonshot | `kimi-k2.5`, `kimi-k2.6`, `kimi-k2.7-code` |
| zai | `glm-5.3`, `glm-5.3-flash`, `glm-4.6v` |
| minimax | `MiniMax-M2.5-highspeed` |

## The fix

`--existing-only` exists for a good reason — the raw new-model set is **173 rows**, mostly upstream image/tts/embedding models we deliberately don't price. The fix was a sledgehammer where a filter was needed.

Adds a complementary `sync --new-only` mode plus a second workflow step feeding a third section in the rolling issue. `filterNew` cuts 173 → **66** actionable rows:

- **Unpriced providers** (Qwen) — derived from the catalog (`pricing.Providers()`, all entries `priced:false`) rather than hardcoded, so it self-corrects once Qwen gets real rates.
- **Non-text modalities** — image/tts/embedding/video/asr/realtime. Vision- and reasoning-capable *text* models are deliberately kept (`deepseek-v4-flash-vision-exp`, `command-a-vision-07-2025`): they bill text tokens and belong in the catalog.
- **`0/0`-priced candidates** — the aggregator has no USD rate, so there is nothing to confirm against an official `source`.
- **Redundant variants** — dated snapshots and `preview`/`latest` aliases of models already carried (`claude-haiku-4-5-20251001` vs. our `claude-haiku-4-5`).

Also fixes a **pre-existing dedupe bug**: models.dev exposes Z.AI under both `zai` and `zhipuai`, both mapping to our `zai` key, so every Z.AI model was reported twice. Rows that agree on the model but *disagree* on price are preserved — that disagreement is real signal.

## Unchanged by design

Still **human-gated**. The job never edits `prices.json`; a human confirms each candidate against its official `source`. The existing `drift_suppressions.json` mechanism already accepts `kind: "new"`, so models we deliberately don't carry can be silenced there.

## Verification

- 12 new table-free unit tests in `cmd/pricing-sync/newfilter_test.go`, including a regression guard that `gemini-3.8-flash` survives every filter.
- `just build`, `just vet`, `just fmt-check`, `just test-race` — all pass.
- `just complexity` — clean repo-wide. Note: this recipe **silently passes when `gocyclo`/`gocognit` are not installed** (`sh: gocyclo: command not found` → empty violations → OK). I installed both and verified for real; `runSync` had gone to cyclomatic 6, fixed by extracting `parseSyncFlags`. Worth hardening that recipe separately.

## Follow-up (not in this PR)

The remaining 66 include a permanent tail of legacy models never carried on purpose (`gpt-4`, `gpt-3.5-turbo`, `o1`, `open-mixtral-8x7b`, `mistral-large-2411`). Those should be dispositioned into `drift_suppressions.json` so day-one signal is clean — a catalog-scope judgment call left to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E8omziXqFAWYtenybNoNb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790958832&installation_model_id=21126&pr_number=290&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F290&signature=3d9034aa2c4bb752adf7af014cdc777e4dd8a05cb8bc570bfe801d9fa6169713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting upstream text models missing from the pricing catalog.
  * Added a `new-prices` command to report actionable new model candidates.
  * Pricing synchronization reports now include newly discovered models alongside existing price drift.

* **Bug Fixes**
  * Improved filtering to exclude non-text models, unpriced providers, duplicates, and variants of models already in the catalog.

* **Documentation**
  * Updated pricing integration guidance with the new command and expanded automated reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->