### PR TITLE
Retain node and edge comments through fmt (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to dippin-lang are documented here. Versions follow [semver]
 
 ## [Unreleased]
 
+### Added
+- **`dippin fmt` now retains node and edge comments** ([#259](https://github.com/2389-research/dippin-lang/issues/259)). Whole-line comments immediately above a node or edge, trailing inline comments on node body lines and edge lines, and whole-line comments inside a node body all survive `fmt` verbatim, joining the leading file-level header block retained in v0.67.0. The lexer records each comment it strips (with its source line) and the parser re-attaches it to the owning entity (`ir.Node.HeaderComment`/`BodyComments`, `ir.Edge.HeaderComment`/`TrailingComment`); the formatter re-emits it at a canonical position — node/edge headers stay above the declaration, a trailing inline comment on an attribute line moves to the end of that node's body, and a trailing edge comment appends to the re-emitted edge line. Formatting is idempotent (`fmt(fmt(x)) == fmt(x)`), which unblocks `dippin fmt -check` as a CI gate for enforcing canonical formatting — the pipelines repo's `# ABOUTME:` convention across ~60 files can now be canonicalized safely.
+
+### Notes
+- Comment positions with no IR slot yet — the `dip` pragma, `goal`/`start`/`exit`, `defaults`, `vars`, `inputs`, `stylesheet` lines — are still dropped by `fmt`, as before (strictly an improvement; nothing is newly lost). Comments inside a multiline block (`prompt:`, `command:`, …) are block content, not comments, and always survive; a `#` inside a quoted value is not a comment and never was.
+
 ## [v0.70.0] — 2026-09-02
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -326,7 +326,7 @@ The lexer (`lexer.go`) converts source text into a flat token stream. Key featur
 - **Indentation tracking**: Maintains an indent stack. When indentation increases, emits `TokenIndent`. When it decreases, emits `TokenOutdent` (potentially multiple if skipping levels).
 - **Token types**: `Keyword`, `Identifier`, `Operator`, `Literal`, `Colon`, `Comma`, `Arrow` (`->`), `BackArrow` (`<-`), `LParen`, `RParen`, `Newline`, `EOF`.
 - **String handling**: The token literal (`TokenLiteral`, used in the `edges` section for edge attributes and `when` conditions) accepts both double-quoted strings (`\"` and `\\` escapes) and single-quoted (YAML-style) strings — literal apart from the `''` → `'` escape. The token-stream comment stripper (`findUnquotedHash`) keeps a `#` inside either quote; a single quote is treated as a string delimiter only at a token-start boundary, so a prose apostrophe (e.g. in `goal: it's great # note`) does not protect a trailing comment. Single-line **field values** are taken via raw extraction (`RawValueText` → `unquoteRaw`) and accept the same two string forms.
-- **Comments**: `#` to end-of-line, stripped during lexing.
+- **Comments**: `#` to end-of-line, stripped from the token stream during lexing. The lexer records each stripped comment (whole-line or trailing inline, with its source line) and the parser re-attaches it to the owning entity after parsing — `ir.Workflow.HeaderComment`, `ir.Node.HeaderComment`/`BodyComments`, `ir.Edge.HeaderComment`/`TrailingComment` — so the formatter re-emits it and `dippin fmt` no longer silently drops comments (#259).
 
 ### Stage 2: Parser
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -57,7 +57,7 @@ workflow Example         # level 0
 
 ## Comments
 
-Line comments start with `#` and extend to the end of the line. They are ignored by the parser.
+Line comments start with `#` and extend to the end of the line. A `#` inside a quoted value is part of the value, not a comment.
 
 ```dippin
 # This is a comment
@@ -66,6 +66,8 @@ workflow Example   # Inline comment
 ```
 
 Section headers like `# ── Phase 1 ──────────` are purely decorative — the parser treats them as regular comments.
+
+**`dippin fmt` retains comments** (issue #259): the leading file-level header block, whole-line comments immediately above a node or edge, trailing inline comments on node body lines and edge lines, and whole-line comments inside a node body all survive `fmt` verbatim. A trailing inline comment on an attribute line is re-emitted at the end of that node's body — `fmt`'s canonical position for it — so a file is not byte-identical after its first format, but formatting is idempotent: `fmt(fmt(x)) == fmt(x)`, which is what makes `dippin fmt -check` usable as a CI gate. Comments on other lines (the `dip` pragma, `goal`/`start`/`exit`, `defaults`, `vars`, `inputs`, `stylesheet`) are not yet retained and are dropped by `fmt`, as before. Comments inside a multiline block (`prompt:`, `command:`, …) are block content, not comments — they always survive.
 
 ---
 

--- a/formatter/format.go
+++ b/formatter/format.go
@@ -362,13 +362,29 @@ func writeVars(wr *writer, vars map[string]string) {
 }
 
 func writeNode(wr *writer, n *ir.Node) {
+	for _, l := range n.HeaderComment {
+		wr.line("%s", l)
+	}
 	if writeStructuralNode(wr, n) {
+		writeNodeBodyComments(wr, n)
 		return
 	}
 	wr.line("%s %s", n.Kind, n.ID)
 	wr.push()
 	writeNodeConfigFields(wr, n)
+	writeNodeBodyComments(wr, n)
 	wr.pop()
+}
+
+// writeNodeBodyComments emits the retained node-body comments (trailing inline
+// and whole-line comments captured from the body) verbatim as the last lines
+// of the node body — fmt's canonical position for a comment whose original
+// line is no longer where the formatter places that attribute, so formatting
+// is idempotent (#259).
+func writeNodeBodyComments(wr *writer, n *ir.Node) {
+	for _, l := range n.BodyComments {
+		wr.line("%s", l)
+	}
 }
 
 // writeStructuralNode writes parallel/fan_in nodes. Returns true if handled.
@@ -935,6 +951,9 @@ func writeEdges(wr *writer, w *ir.Workflow) {
 }
 
 func writeEdge(wr *writer, w *ir.Workflow, e *ir.Edge) {
+	for _, l := range e.HeaderComment {
+		wr.line("%s", l)
+	}
 	if e.Comment != "" {
 		wr.line("# %s", e.Comment)
 	}
@@ -942,7 +961,11 @@ func writeEdge(wr *writer, w *ir.Workflow, e *ir.Edge) {
 	parts = append(parts, fmt.Sprintf("%s -> %s", e.From, e.To))
 	parts = appendEdgeCondition(parts, w, e)
 	parts = appendEdgeAttrs(parts, e)
-	wr.line("%s", strings.Join(parts, "  "))
+	line := strings.Join(parts, "  ")
+	if e.TrailingComment != "" {
+		line += "  " + e.TrailingComment
+	}
+	wr.line("%s", line)
 }
 
 // appendEdgeCondition appends the condition part if one is present. When the

--- a/ir/edge.go
+++ b/ir/edge.go
@@ -13,7 +13,14 @@ type Edge struct {
 	Restart   bool       // Back-edge: triggers downstream clear + re-execution
 	Override  bool       // Carried, not interpreted: human-authored validation override (tracker#271)
 	Comment   string     // Optional leading `# ` line the formatter emits before this edge (migration review notes)
-	Source    SourceLocation
+	// HeaderComment holds the contiguous run of whole-line `#` comment lines
+	// immediately above the edge line, in source order, each verbatim (leading
+	// `#` included). The formatter re-emits them above the edge (#259).
+	// Distinct from Comment, which stores a single unadorned line produced by
+	// the DOT migration path.
+	HeaderComment   []string
+	TrailingComment string // Trailing inline `# ...` comment on the edge line itself, verbatim (leading `#` included); the formatter appends it to the re-emitted edge line (#259)
+	Source          SourceLocation
 }
 
 // EdgeRoutesOnFail reports whether an edge's guard routes the failure outcome

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -40,8 +40,9 @@ type Workflow struct {
 	// (leading `#` included), with surrounding blank lines dropped but interior
 	// blank lines preserved. Empty when the file has no leading comment. The
 	// formatter re-emits these so `dippin fmt` no longer erases `# ABOUTME:` /
-	// provider-dependency headers (#259). Inline/trailing/between-node comments
-	// are not yet retained.
+	// provider-dependency headers (#259). Node/edge comment retention lives on
+	// ir.Node.HeaderComment/BodyComments and ir.Edge.HeaderComment/
+	// TrailingComment (#259).
 	HeaderComment []string
 }
 
@@ -118,6 +119,19 @@ type Node struct {
 	Retry   RetryConfig
 	IO      NodeIO // Declared inputs/outputs (advisory in v1)
 	Source  SourceLocation
+	// HeaderComment holds the contiguous run of whole-line `#` comment lines
+	// immediately above the node declaration, in source order, each line
+	// verbatim (leading `#` included). Empty when there is none. The formatter
+	// re-emits them directly above the node declaration so `dippin fmt`
+	// preserves them (#259).
+	HeaderComment []string
+	// BodyComments holds the comments captured from within the node's body
+	// extent — trailing inline comments after body lines and whole-line
+	// comments between them — in source order, each verbatim (leading `#`
+	// included). The formatter re-emits them as the last lines of the node
+	// body: fmt's canonical position for a comment whose original attribute
+	// line is no longer where the formatter places that attribute (#259).
+	BodyComments []string
 }
 
 // NodeKind enumerates node types explicitly.

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -1,0 +1,124 @@
+package parser
+
+import "github.com/2389-research/dippin-lang/ir"
+
+// nodeSpan pairs a parsed node with the 1-based source line of its
+// declaration, for comment attachment (#259).
+type nodeSpan struct {
+	node  *ir.Node
+	start int
+}
+
+// edgeSpan pairs a parsed edge with the 1-based source line of its
+// declaration, for comment attachment (#259).
+type edgeSpan struct {
+	edge *ir.Edge
+	line int
+}
+
+// recordNodeSpan remembers a node's declaration line so attachComments can
+// scope its body comments to the node's source extent (#259).
+func (p *Parser) recordNodeSpan(n *ir.Node, declLine int) {
+	p.nodeSpans = append(p.nodeSpans, nodeSpan{node: n, start: declLine})
+}
+
+// attachComments transfers the comments the lexer stripped during
+// tokenization onto the parsed workflow (#259), so `dippin fmt` can re-emit
+// them instead of silently dropping them:
+//
+//   - a contiguous run of whole-line comments immediately above a node
+//     declaration becomes that node's HeaderComment;
+//   - comments on lines within a node's extent — trailing inline after a body
+//     line, or whole-line — become the node's BodyComments, in source order;
+//   - a contiguous run of whole-line comments immediately above an edge line
+//     becomes the edge's HeaderComment, and the trailing inline comment on
+//     the edge line itself becomes its TrailingComment.
+//
+// Comments on other lines (the dip pragma, workflow header fields, defaults,
+// vars, inputs, stylesheet) have no IR slot yet and are dropped, as before.
+// Node extents are capped at the next top-level line so a comment between a
+// node and a later section attaches to the node, not the section. Header
+// runs are maximal consecutive line-number runs ending at the declaration
+// line minus one: a blank line between a comment and a node breaks the run
+// (matching Workflow.HeaderComment's surrounding-blank trimming).
+func (p *Parser) attachComments() {
+	comms := p.lexer.Comments()
+	if len(comms) == 0 {
+		return
+	}
+	standalone := make(map[int]string, len(comms))
+	trailing := make(map[int]string, len(comms))
+	for _, c := range comms {
+		if c.kind == commentStandalone {
+			standalone[c.line] = c.text
+		} else {
+			trailing[c.line] = c.text
+		}
+	}
+	claimed := make(map[int]bool, len(comms))
+
+	// Node header blocks: the maximal run of whole-line comment lines ending
+	// exactly at the declaration line minus one.
+	for i := range p.nodeSpans {
+		ns := &p.nodeSpans[i]
+		var block []string
+		for l := ns.start - 1; ; l-- {
+			text, ok := standalone[l]
+			if !ok {
+				break
+			}
+			block = append([]string{text}, block...)
+			claimed[l] = true
+		}
+		ns.node.HeaderComment = block
+	}
+
+	// Edge header blocks + trailing inline comments. A run stops at a line
+	// already claimed by a node header (a node declared after the edges
+	// block in the source).
+	for i := range p.edgeSpans {
+		es := &p.edgeSpans[i]
+		var block []string
+		for l := es.line - 1; ; l-- {
+			if claimed[l] {
+				break
+			}
+			text, ok := standalone[l]
+			if !ok {
+				break
+			}
+			block = append([]string{text}, block...)
+			claimed[l] = true
+		}
+		es.edge.HeaderComment = block
+		if text, ok := trailing[es.line]; ok {
+			es.edge.TrailingComment = text
+		}
+	}
+
+	// Node body comments: every unclaimed comment on a line from the node's
+	// declaration through the line before the next top-level construct.
+	maxLine := len(p.lexer.lines)
+	for i := range p.nodeSpans {
+		ns := &p.nodeSpans[i]
+		end := maxLine
+		for _, l := range p.topLines {
+			if l > ns.start && l < end {
+				end = l
+			}
+		}
+		var body []string
+		for l := ns.start; l < end; l++ {
+			if claimed[l] {
+				continue
+			}
+			if text, ok := trailing[l]; ok {
+				body = append(body, text)
+			}
+			if text, ok := standalone[l]; ok {
+				body = append(body, text)
+			}
+		}
+		ns.node.BodyComments = body
+	}
+}

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -24,23 +24,12 @@ func (p *Parser) recordNodeSpan(n *ir.Node, declLine int) {
 
 // attachComments transfers the comments the lexer stripped during
 // tokenization onto the parsed workflow (#259), so `dippin fmt` can re-emit
-// them instead of silently dropping them:
-//
-//   - a contiguous run of whole-line comments immediately above a node
-//     declaration becomes that node's HeaderComment;
-//   - comments on lines within a node's extent — trailing inline after a body
-//     line, or whole-line — become the node's BodyComments, in source order;
-//   - a contiguous run of whole-line comments immediately above an edge line
-//     becomes the edge's HeaderComment, and the trailing inline comment on
-//     the edge line itself becomes its TrailingComment.
+// them instead of silently dropping them. It indexes the recorded comments by
+// line, then runs three attachment phases: node header runs, edge header +
+// trailing inline, and node body comments.
 //
 // Comments on other lines (the dip pragma, workflow header fields, defaults,
 // vars, inputs, stylesheet) have no IR slot yet and are dropped, as before.
-// Node extents are capped at the next top-level line so a comment between a
-// node and a later section attaches to the node, not the section. Header
-// runs are maximal consecutive line-number runs ending at the declaration
-// line minus one: a blank line between a comment and a node breaks the run
-// (matching Workflow.HeaderComment's surrounding-blank trimming).
 func (p *Parser) attachComments() {
 	comms := p.lexer.Comments()
 	if len(comms) == 0 {
@@ -57,68 +46,90 @@ func (p *Parser) attachComments() {
 	}
 	claimed := make(map[int]bool, len(comms))
 
-	// Node header blocks: the maximal run of whole-line comment lines ending
-	// exactly at the declaration line minus one.
 	for i := range p.nodeSpans {
-		ns := &p.nodeSpans[i]
-		var block []string
-		for l := ns.start - 1; ; l-- {
-			text, ok := standalone[l]
-			if !ok {
-				break
-			}
-			block = append([]string{text}, block...)
-			claimed[l] = true
-		}
-		ns.node.HeaderComment = block
+		p.attachNodeHeader(&p.nodeSpans[i], standalone, claimed)
 	}
-
-	// Edge header blocks + trailing inline comments. A run stops at a line
-	// already claimed by a node header (a node declared after the edges
-	// block in the source).
 	for i := range p.edgeSpans {
-		es := &p.edgeSpans[i]
-		var block []string
-		for l := es.line - 1; ; l-- {
-			if claimed[l] {
-				break
-			}
-			text, ok := standalone[l]
-			if !ok {
-				break
-			}
-			block = append([]string{text}, block...)
-			claimed[l] = true
-		}
-		es.edge.HeaderComment = block
-		if text, ok := trailing[es.line]; ok {
-			es.edge.TrailingComment = text
-		}
+		p.attachEdgeComments(&p.edgeSpans[i], standalone, trailing, claimed)
 	}
-
-	// Node body comments: every unclaimed comment on a line from the node's
-	// declaration through the line before the next top-level construct.
-	maxLine := len(p.lexer.lines)
 	for i := range p.nodeSpans {
-		ns := &p.nodeSpans[i]
-		end := maxLine
-		for _, l := range p.topLines {
-			if l > ns.start && l < end {
-				end = l
-			}
-		}
-		var body []string
-		for l := ns.start; l < end; l++ {
-			if claimed[l] {
-				continue
-			}
-			if text, ok := trailing[l]; ok {
-				body = append(body, text)
-			}
-			if text, ok := standalone[l]; ok {
-				body = append(body, text)
-			}
-		}
-		ns.node.BodyComments = body
+		p.attachNodeBody(&p.nodeSpans[i], standalone, trailing, claimed)
 	}
+}
+
+// attachNodeHeader sets the node's HeaderComment to the maximal run of
+// whole-line comment lines ending exactly at the declaration line minus one.
+// A blank line between a comment and a node breaks the run (matching
+// Workflow.HeaderComment's surrounding-blank trimming). Lines in the run are
+// marked claimed so later phases do not double-attach them.
+func (p *Parser) attachNodeHeader(ns *nodeSpan, standalone map[int]string, claimed map[int]bool) {
+	var block []string
+	for l := ns.start - 1; ; l-- {
+		text, ok := standalone[l]
+		if !ok {
+			break
+		}
+		block = append([]string{text}, block...)
+		claimed[l] = true
+	}
+	ns.node.HeaderComment = block
+}
+
+// attachEdgeComments sets the edge's HeaderComment to the run of whole-line
+// comment lines immediately above the edge line, and its TrailingComment to
+// the inline comment on the edge line itself. The header run stops at a line
+// already claimed by a node header (a node declared after the edges block in
+// the source) as well as at any non-comment line.
+func (p *Parser) attachEdgeComments(es *edgeSpan, standalone, trailing map[int]string, claimed map[int]bool) {
+	var block []string
+	for l := es.line - 1; ; l-- {
+		if claimed[l] {
+			break
+		}
+		text, ok := standalone[l]
+		if !ok {
+			break
+		}
+		block = append([]string{text}, block...)
+		claimed[l] = true
+	}
+	es.edge.HeaderComment = block
+	if text, ok := trailing[es.line]; ok {
+		es.edge.TrailingComment = text
+	}
+}
+
+// attachNodeBody sets the node's BodyComments to every unclaimed comment on a
+// line within the node's extent, in source order. The extent runs from the
+// declaration line to the line before the next top-level construct, so a
+// comment between a node and a later section attaches to the node, not the
+// section.
+func (p *Parser) attachNodeBody(ns *nodeSpan, standalone, trailing map[int]string, claimed map[int]bool) {
+	end := p.nodeBodyEnd(ns.start)
+	var body []string
+	for l := ns.start; l < end; l++ {
+		if claimed[l] {
+			continue
+		}
+		if text, ok := trailing[l]; ok {
+			body = append(body, text)
+		}
+		if text, ok := standalone[l]; ok {
+			body = append(body, text)
+		}
+	}
+	ns.node.BodyComments = body
+}
+
+// nodeBodyEnd returns the one-past-the-last source line belonging to a node's
+// extent: the smallest top-level line greater than start, or the input's line
+// count when the node is the last top-level construct.
+func (p *Parser) nodeBodyEnd(start int) int {
+	end := len(p.lexer.lines)
+	for _, l := range p.topLines {
+		if l > start && l < end {
+			end = l
+		}
+	}
+	return end
 }

--- a/parser/comments_test.go
+++ b/parser/comments_test.go
@@ -1,0 +1,281 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/formatter"
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/parser"
+)
+
+func parseMust(t *testing.T, input string) *ir.Workflow {
+	t.Helper()
+	w, err := parser.NewParser(input, "test.dip").Parse()
+	if err != nil {
+		t.Fatalf("parse failed: %v\nsource:\n%s", err, input)
+	}
+	return w
+}
+
+// TestAttachNodeHeaderComment verifies whole-line comments immediately above a
+// node declaration become that node's HeaderComment, in source order (#259).
+func TestAttachNodeHeaderComment(t *testing.T) {
+	w := parseMust(t, `workflow T
+  start: A
+  exit: B
+
+  # first line of the block
+  # second line of the block
+  agent A
+    prompt: "hi"
+  agent B
+    prompt: "bye"
+`)
+	a := w.Node("A")
+	b := w.Node("B")
+	if a == nil || b == nil {
+		t.Fatalf("missing nodes: %#v", w.Nodes)
+	}
+	want := []string{"# first line of the block", "# second line of the block"}
+	if len(a.HeaderComment) != len(want) {
+		t.Fatalf("A.HeaderComment = %#v, want %#v", a.HeaderComment, want)
+	}
+	for i := range want {
+		if a.HeaderComment[i] != want[i] {
+			t.Errorf("A.HeaderComment[%d] = %q, want %q", i, a.HeaderComment[i], want[i])
+		}
+	}
+	if len(b.HeaderComment) != 0 {
+		t.Errorf("B.HeaderComment = %#v, want empty (the block belongs to A, which follows it)", b.HeaderComment)
+	}
+}
+
+// TestAttachNodeBodyComments verifies trailing inline and mid-body whole-line
+// comments inside a node become its BodyComments, in source order (#259).
+func TestAttachNodeBodyComments(t *testing.T) {
+	w := parseMust(t, `workflow T
+  start: A
+  exit: A
+
+  agent A
+    label: A        # trailing on label
+    # mid-body note
+    prompt: "hi"  # trailing on prompt
+`)
+	a := w.Node("A")
+	want := []string{"# trailing on label", "# mid-body note", "# trailing on prompt"}
+	if len(a.BodyComments) != len(want) {
+		t.Fatalf("A.BodyComments = %#v, want %#v", a.BodyComments, want)
+	}
+	for i := range want {
+		if a.BodyComments[i] != want[i] {
+			t.Errorf("A.BodyComments[%d] = %q, want %q", i, a.BodyComments[i], want[i])
+		}
+	}
+}
+
+// TestAttachNodeDeclLineTrailingComment verifies the trailing comment on the
+// node declaration line itself is retained, on the node (#259).
+func TestAttachNodeDeclLineTrailingComment(t *testing.T) {
+	w := parseMust(t, `workflow T
+  start: A
+  exit: A
+
+  agent A  # entry point
+    prompt: "hi"
+`)
+	a := w.Node("A")
+	want := []string{"# entry point"}
+	if len(a.BodyComments) != len(want) || a.BodyComments[0] != want[0] {
+		t.Fatalf("A.BodyComments = %#v, want %#v", a.BodyComments, want)
+	}
+	if len(a.HeaderComment) != 0 {
+		t.Errorf("A.HeaderComment = %#v, want empty (the comment is on the declaration line)", a.HeaderComment)
+	}
+}
+
+// TestAttachHeaderRunBreaksAtBlank verifies a blank line between the comment
+// and the node breaks the header run: the comment attaches to the preceding
+// node's body instead (#259).
+func TestAttachHeaderRunBreaksAtBlank(t *testing.T) {
+	w := parseMust(t, `workflow T
+  start: A
+  exit: B
+
+  agent A
+    prompt: "hi"
+  # orphaned by the blank line
+
+  agent B
+    prompt: "bye"
+`)
+	a := w.Node("A")
+	b := w.Node("B")
+	if len(b.HeaderComment) != 0 {
+		t.Errorf("B.HeaderComment = %#v, want empty (blank line breaks the run)", b.HeaderComment)
+	}
+	want := []string{"# orphaned by the blank line"}
+	if len(a.BodyComments) != len(want) || a.BodyComments[0] != want[0] {
+		t.Errorf("A.BodyComments = %#v, want %#v", a.BodyComments, want)
+	}
+}
+
+// TestAttachEdgeComments verifies whole-line comments above an edge line become
+// the edge's HeaderComment and the trailing inline comment on the edge line
+// becomes its TrailingComment (#259).
+func TestAttachEdgeComments(t *testing.T) {
+	w := parseMust(t, `workflow T
+  start: A
+  exit: B
+
+  agent A
+    prompt: "hi"
+  agent B
+    prompt: "bye"
+
+  edges
+    # routing note
+    A -> B  # success path
+`)
+	e := w.Edges[0]
+	if e == nil {
+		t.Fatal("no edges parsed")
+	}
+	if len(e.HeaderComment) != 1 || e.HeaderComment[0] != "# routing note" {
+		t.Errorf("edge.HeaderComment = %#v, want [\"# routing note\"]", e.HeaderComment)
+	}
+	if e.TrailingComment != "# success path" {
+		t.Errorf("edge.TrailingComment = %q, want %q", e.TrailingComment, "# success path")
+	}
+}
+
+// TestCommentInsideRawBlockIsContent verifies a `#` line inside an indented raw
+// prompt block is prompt content, not a retained comment (#259).
+func TestCommentInsideRawBlockIsContent(t *testing.T) {
+	w := parseMust(t, `workflow T
+  start: A
+  exit: A
+
+  agent A
+    prompt:
+      line one
+      # not a comment
+`)
+	a := w.Node("A")
+	cfg, ok := a.Config.(ir.AgentConfig)
+	if !ok {
+		t.Fatalf("A config is %T, want ir.AgentConfig", a.Config)
+	}
+	if !strings.Contains(cfg.Prompt, "# not a comment") {
+		t.Errorf("prompt lost the raw-block line:\n%q", cfg.Prompt)
+	}
+	if len(a.BodyComments) != 0 || len(a.HeaderComment) != 0 {
+		t.Errorf("A retained comments from raw-block content: header=%#v body=%#v", a.HeaderComment, a.BodyComments)
+	}
+}
+
+// TestHashInsideQuotedValueIsNotAComment verifies a # inside a quoted value is
+// not treated as a comment and does not truncate the value (#259).
+func TestHashInsideQuotedValueIsNotAComment(t *testing.T) {
+	w := parseMust(t, `workflow T
+  start: A
+  exit: A
+
+  agent A
+    label: "A # one"
+    prompt: "hi"
+`)
+	a := w.Node("A")
+	if a.Label != "A # one" {
+		t.Errorf("A.Label = %q, want %q", a.Label, "A # one")
+	}
+	if len(a.BodyComments) != 0 {
+		t.Errorf("A.BodyComments = %#v, want empty", a.BodyComments)
+	}
+}
+
+// TestFormatCommentsIdempotent runs the issue #259 repro through Format twice
+// and requires both comment retention and byte-identical idempotency — the
+// property that makes `fmt --check` usable as a CI gate.
+func TestFormatCommentsIdempotent(t *testing.T) {
+	input := `# ABOUTME: leading file comment
+# second leading line
+workflow CommentTest
+  start: A
+  exit: B
+
+  # comment between defaults and nodes
+  agent A
+    label: A     # trailing inline comment
+    prompt: "hi"
+  agent B
+    prompt: "bye"
+
+  edges
+    A -> B  # edge comment
+`
+	w := parseMust(t, input)
+	first := formatter.Format(w)
+
+	mustContain := []string{
+		"# ABOUTME: leading file comment",
+		"# second leading line",
+		"# comment between defaults and nodes",
+		"# trailing inline comment",
+		"A -> B  # edge comment",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(first, want) {
+			t.Errorf("formatted output missing %q\ngot:\n%s", want, first)
+		}
+	}
+
+	w2 := parseMust(t, first)
+	second := formatter.Format(w2)
+	if first != second {
+		t.Errorf("formatter not idempotent with comments\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestStructuralNodeComments verifies comment retention for inline parallel and
+// fan_in nodes, whose declarations share a line with their targets (#259).
+func TestStructuralNodeComments(t *testing.T) {
+	w := parseMust(t, `workflow T
+  start: Split
+  exit: Join
+
+  # fan out
+  parallel Split -> A, B
+    # split note
+
+  agent A
+    prompt: "a"
+  agent B
+    prompt: "b"
+  fan_in Join <- A, B  # merge
+
+  edges
+    Join -> Join
+`)
+	split := w.Node("Split")
+	join := w.Node("Join")
+	if split == nil || join == nil {
+		t.Fatalf("missing structural nodes: %#v", w.Nodes)
+	}
+	if len(split.HeaderComment) != 1 || split.HeaderComment[0] != "# fan out" {
+		t.Errorf("Split.HeaderComment = %#v, want [\"# fan out\"]", split.HeaderComment)
+	}
+	if len(split.BodyComments) != 1 || split.BodyComments[0] != "# split note" {
+		t.Errorf("Split.BodyComments = %#v, want [\"# split note\"]", split.BodyComments)
+	}
+	if len(join.BodyComments) != 1 || join.BodyComments[0] != "# merge" {
+		t.Errorf("Join.BodyComments = %#v, want [\"# merge\"]", join.BodyComments)
+	}
+
+	formatted := formatter.Format(w)
+	w2 := parseMust(t, formatted)
+	if formatter.Format(w2) != formatted {
+		t.Errorf("formatter not idempotent with structural-node comments\nfirst:\n%s\nsecond:\n%s", formatted, formatter.Format(w2))
+	}
+}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -30,6 +30,24 @@ const (
 	TokenRawBlock // Raw text block (multiline prompt/command content)
 )
 
+// commentKind distinguishes the two comment shapes the lexer records during
+// tokenization (#259).
+type commentKind int
+
+const (
+	commentStandalone commentKind = iota // whole-line `#` comment
+	commentTrailing                      // trailing inline comment after code
+)
+
+// lineComment is a comment stripped during tokenization, kept so the parser
+// can attach it to a parsed entity by source line (#259). Text is verbatim
+// with the leading `#`.
+type lineComment struct {
+	line int
+	kind commentKind
+	text string
+}
+
 type Token struct {
 	Type     TokenType
 	Value    string
@@ -45,11 +63,16 @@ type Lexer struct {
 	indentStack []int
 	tokens      []Token
 	tokenIdx    int
-	errs        []string // lex-time errors (e.g. unterminated string), surfaced by Parse
+	errs        []string      // lex-time errors (e.g. unterminated string), surfaced by Parse
+	comments    []lineComment // comments stripped during tokenization, in line order (#259)
 }
 
 // Errors returns the lex-time errors accumulated during tokenization.
 func (l *Lexer) Errors() []string { return l.errs }
+
+// Comments returns the comments stripped during tokenization, in source-line
+// order, for the parser to attach to parsed entities (#259).
+func (l *Lexer) Comments() []lineComment { return l.comments }
 
 func NewLexer(input string, filename string) *Lexer {
 	l := &Lexer{
@@ -201,12 +224,33 @@ func opensSingleQuote(s string, i int) bool {
 // whitespace (not inside a value). Does NOT strip # that starts the line content.
 func stripComment(line string) string {
 	trimmed := strings.TrimRight(line, " \t\r")
-	idx := findUnquotedHash(trimmed)
-	if idx < 0 {
+	code, comment := splitTrailingComment(trimmed)
+	if comment == "" {
 		return trimmed
 	}
-	if isStrippableHash(trimmed, idx) {
-		return trimmed[:idx]
+	return code
+}
+
+// splitTrailingComment splits a (trailing-whitespace-trimmed) line into its code
+// portion and its trailing comment portion — the `# ...` tail, trimmed and kept
+// verbatim including the leading `#`. The comment portion is empty when the line
+// has no strippable comment (a # inside quotes, or one not preceded by
+// whitespace). The code portion may retain the whitespace that separated it from
+// the comment; callers that lex it are unaffected.
+func splitTrailingComment(line string) (code, comment string) {
+	idx := findUnquotedHash(line)
+	if idx < 0 || !isStrippableHash(line, idx) {
+		return line, ""
+	}
+	return line[:idx], strings.TrimSpace(line[idx:])
+}
+
+// standaloneCommentText returns the trimmed whole-line comment text if the line
+// is a `#` comment, or "" for a blank line or code line.
+func standaloneCommentText(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) == 0 || trimmed[0] != '#' {
+		return ""
 	}
 	return trimmed
 }
@@ -242,10 +286,16 @@ func (l *Lexer) lexOneLine(i int, filename string) (bool, int) {
 	trimmed := strings.TrimRight(line, " \t\r")
 
 	if l.shouldSkipLine(trimmed) {
+		if text := standaloneCommentText(trimmed); text != "" {
+			l.comments = append(l.comments, lineComment{line: i + 1, kind: commentStandalone, text: text})
+		}
 		return false, 0
 	}
 
-	trimmed = stripComment(trimmed)
+	trimmed, comment := splitTrailingComment(trimmed)
+	if comment != "" {
+		l.comments = append(l.comments, lineComment{line: i + 1, kind: commentTrailing, text: comment})
+	}
 	if len(strings.TrimSpace(trimmed)) == 0 {
 		return false, 0
 	}

--- a/parser/parse_edges.go
+++ b/parser/parse_edges.go
@@ -77,12 +77,13 @@ func (p *Parser) parseElseDefault() {
 
 // parseSingleEdge parses a single edge declaration: "from -> to [attributes...]"
 func (p *Parser) parseSingleEdge() {
-	from := p.lexer.NextToken().Value
+	fromTok := p.lexer.NextToken()
 	p.expect(TokenArrow)
 	to := p.lexer.NextToken().Value
-	edge := &ir.Edge{From: from, To: to}
+	edge := &ir.Edge{From: fromTok.Value, To: to}
 	p.parseEdgeAttributes(edge)
 	p.workflow.Edges = append(p.workflow.Edges, edge)
+	p.edgeSpans = append(p.edgeSpans, edgeSpan{edge: edge, line: fromTok.Location.Line})
 	p.expect(TokenNewline)
 }
 

--- a/parser/parse_nodes.go
+++ b/parser/parse_nodes.go
@@ -40,6 +40,7 @@ func (p *Parser) parseNode(kind ir.NodeKind) {
 	p.parseNodeBody(node)
 	p.expect(TokenOutdent)
 	p.workflow.Nodes = append(p.workflow.Nodes, node)
+	p.recordNodeSpan(node, node.Source.Line)
 }
 
 // parseNodeBody parses the indented fields within a node declaration.
@@ -788,27 +789,31 @@ func (p *Parser) parseParamLine(params map[string]string, line string) {
 }
 
 func (p *Parser) parseParallel() {
+	decl := p.lexer.PeekToken().Location
 	p.lexer.NextToken() // parallel
 	id := p.lexer.NextToken().Value
 
 	if p.lexer.PeekToken().Type == TokenArrow {
-		p.parseParallelInline(id)
+		p.parseParallelInline(id, decl)
 		return
 	}
-	p.parseParallelBlock(id)
+	p.parseParallelBlock(id, decl)
 }
 
 // parseParallelInline handles: parallel ID -> target, target
 // An optional indented params: block may follow the inline target list.
-func (p *Parser) parseParallelInline(id string) {
+func (p *Parser) parseParallelInline(id string, decl ir.SourceLocation) {
 	p.expect(TokenArrow)
 	targets := p.parseCommaList()
 	params := p.parseOptionalParamsBlock("parallel")
-	p.workflow.Nodes = append(p.workflow.Nodes, &ir.Node{
+	node := &ir.Node{
 		ID:     id,
 		Kind:   ir.NodeParallel,
+		Source: decl,
 		Config: ir.ParallelConfig{Targets: targets, Params: params},
-	})
+	}
+	p.workflow.Nodes = append(p.workflow.Nodes, node)
+	p.recordNodeSpan(node, decl.Line)
 }
 
 // tokenIsIdent reports whether t is the given keyword identifier.
@@ -907,22 +912,25 @@ func (p *Parser) skipBalancedBlock() {
 }
 
 // parseParallelBlock handles block form with per-branch config and an optional params block.
-func (p *Parser) parseParallelBlock(id string) {
+func (p *Parser) parseParallelBlock(id string, decl ir.SourceLocation) {
 	p.expect(TokenNewline)
 	p.expect(TokenIndent)
 	branches, params := p.parseParallelBody()
 	p.expect(TokenOutdent)
 
 	targets := branchTargets(branches)
-	p.workflow.Nodes = append(p.workflow.Nodes, &ir.Node{
-		ID:   id,
-		Kind: ir.NodeParallel,
+	node := &ir.Node{
+		ID:     id,
+		Kind:   ir.NodeParallel,
+		Source: decl,
 		Config: ir.ParallelConfig{
 			Targets:  targets,
 			Branches: branches,
 			Params:   params,
 		},
-	})
+	}
+	p.workflow.Nodes = append(p.workflow.Nodes, node)
+	p.recordNodeSpan(node, decl.Line)
 }
 
 // parseParallelBody parses branch declarations and an optional params block
@@ -1056,14 +1064,18 @@ func branchTargets(branches []ir.BranchConfig) []string {
 // parseFanIn handles: fan_in ID <- source, source
 // An optional indented params: block may follow the source list.
 func (p *Parser) parseFanIn() {
+	decl := p.lexer.PeekToken().Location
 	p.lexer.NextToken() // fan_in
 	id := p.lexer.NextToken().Value
 	p.expect(TokenBackArrow)
 	sources := p.parseCommaList()
 	params := p.parseOptionalParamsBlock("fan_in")
-	p.workflow.Nodes = append(p.workflow.Nodes, &ir.Node{
+	node := &ir.Node{
 		ID:     id,
 		Kind:   ir.NodeFanIn,
+		Source: decl,
 		Config: ir.FanInConfig{Sources: sources, Params: params},
-	})
+	}
+	p.workflow.Nodes = append(p.workflow.Nodes, node)
+	p.recordNodeSpan(node, decl.Line)
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -14,6 +14,12 @@ type Parser struct {
 	diagnostics []string // Simple for now
 	workflow    *ir.Workflow
 	version     int // .dip format version; defaults to 1 when no `dip N` declaration is present
+	// Comment-attachment bookkeeping, populated while parsing and consumed by
+	// attachComments (#259): declaration lines of nodes and edges, plus every
+	// top-level identifier line (the extent cap for node bodies).
+	nodeSpans []nodeSpan
+	edgeSpans []edgeSpan
+	topLines  []int
 }
 
 func NewParser(input string, filename string) *Parser {
@@ -77,6 +83,7 @@ func (p *Parser) Parse() (*ir.Workflow, error) {
 	p.diagnostics = append(p.diagnostics, p.lexer.Errors()...)
 	p.parseVersionDeclaration()
 	p.parseTopLevel()
+	p.attachComments()
 	p.rejectRedundantFanEdgesUnderV2()
 	if len(p.diagnostics) > 0 {
 		return p.workflow, fmt.Errorf("parsing errors: %s", strings.Join(p.diagnostics, "; "))
@@ -181,6 +188,7 @@ func (p *Parser) parseWorkflowBody() {
 			continue
 		}
 		if t.Type == TokenIdentifier {
+			p.topLines = append(p.topLines, t.Location.Line)
 			p.dispatchWorkflowField(t)
 		} else {
 			p.lexer.NextToken()

--- a/parser/roundtrip_test.go
+++ b/parser/roundtrip_test.go
@@ -67,7 +67,43 @@ func assertWorkflowsEqual(t *testing.T, a, b *ir.Workflow) {
 	if len(a.Edges) != len(b.Edges) {
 		t.Errorf("Edges: %d vs %d", len(a.Edges), len(b.Edges))
 	}
+	assertCommentsEqual(t, a, b)
 	assertRequiresEqual(t, a.Requires, b.Requires)
+}
+
+// assertCommentsEqual verifies comment retention (#259) survives the
+// parse -> Format -> parse round trip: the reparse of the formatted output
+// carries the same node/edge comments as the first parse.
+func assertCommentsEqual(t *testing.T, a, b *ir.Workflow) {
+	t.Helper()
+	for i := range a.Nodes {
+		if !equalCommentSlices(a.Nodes[i].HeaderComment, b.Nodes[i].HeaderComment) {
+			t.Errorf("Nodes[%d].HeaderComment: %#v vs %#v", i, a.Nodes[i].HeaderComment, b.Nodes[i].HeaderComment)
+		}
+		if !equalCommentSlices(a.Nodes[i].BodyComments, b.Nodes[i].BodyComments) {
+			t.Errorf("Nodes[%d].BodyComments: %#v vs %#v", i, a.Nodes[i].BodyComments, b.Nodes[i].BodyComments)
+		}
+	}
+	for i := range a.Edges {
+		if !equalCommentSlices(a.Edges[i].HeaderComment, b.Edges[i].HeaderComment) {
+			t.Errorf("Edges[%d].HeaderComment: %#v vs %#v", i, a.Edges[i].HeaderComment, b.Edges[i].HeaderComment)
+		}
+		if a.Edges[i].TrailingComment != b.Edges[i].TrailingComment {
+			t.Errorf("Edges[%d].TrailingComment: %q vs %q", i, a.Edges[i].TrailingComment, b.Edges[i].TrailingComment)
+		}
+	}
+}
+
+func equalCommentSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func assertRequiresEqual(t *testing.T, a, b []string) {

--- a/parser/testdata/comments.dip
+++ b/parser/testdata/comments.dip
@@ -1,0 +1,24 @@
+# ABOUTME: comment retention fixture (#259)
+# Whole-line, trailing inline, and edge comments must survive fmt.
+workflow Comments
+  goal: "Keep every comment through fmt"
+  start: First
+  exit: Done
+
+  # whole-line comment directly above a node
+  agent First
+    label: First        # trailing inline on an attribute
+    # a whole-line comment mid-body
+    prompt: "Greet."
+  agent Middle
+    prompt: "Pass through."
+      # indented mid-body comment
+  # between-nodes comment
+
+  agent Done
+    prompt: "Wrap up."
+
+  edges
+    # routing note above an edge
+    First -> Middle  # trailing edge comment
+    Middle -> Done


### PR DESCRIPTION
## What

Closes the remaining scope of #259. v0.67.0 retained only the leading file-level comment block; everything else — whole-line comments above/between nodes, trailing inline comments, edge comments — was still silently erased by `dippin fmt`, which is exactly what makes `fmt --check` useless as a CI gate (and blocks the pipelines repo from canonicalizing its ~60-file `# ABOUTME:` convention).

## Approach

No token-stream changes, so no risk to existing parsing:

1. **Lexer** records each comment it strips (whole-line vs trailing inline, with source line) into a side channel (`Lexer.Comments()`). `stripComment` is refactored onto a shared `splitTrailingComment` with identical semantics.
2. **Post-parse pass** (`parser/comments.go`) re-attaches recorded comments to the owning entities by source line:
   - contiguous whole-line run directly above a node/edge → `HeaderComment`
   - trailing inline + mid-body whole-line comments inside a node's extent → `Node.BodyComments`
   - trailing inline on the edge line → `Edge.TrailingComment`

   Extent caps (top-level line numbers) and blank-line-run rules keep comments on the right entity; a comment directly above a later node belongs to that node's header, not the previous node's body.
3. **Formatter** re-emits at canonical positions: headers above the declaration, node body comments as the node's last body lines, edge trailing comments appended to the edge line. Node body comments get one canonical position because the formatter owns attribute ordering.

Result: `fmt(fmt(x)) == fmt(x)` — idempotent, so `dippin fmt -check` is now a workable CI gate.

## Verified

- The issue's exact repro: all five comment shapes survive
- `fmt -check`: unformatted → exit 1, after `fmt -write` → exit 0
- `validate` clean on formatted output; v1 `--migrate` also preserves comments
- Real example files: comment counts preserved through fmt
- 9 new parser tests, a `parser/testdata/comments.dip` roundtrip fixture, `assertWorkflowsEqual` now compares comment fields; full suite green; WASM build clean
- Docs updated (`docs/syntax.md` Comments section, `docs/architecture.md`), CHANGELOG entry

## Known remaining gap (documented)

Comments on workflow-level field lines (`goal:`/`start:`/`exit:`, `defaults`, `vars`, `inputs`, `stylesheet`) still have no IR slot and are dropped, as before — strictly an improvement, nothing newly lost. None of those positions were in the issue's repro; adding IR slots for them is a natural follow-up if full parity is wanted. Comments inside multiline blocks are content, not comments, and always survive; a `#` inside a quoted value was never a comment and still isn't.

Closes #259

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/dippin-lang/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791127883&installation_model_id=21126&pr_number=295&repository=2389-research%2Fdippin-lang&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fdippin-lang%2Fpull%2F295&signature=9edf423a9ed80189ae55ed8888c6952853bdbea9521f64a90175bbaf706cc340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `dippin fmt` now preserves and re-emits supported comments, including comments above nodes and edges, inline trailing comments, and comments within node bodies.
  - Formatting with comments is idempotent, producing consistent output across repeated runs.
  - `#` characters inside quoted values and raw prompt blocks remain preserved as content.

- **Documentation**
  - Updated syntax, architecture, and changelog documentation to describe comment retention and unsupported comment locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->